### PR TITLE
fix: drain instances that no longer match cookbook on reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Cookbook hot-reload now drains instances that no longer match the cookbook.
+  Previously, disabling a model (or removing a profile, or changing its
+  `llama_server_args`) left the running `llama-server` process alive
+  indefinitely, continuing to hold VRAM/sysmem even though the local node no
+  longer advertised the model. Reload now marks such instances `draining`
+  (graceful: in-flight requests finish, no new dispatches) and the standard
+  eviction path terminates them as soon as they go idle. Emits a new
+  `instance_orphaned_by_reload` event with `reason` field
+  (`model_or_profile_missing_or_disabled` | `args_changed`). As
+  defense-in-depth, the idle-eviction loop now also drains immediately when
+  a profile no longer resolves or its args_hash has drifted, replacing the
+  previous 600-second fallback timeout.
+
 ## [1.1.1] - 2026-04-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   defense-in-depth, the idle-eviction loop now also drains immediately when
   a profile no longer resolves or its args_hash has drifted, replacing the
   previous 600-second fallback timeout.
+- Cookbook watcher now survives rename-based edits. `sed -i`, most editors'
+  save-atomic, and IDE autosave all replace the file via `rename(tmp,
+  cookbook.yaml)`, which silently invalidated the inotify watch because the
+  watch was bound to the original file's inode. A single rename-based save
+  would fire one final event, then the watcher stopped receiving anything —
+  subsequent cookbook changes required a restart. The watcher now watches
+  the parent directory and filters events by the cookbook's filename, so
+  both in-place and rename-based writes keep firing reload events
+  indefinitely.
 
 ## [1.1.1] - 2026-04-16
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,11 +141,47 @@ async fn main() -> anyhow::Result<()> {
         let watcher_state = node_state.clone();
         let watcher_span = span.clone();
 
+        // Resolve the directory that contains the cookbook. We watch the
+        // directory — not the file — so edits that replace the inode (atomic
+        // rename used by `sed -i`, most editors' save-atomic, IDE autosave)
+        // keep producing events. A single-file watch breaks after any such
+        // edit because inotify's watch is bound to the original inode and is
+        // silently lost when that inode is unlinked.
+        let canonical_cookbook_path = match std::fs::canonicalize(&cookbook_path) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!(
+                    "Failed to canonicalize cookbook path {}: {}",
+                    cookbook_path.display(),
+                    e
+                );
+                return Err(e.into());
+            }
+        };
+        let cookbook_dir = canonical_cookbook_path
+            .parent()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Cookbook path has no parent directory: {}",
+                    canonical_cookbook_path.display()
+                )
+            })?
+            .to_path_buf();
+        let cookbook_filename = canonical_cookbook_path
+            .file_name()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Cookbook path has no file name: {}",
+                    canonical_cookbook_path.display()
+                )
+            })?
+            .to_os_string();
+
         // Create a channel for filesystem events
         let (tx, mut rx) = tokio::sync::mpsc::channel::<notify::Result<notify::Event>>(16);
 
         // Spawn the watcher in a blocking thread since notify uses std channels
