### PR TITLE
feat: drain scheduling for GPU time-sharing between competing models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-03-31
+
+### Added
+
+- **Drain scheduling for GPU time-sharing.** When a request arrives for a model
+  that needs VRAM held by another model, the incumbent is now drained (stops
+  accepting new requests) and evicted once its in-flight requests complete.
+  Previously, the incumbent held the GPU indefinitely as long as it had any
+  demand, causing starvation for competing models.
+
+  - New `min_eviction_tenure_secs` config option (default: 15) controls the
+    minimum time a model must serve before it can be forcibly drained by a
+    competitor. Configurable globally in `model_defaults` or per-profile.
+  - Running requests are never interrupted. The drain only prevents new
+    dispatches; in-flight requests complete naturally, however long they take.
+  - Drains are reversible: if the competing requests are handled elsewhere
+    (e.g., by a peer node or timeout), the drain is cancelled and the
+    incumbent resumes serving.
+
+- **Instant gossip.** Significant state changes (instance ready, instance
+  stopped, cookbook reload) now trigger an immediate gossip round to peers,
+  complementing the periodic gossip interval. Peers learn about capacity
+  changes within milliseconds instead of waiting for the next gossip tick.
+
 ## [1.0.2] - 2026-03-31
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,7 +1701,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.0.2"
+version = "1.1.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -41,9 +41,15 @@ pub async fn start_gossip_loop(state: Arc<NodeState>) {
     // Use tokio::time::interval so the first tick fires immediately (no initial sleep),
     // then subsequent ticks wait `gossip_interval_seconds`.
     let mut interval = tokio::time::interval(period);
+    let gossip_trigger = state.gossip_trigger.clone();
 
     loop {
-        interval.tick().await;
+        // Wait for either the periodic interval or an instant gossip trigger
+        // (fired when significant state changes occur: instance ready/stopped, drain, etc.)
+        tokio::select! {
+            _ = interval.tick() => {}
+            _ = gossip_trigger.notified() => {}
+        }
         let my_state = state.get_self_peer_state().await;
 
         // Collect all targets: seeds + mDNS-discovered + known peers
@@ -443,6 +449,7 @@ mod tests {
                 max_instances_per_model: 1,
                 max_wait_in_queue_ms: 500,
                 max_request_duration_ms: 300_000,
+                min_eviction_tenure_secs: 15,
             },
             llama_cpp_ports: None,
             llama_cpp: LlamaCppConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -171,6 +171,11 @@ pub struct ModelDefaults {
     /// Maximum request duration (ms). 0 = unlimited (no timeout).
     #[serde(default = "default_max_request_duration_ms")]
     pub max_request_duration_ms: u64,
+    /// Minimum time (seconds) an instance must serve before it can be drained
+    /// for a competing model. After tenure expires, the instance yields to
+    /// queued competitors on its next idle transition. 0 = drain immediately.
+    #[serde(default = "default_min_eviction_tenure_secs")]
+    pub min_eviction_tenure_secs: u64,
 }
 
 fn default_max_wait_in_queue_ms() -> u64 {
@@ -179,6 +184,10 @@ fn default_max_wait_in_queue_ms() -> u64 {
 
 fn default_max_request_duration_ms() -> u64 {
     0
+}
+
+fn default_min_eviction_tenure_secs() -> u64 {
+    15
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -525,6 +534,9 @@ pub struct Profile {
     /// Override the global max_queue_size_per_model for this profile.
     #[serde(default)]
     pub max_queue_size: Option<usize>,
+    /// Override the global min_eviction_tenure_secs for this profile.
+    #[serde(default)]
+    pub min_eviction_tenure_secs: Option<u64>,
 }
 
 impl Profile {
@@ -537,6 +549,10 @@ impl Profile {
 
     pub fn effective_max_queue_size(&self, defaults: &ModelDefaults) -> usize {
         self.max_queue_size.unwrap_or(defaults.max_queue_size_per_model)
+    }
+
+    pub fn effective_min_eviction_tenure_secs(&self, defaults: &ModelDefaults) -> u64 {
+        self.min_eviction_tenure_secs.unwrap_or(defaults.min_eviction_tenure_secs)
     }
 
     /// Returns the effective startup timeout in seconds.
@@ -675,6 +691,7 @@ mod tests {
             max_instances_per_model: 5,
             max_wait_in_queue_ms: 60_000,
             max_request_duration_ms: 300_000,
+            min_eviction_tenure_secs: 15,
         }
     }
 
@@ -693,6 +710,7 @@ mod tests {
             startup_timeout_seconds: None,
             download_timeout_seconds: None,
             max_queue_size: None,
+            min_eviction_tenure_secs: None,
         }
     }
 
@@ -877,6 +895,7 @@ mod tests {
             startup_timeout_seconds: None,
             download_timeout_seconds: None,
             max_queue_size: None,
+            min_eviction_tenure_secs: None,
         };
         assert!(profile.validate("test_model").is_err());
     }
@@ -897,6 +916,7 @@ mod tests {
             startup_timeout_seconds: None,
             download_timeout_seconds: None,
             max_queue_size: None,
+            min_eviction_tenure_secs: None,
         };
         assert!(profile.validate("test_model").is_err());
     }
@@ -917,6 +937,7 @@ mod tests {
             startup_timeout_seconds: None,
             download_timeout_seconds: None,
             max_queue_size: None,
+            min_eviction_tenure_secs: None,
         };
         assert!(profile.validate("test_model").is_ok());
     }
@@ -937,6 +958,7 @@ mod tests {
             startup_timeout_seconds: None,
             download_timeout_seconds: None,
             max_queue_size: None,
+            min_eviction_tenure_secs: None,
         };
         assert!(profile.validate("test_model").is_ok());
     }

--- a/src/health.rs
+++ b/src/health.rs
@@ -90,6 +90,7 @@ mod tests {
                 max_instances_per_model: 1,
                 max_wait_in_queue_ms: 500,
                 max_request_duration_ms: 300_000,
+                min_eviction_tenure_secs: 15,
             },
             llama_cpp_ports: None,
             llama_cpp: LlamaCppConfig {

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -178,6 +178,9 @@ pub struct Instance {
     pub is_cold_start: bool,
     /// Whether this instance is draining (no new requests should be assigned).
     pub draining: AtomicBool,
+    /// Earliest time this instance can be drained for a competing model.
+    /// Set to `now() + tenure` when instance reaches Ready.
+    pub evictable_after: Mutex<Option<Instant>>,
 }
 
 impl Drop for Instance {
@@ -237,6 +240,7 @@ impl Instance {
             parsed_params: Mutex::new(None),
             is_cold_start,
             draining: AtomicBool::new(false),
+            evictable_after: Mutex::new(None),
         }
     }
 

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -123,6 +123,14 @@ pub struct NodeState {
     /// Notified when cluster capacity changes (instance idle, terminated, peer update).
     /// Used by route_or_wait() to efficiently wait for capacity.
     pub capacity_notify: Arc<Notify>,
+    /// Model:profile keys that failed to spawn due to InsufficientResources
+    /// and need eviction of existing instances to proceed. Used by the drain
+    /// scheduler to decide when to drain an incumbent model.
+    pub needs_eviction: Arc<RwLock<HashSet<String>>>,
+    /// Signalled to trigger an immediate gossip round to peers (e.g., after
+    /// an instance stops, starts, or is drained). Complements the periodic
+    /// gossip interval for latency-sensitive state changes.
+    pub gossip_trigger: Arc<Notify>,
 }
 
 use crate::security;
@@ -221,6 +229,8 @@ impl NodeState {
             discovery,
             circuit_breaker,
             capacity_notify: Arc::new(Notify::new()),
+            needs_eviction: Arc::new(RwLock::new(HashSet::new())),
+            gossip_trigger: Arc::new(Notify::new()),
         })
     }
 
@@ -254,6 +264,9 @@ impl NodeState {
         // A config change (e.g. reduced context length) may lower VRAM estimates
         // enough to unblock previously-stuck spawns.
         self.notify_all_queues().await;
+
+        // Trigger instant gossip so peers learn about model changes immediately
+        self.gossip_trigger.notify_one();
 
         Ok(())
     }
@@ -511,6 +524,9 @@ impl NodeState {
 
         self.update_peak_memory(&inst.model_name, &inst.profile_id)
             .await;
+
+        // Trigger instant gossip so peers learn about freed capacity immediately
+        self.gossip_trigger.notify_one();
     }
 
     // Helper to identify victims for eviction. Needs to be called under lock if we want to be sure.