-        let cookbook_path_for_watcher = cookbook_path.clone();
+        let watched_dir = cookbook_dir.clone();
         let rt = tokio::runtime::Handle::current();
         std::thread::spawn(move || {
             let rt = rt.clone();
@@ -164,8 +200,8 @@ async fn main() -> anyhow::Result<()> {
                 }
             };
 
-            if let Err(e) = watcher.watch(&cookbook_path_for_watcher, RecursiveMode::NonRecursive) {
-                eprintln!("Failed to watch cookbook file: {}", e);
+            if let Err(e) = watcher.watch(&watched_dir, RecursiveMode::NonRecursive) {
+                eprintln!("Failed to watch cookbook directory: {}", e);
                 return;
             }
 
@@ -179,38 +215,62 @@ async fn main() -> anyhow::Result<()> {
         tokio::spawn(
             async move {
                 info!(
-                    path = %cookbook_path.display(),
+                    path = %canonical_cookbook_path.display(),
+                    watched_dir = %cookbook_dir.display(),
                     "Started cookbook file watcher"
                 );
 
                 while let Some(event_result) = rx.recv().await {
                     match event_result {
                         Ok(event) => {
-                            // Only react to modify/create events
-                            if matches!(
+                            // Only react to events that touch the cookbook file.
+                            // notify emits absolute paths when watching an
+                            // absolute directory path, so filename comparison
+                            // against `cookbook_filename` is sufficient.
+                            let touches_cookbook = event
+                                .paths
+                                .iter()
+                                .any(|p| p.file_name() == Some(&cookbook_filename));
+                            if !touches_cookbook {
+                                continue;
+                            }
+
+                            // Ignore metadata-only changes (chmod, touch) —
+                            // the file's contents weren't rewritten, so the
+                            // reload would be a no-op at best and a thrash at
+                            // worst (many editors emit a burst of events).
+                            let kind_is_reloadable = matches!(
                                 event.kind,
-                                notify::EventKind::Modify(_) | notify::EventKind::Create(_)
-                            ) {
-                                info!(
-                                    event = "cookbook_change_detected",
-                                    paths = ?event.paths,
-                                    "Cookbook file changed, reloading"
-                                );
+                                notify::EventKind::Modify(notify::event::ModifyKind::Data(_))
+                                    | notify::EventKind::Modify(notify::event::ModifyKind::Name(_))
+                                    | notify::EventKind::Modify(notify::event::ModifyKind::Any)
+                                    | notify::EventKind::Create(_)
+                                    | notify::EventKind::Remove(_)
+                            );
+                            if !kind_is_reloadable {
+                                continue;
+                            }
 
-                                // Small debounce delay to handle rapid successive events
-                                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                            info!(
+                                event = "cookbook_change_detected",
+                                paths = ?event.paths,
+                                kind = ?event.kind,
+                                "Cookbook file changed, reloading"
+                            );
 
-                                match watcher_state.reload_cookbook(&cookbook_path).await {
-                                    Ok(()) => {
-                                        // Successfully reloaded - the reload_cookbook method logs this
-                                    }
-                                    Err(e) => {
-                                        error!(
-                                            event = "cookbook_reload_failed",
-                                            error = %e,
-                                            "Failed to reload cookbook"
-                                        );
-                                    }
+                            // Small debounce delay to handle rapid successive events
+                            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+                            match watcher_state.reload_cookbook(&cookbook_path).await {
+                                Ok(()) => {
+                                    // Successfully reloaded - the reload_cookbook method logs this
+                                }
+                                Err(e) => {
+                                    error!(
+                                        event = "cookbook_reload_failed",
+                                        error = %e,
+                                        "Failed to reload cookbook"
+                                    );
                                 }
                             }
                         }

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -260,6 +260,20 @@ impl NodeState {
             "Cookbook reloaded successfully"
         );
 
+        // Reconcile running instances against the new cookbook. Instances whose
+        // model/profile is no longer enabled, or whose args_hash no longer
+        // matches the cookbook, are marked draining so the eviction loop
+        // terminates them gracefully once their in-flight requests complete.
+        let orphaned = self.reconcile_instances_with_cookbook().await;
+        if orphaned > 0 {
+            // Run an eviction pass immediately so already-idle orphans are
+            // stopped now rather than waiting up to 10s for the next periodic
+            // tick.
+            if let Err(e) = self.check_idle_instances().await {
+                error!("Post-reload eviction pass failed: {}", e);
+            }
+        }
+
         // Wake all queued waiters so they re-attempt with the updated cookbook.
         // A config change (e.g. reduced context length) may lower VRAM estimates
         // enough to unblock previously-stuck spawns.
@@ -269,6 +283,71 @@ impl NodeState {
         self.gossip_trigger.notify_one();
 
         Ok(())
+    }
+
+    /// Find running instances whose `(model, profile, args_hash)` no longer
+    /// matches the current cookbook and mark them as `draining`. The regular
+    /// eviction loop terminates them once their in-flight requests finish.
+    ///
+    /// Returns the number of instances newly marked draining.
+    async fn reconcile_instances_with_cookbook(&self) -> usize {
+        use crate::node_state::model_index::build_pre_args;
+
+        let instances = self.instances.read().await;
+        let mut newly_drained = 0usize;
+
+        for inst_lock in instances.values() {
+            // Snapshot the instance's identity while holding only the inner read lock.
+            let (model_name, profile_id, inst_args_hash, inst_id, already_draining) = {
+                let inst = inst_lock.read().await;
+                (
+                    inst.model_name.clone(),
+                    inst.profile_id.clone(),
+                    inst.args_hash.clone(),
+                    inst.id.clone(),
+                    inst.draining.load(Ordering::Relaxed),
+                )
+            };
+
+            if already_draining {
+                continue;
+            }
+
+            let reason = match self
+                .resolve_model(&format!("{}:{}", model_name, profile_id))
+                .await
+            {
+                // Whole model missing, model disabled, or profile removed: model_index
+                // only contains enabled models/profiles, so None covers all three.
+                None => Some("model_or_profile_missing_or_disabled"),
+                Some((_, new_profile)) => {
+                    let (pre_args, _, _) = build_pre_args(&new_profile);
+                    let new_hash = compute_args_hash(&pre_args);
+                    if new_hash != inst_args_hash {
+                        Some("args_changed")
+                    } else {
+                        None
+                    }
+                }
+            };
+
+            if let Some(reason) = reason {
+                let inst = inst_lock.read().await;
+                inst.draining.store(true, Ordering::Relaxed);
+                drop(inst);
+                info!(
+                    event = "instance_orphaned_by_reload",
+                    instance_id = %inst_id,
+                    model = %model_name,
+                    profile = %profile_id,
+                    reason = reason,
+                    "Instance marked draining: no longer matches cookbook"
+                );
+                newly_drained += 1;
+            }
+        }
+
+        newly_drained
     }
 
     pub async fn get_available_port(&self) -> Result<u16, NodeError> {
@@ -2223,16 +2302,31 @@ impl NodeState {
             }
 
             if inst.in_flight_requests == 0 {
-                // Determine timeout from profile
-                let mut timeout_secs = 600; // Default fallback
-                if let Some((_, profile)) = self
+                // Defense-in-depth against orphaned instances: if the profile
+                // no longer resolves in the cookbook, or its args_hash has
+                // drifted from the current cookbook, drain immediately rather
+                // than waiting for an idle_timeout that was tied to the old
+                // profile. The normal reconcile path in `reload_cookbook` also
+                // marks these as `draining`; this branch catches any race or
+                // instances spawned by paths that bypass reload reconciliation.
+                let should_evict_now = match self
                     .resolve_model(&format!("{}:{}", inst.model_name, inst.profile_id))
                     .await
                 {
-                    timeout_secs = profile.idle_timeout_seconds;
-                }
+                    None => true,
+                    Some((_, profile)) => {
+                        use crate::node_state::model_index::build_pre_args;
+                        let (pre_args, _, _) = build_pre_args(&profile);
+                        let new_hash = compute_args_hash(&pre_args);
+                        if new_hash != inst.args_hash {
+                            true
+                        } else {
+                            inst.last_activity.elapsed().as_secs() > profile.idle_timeout_seconds
+                        }
+                    }
+                };
 
-                if inst.last_activity.elapsed().as_secs() > timeout_secs {
+                if should_evict_now {
                     to_evict.push((id.clone(), inst_lock.clone(), EvictionReason::Idle));
                 }
             }

--- a/tests/integration_test_reload_eviction.rs
+++ b/tests/integration_test_reload_eviction.rs
@@ -176,11 +176,20 @@ async fn spawn_instance_for(client: &reqwest::Client, model: &str) {
     );
 }
 
-async fn write_cookbook(path: &std::path::Path, content: &str) {
-    // Write in place. A rename-over would break the inotify watcher on Linux:
-    // the watch is set on the inode, and renaming a new file over the target
-    // replaces the inode without firing events on the new one.
+/// In-place overwrite. Preserves the inode; triggers `IN_MODIFY`.
+async fn write_cookbook_inplace(path: &std::path::Path, content: &str) {
     tokio::fs::write(path, content).await.unwrap();
+}
+
+/// Rename-based write. Writes a sibling temp file, then atomically renames
+/// it over `path`. This is the pattern used by `sed -i`, `vim` with its
+/// default `:set writebackup`, and most IDEs' save-atomic. The inode of the
+/// file at `path` changes — which used to silently break the watcher when
+/// it was bound to the file inode rather than the parent directory.
+async fn write_cookbook_rename(path: &std::path::Path, content: &str) {
+    let tmp = path.with_extension("yaml.tmp");
+    tokio::fs::write(&tmp, content).await.unwrap();
+    tokio::fs::rename(&tmp, path).await.unwrap();
 }
 
 #[tokio::test]
@@ -248,16 +257,21 @@ async fn reload_drains_orphaned_instances() {
         loaded
     );
 
-    write_cookbook(&cookbook_path, COOKBOOK_DISABLED).await;
+    // Case 1 uses an in-place write (the OpenAI-text-editor path).
+    write_cookbook_inplace(&cookbook_path, COOKBOOK_DISABLED).await;
 
     assert!(
         wait_for_unload(&client, "mock-model:default", Duration::from_secs(30)).await,
         "mock-model:default should have been drained within 30s after disable"
     );
 
-    // ── Case 2: changing llama_server_args drains the stale instance ────────
-    write_cookbook(&cookbook_path, COOKBOOK_ENABLED).await;
-    // /v1/models exposes default-profile models under the bare model name.
+    // ── Case 2: args_hash change via atomic rename-over drains the stale
+    //     instance. The rename-over path is how `sed -i` and most editors
+    //     save files, and historically it broke the watcher after the first
+    //     rename (inotify's watch was bound to the replaced inode). The fix
+    //     watches the parent directory and filters by filename, so it keeps
+    //     receiving events after any number of rename-over edits. ──────────
+    write_cookbook_rename(&cookbook_path, COOKBOOK_ENABLED).await;
     assert!(
         wait_for_model_listed(&client, "mock-model", Duration::from_secs(10)).await,
         "cookbook re-enable should make mock-model listed within 10s"
@@ -265,11 +279,12 @@ async fn reload_drains_orphaned_instances() {
 
     spawn_instance_for(&client, "mock-model:default").await;
 
-    write_cookbook(&cookbook_path, COOKBOOK_ARGS_CHANGED).await;
+    write_cookbook_rename(&cookbook_path, COOKBOOK_ARGS_CHANGED).await;
 
     assert!(
         wait_for_unload(&client, "mock-model:default", Duration::from_secs(30)).await,
-        "mock-model:default should have been drained within 30s after args_hash change"
+        "mock-model:default should have been drained within 30s after args_hash change \
+         (regression guard: rename-over must not silence the watcher)"
     );
 
     // ── Teardown ────────────────────────────────────────────────────────────

--- a/tests/integration_test_reload_eviction.rs
+++ b/tests/integration_test_reload_eviction.rs
@@ -1,0 +1,282 @@
+//! Verifies that hot-reloading the cookbook drains running instances whose
+//! (model, profile, args_hash) no longer matches the cookbook. Regression
+//! coverage for <https://github.com/michaelkrauty/llamesh/issues/7>.
+
+use reqwest::StatusCode;
+use std::time::Duration;
+use tokio::time::sleep;
+
+mod common;
+use common::{
+    cleanup_by_port_range_pattern, cleanup_procs, graceful_stop, setup_mock_script, wait_for_ready,
+};
+
+const LISTEN_ADDR: &str = "127.0.0.1:9210";
+const BASE_URL: &str = "http://127.0.0.1:9210";
+
+fn config_yaml(mock_script: &std::path::Path) -> String {
+    format!(
+        r#"
+node_id: "test-reload-drain"
+listen_addr: "{}"
+max_vram_mb: 1024
+max_sysmem_mb: 1024
+default_model: "mock-model:default"
+model_defaults:
+  max_concurrent_requests_per_instance: 2
+  max_queue_size_per_model: 10
+  max_instances_per_model: 2
+  max_wait_in_queue_ms: 5000
+llama_cpp_ports:
+  ranges:
+    - start: 13090
+      end: 13099
+llama_cpp:
+  repo_url: ""
+  repo_path: "."
+  build_path: "."
+  binary_path: "{}"
+  branch: "master"
+  build_args: []
+  build_command_args: []
+  auto_update_interval_seconds: 0
+  enabled: false
+cluster:
+  enabled: false
+  peers: []
+  gossip_interval_seconds: 5
+http:
+  request_body_limit_bytes: 1048576
+  idle_timeout_seconds: 60
+"#,
+        LISTEN_ADDR,
+        mock_script.display()
+    )
+}
+
+const COOKBOOK_ENABLED: &str = r#"
+models:
+  - name: "mock-model"
+    enabled: true
+    profiles:
+      - id: "default"
+        model_path: "./models/mock.gguf"
+        idle_timeout_seconds: 600
+        max_instances: 1
+        llama_server_args: ""
+  - name: "other-model"
+    enabled: true
+    profiles:
+      - id: "default"
+        model_path: "./models/other.gguf"
+        idle_timeout_seconds: 600
+        max_instances: 1
+        llama_server_args: ""
+"#;
+
+const COOKBOOK_DISABLED: &str = r#"
+models:
+  - name: "mock-model"
+    enabled: false
+    profiles:
+      - id: "default"
+        model_path: "./models/mock.gguf"
+        idle_timeout_seconds: 600
+        max_instances: 1
+        llama_server_args: ""
+  - name: "other-model"
+    enabled: true
+    profiles:
+      - id: "default"
+        model_path: "./models/other.gguf"
+        idle_timeout_seconds: 600
+        max_instances: 1
+        llama_server_args: ""
+"#;
+
+const COOKBOOK_ARGS_CHANGED: &str = r#"
+models:
+  - name: "mock-model"
+    enabled: true
+    profiles:
+      - id: "default"
+        model_path: "./models/mock.gguf"
+        idle_timeout_seconds: 600
+        max_instances: 1
+        llama_server_args: "--ctx-size 4096"
+  - name: "other-model"
+    enabled: true
+    profiles:
+      - id: "default"
+        model_path: "./models/other.gguf"
+        idle_timeout_seconds: 600
+        max_instances: 1
+        llama_server_args: ""
+"#;
+
+/// Poll `/cluster/nodes` until `mock-model:default` is no longer present in the
+/// local node's `loaded_models`, or the deadline elapses.
+async fn wait_for_unload(client: &reqwest::Client, model_key: &str, timeout: Duration) -> bool {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        if let Ok(resp) = client.get(format!("{}/cluster/nodes", BASE_URL)).send().await {
+            if let Ok(json) = resp.json::<serde_json::Value>().await {
+                let loaded = json["nodes"]["test-reload-drain"]["loaded_models"]
+                    .as_array()
+                    .cloned()
+                    .unwrap_or_default();
+                if !loaded.iter().any(|m| m.as_str() == Some(model_key)) {
+                    return true;
+                }
+            }
+        }
+        sleep(Duration::from_millis(250)).await;
+    }
+    false
+}
+
+/// Poll `/v1/models` until `model_id` appears in the listed models, or the
+/// deadline elapses. Used to synchronize with cookbook hot-reload.
+async fn wait_for_model_listed(
+    client: &reqwest::Client,
+    model_id: &str,
+    timeout: Duration,
+) -> bool {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        if let Ok(resp) = client.get(format!("{}/v1/models", BASE_URL)).send().await {
+            if let Ok(json) = resp.json::<serde_json::Value>().await {
+                let data = json["data"].as_array().cloned().unwrap_or_default();
+                if data.iter().any(|m| m["id"].as_str() == Some(model_id)) {
+                    return true;
+                }
+            }
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+    false
+}
+
+async fn spawn_instance_for(client: &reqwest::Client, model: &str) {
+    let body = serde_json::json!({
+        "model": model,
+        "messages": [{"role": "user", "content": "hi"}],
+    });
+    let resp = client
+        .post(format!("{}/v1/chat/completions", BASE_URL))
+        .json(&body)
+        .send()
+        .await
+        .expect("request failed");
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "request to spawn {} failed",
+        model
+    );
+}
+
+async fn write_cookbook(path: &std::path::Path, content: &str) {
+    // Write in place. A rename-over would break the inotify watcher on Linux:
+    // the watch is set on the inode, and renaming a new file over the target
+    // replaces the inode without firing events on the new one.
+    tokio::fs::write(path, content).await.unwrap();
+}
+
+#[tokio::test]
+async fn reload_drains_orphaned_instances() {
+    cleanup_procs("mock_server_reload_eviction.sh").await;
+    cleanup_procs("config_reload_eviction.yaml").await;
+    cleanup_by_port_range_pattern("1309[0-9]").await;
+
+    let root = std::env::current_dir().unwrap();
+    let mock_script = setup_mock_script(&root, "reload_eviction").await;
+    let config_path = root.join("tests/config_reload_eviction.yaml");
+    let cookbook_path = root.join("tests/cookbook_reload_eviction.yaml");
+    let mut proxy_bin = root.join("target/release/llamesh");
+    if !proxy_bin.exists() {
+        let debug_bin = root.join("target/debug/llamesh");
+        if debug_bin.exists() {
+            proxy_bin = debug_bin;
+        }
+    }
+
+    tokio::fs::write(&config_path, config_yaml(&mock_script))
+        .await
+        .unwrap();
+    tokio::fs::write(&cookbook_path, COOKBOOK_ENABLED)
+        .await
+        .unwrap();
+
+    let mut proxy_process = tokio::process::Command::new(&proxy_bin)
+        .arg("--config")
+        .arg(&config_path)
+        .arg("--cookbook")
+        .arg(&cookbook_path)
+        .kill_on_drop(true)
+        .spawn()
+        .expect("failed to start proxy");
+
+    assert!(
+        wait_for_ready(BASE_URL).await,
+        "proxy failed to become ready"
+    );
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .unwrap();
+
+    // ── Case 1: disabling a model drains its running instance ───────────────
+    spawn_instance_for(&client, "mock-model:default").await;
+
+    let resp = client
+        .get(format!("{}/cluster/nodes", BASE_URL))
+        .send()
+        .await
+        .unwrap();
+    let json: serde_json::Value = resp.json().await.unwrap();
+    let loaded = json["nodes"]["test-reload-drain"]["loaded_models"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        loaded
+            .iter()
+            .any(|m| m.as_str() == Some("mock-model:default")),
+        "expected mock-model:default to be loaded, got {:?}",
+        loaded
+    );
+
+    write_cookbook(&cookbook_path, COOKBOOK_DISABLED).await;
+
+    assert!(
+        wait_for_unload(&client, "mock-model:default", Duration::from_secs(30)).await,
+        "mock-model:default should have been drained within 30s after disable"
+    );
+
+    // ── Case 2: changing llama_server_args drains the stale instance ────────
+    write_cookbook(&cookbook_path, COOKBOOK_ENABLED).await;
+    // /v1/models exposes default-profile models under the bare model name.
+    assert!(
+        wait_for_model_listed(&client, "mock-model", Duration::from_secs(10)).await,
+        "cookbook re-enable should make mock-model listed within 10s"
+    );
+
+    spawn_instance_for(&client, "mock-model:default").await;
+
+    write_cookbook(&cookbook_path, COOKBOOK_ARGS_CHANGED).await;
+
+    assert!(
+        wait_for_unload(&client, "mock-model:default", Duration::from_secs(30)).await,
+        "mock-model:default should have been drained within 30s after args_hash change"
+    );
+
+    // ── Teardown ────────────────────────────────────────────────────────────
+    graceful_stop(&mut proxy_process).await;
+    cleanup_procs("mock_server_reload_eviction.sh").await;
+    cleanup_by_port_range_pattern("1309[0-9]").await;
+    let _ = tokio::fs::remove_file(mock_script).await;
+    let _ = tokio::fs::remove_file(config_path).await;
+    let _ = tokio::fs::remove_file(cookbook_path).await;
+}


### PR DESCRIPTION
## Summary

Two closely-coupled fixes to the cookbook hot-reload path:

1. **Reconcile running instances with the cookbook on reload.** Disabling a model, removing a profile, or changing its `llama_server_args` previously left the running `llama-server` process alive indefinitely. Reload now marks stale instances `draining` and the standard eviction path terminates them once their in-flight requests finish. Covers four triggers: model missing, model disabled, profile removed, `llama_server_args` changed (args_hash drift). Emits `instance_orphaned_by_reload` with a `reason` field for observability. As defense-in-depth, `check_idle_instances` now drains immediately when a profile no longer resolves or its args_hash has drifted, replacing the previous 600s fallback.

2. **Cookbook watcher survives rename-based edits.** The watcher was bound to the file's inode, so a single rename-based edit (`sed -i`, most editors' save-atomic, IDE autosave) silently invalidated the watch. All subsequent cookbook changes required a proxy restart. The watcher now watches the parent directory and filters events by the cookbook filename, so both write styles keep firing events indefinitely. Found during smoke testing fix #1 — without it, fix #1 doesn't fire for the most common real-world editor workflows.

Fixes #7

## Test plan

- [x] `tests/integration_test_reload_eviction.rs`: Case 1 uses in-place write (disable), Case 2 uses rename-over write (args change) — latter is the regression guard for fix #2
- [x] All 280 tests pass (264 unit + 16 integration)
- [x] Manual smoke test on deployed node: request spawned `gemma-4-e4b-it:default` instance; rename-based edit flipped `enabled: true → false`; `cookbook_change_detected → cookbook_reload → instance_orphaned_by_reload → instance_terminate(reason: drained)` chain fired end-to-end in ~3ms from reload completion