@@ -1159,6 +1175,11 @@ impl NodeState {
                             info!(event = "queue_enqueue", model = %model_name, queue_length = queue_len, spawn_error = spawn_error_reason);
                         }
 
+                        // Track that this model needs eviction to spawn (outside queues lock)
+                        if matches!(e, NodeError::InsufficientResources | NodeError::MaxInstancesNode) {
+                            self.needs_eviction.write().await.insert(key.clone());
+                        }
+
                         // Wait for queue notification with optional timeout
                         let wait_result = match queue_timeout {
                             Some(timeout) => {
@@ -1599,6 +1620,7 @@ impl NodeState {
 
             let inst_clone = inst_arc.clone();
             let startup_timeout = profile.effective_startup_timeout_seconds();
+            let eviction_tenure_secs = profile.effective_min_eviction_tenure_secs(&self.config.model_defaults);
             let api_key = final_args
                 .iter()
                 .position(|arg| arg == "--api-key")
@@ -1612,6 +1634,9 @@ impl NodeState {
             let http_client = self.http_client.clone();
             let metrics = self.metrics.clone();
             let memory_sampler = self.memory_sampler.clone();
+            let needs_eviction = self.needs_eviction.clone();
+            let gossip_trigger = self.gossip_trigger.clone();
+            let model_key = format!("{}:{}", model_name, profile.id);
             let args_hash_clone = args_hash.clone();
             let is_cold = is_cold_start;
             tokio::spawn(async move {
@@ -1627,6 +1652,18 @@ impl NodeState {
                     // Parse model params from startup log now that instance is ready
                     inst.parse_and_store_startup_params();
                     inst.clear_startup_log();
+
+                    // Set eviction tenure — instance cannot be drained by competitors until this expires
+                    {
+                        let mut evictable = inst.evictable_after.lock();
+                        *evictable = Some(std::time::Instant::now() + std::time::Duration::from_secs(eviction_tenure_secs));
+                    }
+
+                    // Clear needs_eviction — this model no longer needs eviction to spawn
+                    needs_eviction.write().await.remove(&model_key);
+
+                    // Trigger instant gossip so peers learn about new model availability
+                    gossip_trigger.notify_one();
 
                     if is_cold {
                         // Cold start: sample memory after ready and store learned value
@@ -2045,6 +2082,65 @@ impl NodeState {
 
         // Wake any cluster-aware waiters (route_or_wait callers)
         self.capacity_notify.notify_waiters();
+    }
+
+    // ── Drain Scheduling ─────────────────────────────────────────────────
+
+    /// Check if any queued model needs eviction of this instance's resources.
+    /// Returns true if there's a model:profile in `needs_eviction` that belongs
+    /// to a different model AND still has a non-empty queue.
+    pub async fn has_queued_competitors_needing_eviction(&self, inst_model: &str) -> bool {
+        let needs = self.needs_eviction.read().await;
+        if needs.is_empty() {
+            return false;
+        }
+        let queues = self.queues.read().await;
+        needs.iter().any(|key| {
+            let model = key.split(':').next().unwrap_or("");
+            model != inst_model && queues.get(key).map(|q| !q.is_empty()).unwrap_or(false)
+        })
+    }
+
+    /// Check if the given model has pending requests (in queue or pending tokens).
+    pub async fn has_pending_for_model(&self, model: &str, profile: &str) -> bool {
+        let key = format!("{}:{}", model, profile);
+        let queues = self.queues.read().await;
+        let has_queue = queues.get(&key).map(|q| !q.is_empty()).unwrap_or(false);
+        if has_queue {
+            return true;
+        }
+        drop(queues);
+        let pending = self.pending_tokens.read().await;
+        pending.get(&key).map(|s| !s.is_empty()).unwrap_or(false)
+    }
+
+    /// Cancel drains that are no longer needed (competitors were handled by
+    /// peers or timed out). Notifies the drained model's queue so its
+    /// pending requests can resume being dispatched.
+    pub async fn maybe_cancel_drains(&self) {
+        let instances = self.instances.read().await;
+        for inst_lock in instances.values() {
+            let inst = inst_lock.read().await;
+            if inst.draining.load(std::sync::atomic::Ordering::Relaxed) {
+                if !self.has_queued_competitors_needing_eviction(&inst.model_name).await {
+                    inst.draining.store(false, std::sync::atomic::Ordering::Relaxed);
+                    info!(
+                        event = "drain_cancelled",
+                        model = %inst.model_name,
+                        profile = %inst.profile_id,
+                        instance_id = %inst.id,
+                        "Drain cancelled — no more competitors needing eviction"
+                    );
+                    drop(inst);
+                    // Wake the model's own queue so pending requests can be dispatched
+                    let model_name = inst_lock.read().await.model_name.clone();
+                    let profile_id = inst_lock.read().await.profile_id.clone();
+                    drop(instances);
+                    self.notify_queue(&model_name, &profile_id).await;
+                    return; // Released instances lock, must restart iteration
+                }
+            }
+        }
     }
 
     pub async fn run_background_tasks(self: Arc<Self>) {
@@ -2481,6 +2577,7 @@ mod tests {
             startup_timeout_seconds: None,
             download_timeout_seconds: None,
             max_queue_size: None,
+            min_eviction_tenure_secs: None,
         }
     }
 
@@ -2491,6 +2588,7 @@ mod tests {
             max_instances_per_model: 1,
             max_wait_in_queue_ms: 500,
             max_request_duration_ms: 300_000,
+            min_eviction_tenure_secs: 15,
         }
     }
 

--- a/src/node_state/model_index.rs
+++ b/src/node_state/model_index.rs
@@ -186,6 +186,7 @@ mod tests {
                             startup_timeout_seconds: None,
                             download_timeout_seconds: None,
                             max_queue_size: None,
+                            min_eviction_tenure_secs: None,
                         },
                         Profile {
                             id: "fast".to_string(),
@@ -201,6 +202,7 @@ mod tests {
                             startup_timeout_seconds: None,
                             download_timeout_seconds: None,
                             max_queue_size: None,
+                            min_eviction_tenure_secs: None,
                         },
                     ],
                 },
@@ -268,6 +270,7 @@ mod tests {
             startup_timeout_seconds: None,
             download_timeout_seconds: None,
             max_queue_size: None,
+            min_eviction_tenure_secs: None,
         };
 
         let (args, model_present, hf_present) = build_pre_args(&profile);
@@ -294,6 +297,7 @@ mod tests {
             startup_timeout_seconds: None,
             download_timeout_seconds: None,
             max_queue_size: None,
+            min_eviction_tenure_secs: None,
         };
 
         let (args, model_present, hf_present) = build_pre_args(&profile);
@@ -338,6 +342,7 @@ mod tests {
             startup_timeout_seconds: None,
             download_timeout_seconds: None,
             max_queue_size: None,
+            min_eviction_tenure_secs: None,
         };
 
         let (args, _, _) = build_pre_args(&profile);
@@ -362,6 +367,7 @@ mod tests {
             startup_timeout_seconds: None,
             download_timeout_seconds: None,
             max_queue_size: None,
+            min_eviction_tenure_secs: None,
         };
 
         let (args, model_present, _) = build_pre_args(&profile);
@@ -387,6 +393,7 @@ mod tests {
             startup_timeout_seconds: None,
             download_timeout_seconds: None,
             max_queue_size: None,
+            min_eviction_tenure_secs: None,
         };
 
         let (args, _, _) = build_pre_args(&profile);
@@ -411,6 +418,7 @@ mod tests {
             startup_timeout_seconds: None,
             download_timeout_seconds: None,
             max_queue_size: None,
+            min_eviction_tenure_secs: None,
         };
 
         let (args, _, _) = build_pre_args(&profile);
@@ -436,6 +444,7 @@ mod tests {
             startup_timeout_seconds: None,
             download_timeout_seconds: None,
             max_queue_size: None,
+            min_eviction_tenure_secs: None,
         };
 
         let (args, _, _) = build_pre_args(&profile);
@@ -461,6 +470,7 @@ mod tests {
             startup_timeout_seconds: None,
             download_timeout_seconds: None,
             max_queue_size: None,
+            min_eviction_tenure_secs: None,
         };
 
         let (args, _, _) = build_pre_args(&profile);
@@ -486,6 +496,7 @@ mod tests {
             startup_timeout_seconds: None,
             download_timeout_seconds: None,
             max_queue_size: None,
+            min_eviction_tenure_secs: None,
         };
 
         let (args, _, _) = build_pre_args(&profile);
@@ -511,6 +522,7 @@ mod tests {
             startup_timeout_seconds: None,
             download_timeout_seconds: None,
             max_queue_size: None,
+            min_eviction_tenure_secs: None,
         };
 
         let (args, _, _) = build_pre_args(&profile);
@@ -535,6 +547,7 @@ mod tests {
             startup_timeout_seconds: None,
             download_timeout_seconds: None,
             max_queue_size: None,
+            min_eviction_tenure_secs: None,
         };
 
         let (args, _, _) = build_pre_args(&profile);
@@ -561,6 +574,7 @@ mod tests {
             startup_timeout_seconds: None,
             download_timeout_seconds: None,
             max_queue_size: None,
+            min_eviction_tenure_secs: None,
         };
 
         let (args, _, _) = build_pre_args(&profile);

--- a/src/router.rs
+++ b/src/router.rs
@@ -503,10 +503,49 @@ pub async fn route_request(
                                         let mut inst = instance_lock.write().await;
                                         inst.in_flight_requests =
                                             inst.in_flight_requests.saturating_sub(1);
+                                        let idle = inst.in_flight_requests == 0;
+
+                                        // ── Drain scheduling ────────────────────────────
+                                        // Check if this instance should be drained for a
+                                        // queued competitor that needs its VRAM.
+                                        if !inst.draining.load(Ordering::Relaxed) {
+                                            let dominated = state
+                                                .has_queued_competitors_needing_eviction(
+                                                    &inst.model_name,
+                                                )
+                                                .await;
+                                            if dominated {
+                                                let tenure_expired = inst
+                                                    .evictable_after
+                                                    .lock()
+                                                    .map(|t| std::time::Instant::now() >= t)
+                                                    .unwrap_or(false);
+                                                let own_queue_empty = idle
+                                                    && !state
+                                                        .has_pending_for_model(
+                                                            &inst.model_name,
+                                                            &inst.profile_id,
+                                                        )
+                                                        .await;
+
+                                                if tenure_expired || own_queue_empty {
+                                                    inst.draining.store(true, Ordering::Relaxed);
+                                                    info!(
+                                                        event = "drain_triggered",
+                                                        model = %inst.model_name,
+                                                        profile = %inst.profile_id,
+                                                        instance_id = %inst.id,
+                                                        reason = if tenure_expired { "tenure_expired" } else { "queue_empty" },
+                                                        "Instance marked draining for competing model"
+                                                    );
+                                                }
+                                            }
+                                        }
+
                                         (
                                             inst.model_name.clone(),
                                             inst.profile_id.clone(),
-                                            inst.in_flight_requests == 0,
+                                            idle,
                                         )
                                     };
                                     state.metrics.dec_current_requests();
@@ -516,6 +555,9 @@ pub async fn route_request(
                                     // If we only notify this model's queue, requests for other models
                                     // will never wake up to check if they can now evict this idle instance.
                                     if became_idle {
+                                        // Check if any drains can be cancelled (competitors may have
+                                        // been handled by peers or timed out while we were draining).
+                                        state.maybe_cancel_drains().await;
                                         state.notify_all_queues().await;
                                     } else {
                                         state.notify_queue(&model_name, &profile_id).await;
@@ -1217,6 +1259,7 @@ mod tests {
             startup_timeout_seconds: None,
             download_timeout_seconds: None,
             max_queue_size: None,
+            min_eviction_tenure_secs: None,
         }
     }
 


### PR DESCRIPTION
## Summary

- When a model queues due to `InsufficientResources`, the incumbent is now drained once its eviction tenure expires or its own queue empties
- In-flight requests complete naturally — running requests are never interrupted
- Drains are reversible if competitors are handled elsewhere (peer forwarding, timeout)
- Significant state changes trigger instant gossip to peers for faster cluster-wide propagation

Fixes #5

## Details

- New `min_eviction_tenure_secs` config (default 15s, per-profile override) — minimum serving time before forced drain
- `needs_eviction` set tracks models that failed to spawn due to resource constraints
- On each request completion, drain conditions are checked: tenure expired OR (idle AND own queue empty)
- `maybe_cancel_drains()` reverses unnecessary drains when competitors are resolved
- Gossip loop now `select!`s on both periodic interval and instant trigger

## Test plan

- [x] `cargo test` — all unit tests pass
- [x] `cargo test --test integration_test` — all 8 integration tests pass
- [x] Manual verification: confirmed the starvation scenario with competing embedding and language models on a single GPU node