### PR TITLE
fix: decrement current_requests on cancel in forward-to-peer path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instance would then never satisfy `in_flight_requests == 0` and would
   refuse to idle-evict, holding VRAM and sysmem indefinitely under any
   workload that experiences cancellations.
+- `current_requests` no longer leaks in the forward-to-peer path when the
+  local node has no entry for the requested model. The `inc_requests()` call
+  at the top of the path had no matching `RequestGuard`, so a cancellation
+  between there and the success-path `dec_current_requests()` leaked the
+  gauge monotonically. A `RequestGuard` now covers the path; on cancellation
+  its `Drop` decrements. On the success path, the decrement is deferred via
+  `CleanupStream` until the response body fully streams to the client (or is
+  dropped on client disconnect), closing a second window where headers had
+  arrived but the body was still in flight.
 
 ## [1.1.0] - 2026-03-31
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -275,7 +275,11 @@ pub async fn route_request(
                 );
 
                 state.metrics.inc_requests();
-                let start_time = std::time::Instant::now();
+                // RequestGuard ensures current_requests is decremented if this
+                // handler is cancelled before we can install the body-level
+                // cleanup below. Without it, a client disconnect during
+                // `client_req.send().await` would leak the gauge monotonically.
+                let guard = RequestGuard::new(state.clone());
 
                 let base = peer.address.trim_end_matches('/');
                 let url = format!("{}{}", base, path_and_query);
@@ -327,13 +331,32 @@ pub async fn route_request(
                 match client_req.send().await {
                     Ok(resp) => {
                         state.circuit_breaker.record_success(&peer.node_id).await;
-                        state.metrics.dec_current_requests();
-                        let _duration = start_time.elapsed().as_millis() as u64;
 
                         let status = resp.status();
                         let headers = resp.headers().clone();
-                        let body_stream = resp.bytes_stream();
-                        let body = Body::from_stream(body_stream);
+
+                        // Defer the dec_current_requests decrement until the
+                        // response body finishes streaming to the client (or is
+                        // dropped on client disconnect). CleanupStream::Drop
+                        // spawns this future on end-of-stream or on drop,
+                        // closing the cancellation window between headers
+                        // arriving and the body fully flushing.
+                        let cleanup_fut: BoxFuture<'static, ()> = {
+                            let state = state.clone();
+                            Box::pin(async move {
+                                state.metrics.dec_current_requests();
+                            })
+                        };
+
+                        // Hand off responsibility for dec from `guard` to
+                        // `cleanup_fut` now that we're committed to returning
+                        // the streaming response.
+                        guard.complete();
+
+                        let tokens_counter = Arc::new(AtomicU64::new(0));
+                        let wrapped =
+                            CleanupStream::new(resp.bytes_stream(), cleanup_fut, tokens_counter);
+                        let body = Body::from_stream(wrapped);
 
                         let mut response = Response::builder().status(status);
                         for (name, value) in headers.iter() {
@@ -348,7 +371,7 @@ pub async fn route_request(
                     }
                     Err(e) => {
                         state.circuit_breaker.record_failure(&peer.node_id).await;
-                        state.metrics.dec_current_requests();
+                        // guard Drop handles dec_current_requests on return.
                         state.metrics.inc_errors();
                         error!(peer = %peer.node_id, error = %e, "Failed to forward to peer");
                         return Err(AppError::new(

--- a/tests/integration_test_peer_forward_cancellation.rs
+++ b/tests/integration_test_peer_forward_cancellation.rs
@@ -1,0 +1,297 @@
+//! Verifies that a cancelled request in the forward-to-peer path does not
+//! leak the node-level `current_requests` gauge. Regression coverage for the
+//! counter leak in the local-unknown-model forward handler, where a missing
+//! `RequestGuard` let the `inc_requests()` at the top of the path go
+//! unbalanced on cancellation.
+//!
+//! Setup: two nodes A and B with gossip enabled. Node A owns `peer-model`,
+//! Node B does not. A client sends a request for `peer-model` to Node B with
+//! a short timeout; Node B forwards to Node A, but the mock llama-server on
+//! Node A takes 500-2000ms to produce headers, so the client's 300ms timeout
+//! aborts while Node B is still inside `client_req.send().await`.
+//!
+//! Assertion: Node B's `current_requests` returns to 0 within a bounded
+//! interval after the abort. Without the fix, it stays > 0 forever.
+
+use reqwest::StatusCode;
+use std::path::Path;
+use std::time::Duration;
+use tokio::time::sleep;
+
+mod common;
+use common::{
+    cleanup_by_port_range_pattern, cleanup_procs, graceful_stop, setup_mock_script, wait_for_ready,
+};
+
+const NODE_A_ADDR: &str = "127.0.0.1:9230";
+const NODE_B_ADDR: &str = "127.0.0.1:9231";
+const NODE_A_URL: &str = "http://127.0.0.1:9230";
+const NODE_B_URL: &str = "http://127.0.0.1:9231";
+
+fn config_node(
+    node_id: &str,
+    listen: &str,
+    peer: &str,
+    port_start: u16,
+    port_end: u16,
+    mock_script: &Path,
+) -> String {
+    format!(
+        r#"
+node_id: "{node_id}"
+listen_addr: "{listen}"
+public_url: "http://{listen}"
+max_vram_mb: 1024
+max_sysmem_mb: 1024
+default_model: "peer-model:default"
+model_defaults:
+  max_concurrent_requests_per_instance: 2
+  max_queue_size_per_model: 10
+  max_instances_per_model: 2
+  max_wait_in_queue_ms: 5000
+llama_cpp_ports:
+  ranges:
+    - start: {port_start}
+      end: {port_end}
+llama_cpp:
+  repo_url: ""
+  repo_path: "."
+  build_path: "."
+  binary_path: "{}"
+  branch: "master"
+  build_args: []
+  build_command_args: []
+  auto_update_interval_seconds: 0
+  enabled: false
+cluster:
+  enabled: true
+  peers: ["{peer}"]
+  gossip_interval_seconds: 1
+http:
+  request_body_limit_bytes: 1048576
+  idle_timeout_seconds: 60
+"#,
+        mock_script.display(),
+    )
+}
+
+const COOKBOOK_A: &str = r#"
+models:
+  - name: "peer-model"
+    enabled: true
+    profiles:
+      - id: "default"
+        model_path: "./models/mock.gguf"
+        idle_timeout_seconds: 60
+        max_instances: 1
+        llama_server_args: ""
+"#;
+
+// Node B does not know about peer-model; B must forward to A.
+const COOKBOOK_B: &str = r#"
+models:
+  - name: "other-model"
+    enabled: true
+    profiles:
+      - id: "default"
+        model_path: "./models/other.gguf"
+        idle_timeout_seconds: 60
+        max_instances: 1
+        llama_server_args: ""
+"#;
+
+async fn current_requests(client: &reqwest::Client, base_url: &str) -> u64 {
+    let Ok(resp) = client.get(format!("{base_url}/metrics/json")).send().await else {
+        return u64::MAX;
+    };
+    let Ok(json) = resp.json::<serde_json::Value>().await else {
+        return u64::MAX;
+    };
+    json["current_requests"].as_u64().unwrap_or(u64::MAX)
+}
+
+async fn wait_for_current_requests(
+    client: &reqwest::Client,
+    base_url: &str,
+    expected: u64,
+    timeout: Duration,
+) -> bool {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        if current_requests(client, base_url).await == expected {
+            return true;
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+    false
+}
+
+async fn wait_for_peer_discovery(
+    client: &reqwest::Client,
+    base_url: &str,
+    peer_node_id: &str,
+    timeout: Duration,
+) -> bool {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        if let Ok(resp) = client.get(format!("{base_url}/cluster/nodes")).send().await {
+            if let Ok(json) = resp.json::<serde_json::Value>().await {
+                if json["nodes"][peer_node_id]["ready"]
+                    .as_bool()
+                    .unwrap_or(false)
+                {
+                    return true;
+                }
+            }
+        }
+        sleep(Duration::from_millis(200)).await;
+    }
+    false
+}
+
+#[tokio::test]
+async fn cancelled_peer_forward_does_not_leak_current_requests() {
+    cleanup_procs("mock_server_peer_fwd_cancel.sh").await;
+    cleanup_procs("config_peer_fwd_cancel").await;
+    cleanup_by_port_range_pattern("1312[0-9]").await;
+
+    let root = std::env::current_dir().unwrap();
+    let mock_script = setup_mock_script(&root, "peer_fwd_cancel").await;
+
+    let config_a_path = root.join("tests/config_peer_fwd_cancel_a.yaml");
+    let cookbook_a_path = root.join("tests/cookbook_peer_fwd_cancel_a.yaml");
+    let config_b_path = root.join("tests/config_peer_fwd_cancel_b.yaml");
+    let cookbook_b_path = root.join("tests/cookbook_peer_fwd_cancel_b.yaml");
+
+    let mut proxy_bin = root.join("target/release/llamesh");
+    if !proxy_bin.exists() {
+        let debug_bin = root.join("target/debug/llamesh");
+        if debug_bin.exists() {
+            proxy_bin = debug_bin;
+        }
+    }
+
+    tokio::fs::write(
+        &config_a_path,
+        config_node(
+            "node-a-cancel",
+            NODE_A_ADDR,
+            NODE_B_URL,
+            13120,
+            13124,
+            &mock_script,
+        ),
+    )
+    .await
+    .unwrap();
+    tokio::fs::write(&cookbook_a_path, COOKBOOK_A).await.unwrap();
+    tokio::fs::write(
+        &config_b_path,
+        config_node(
+            "node-b-cancel",
+            NODE_B_ADDR,
+            NODE_A_URL,
+            13125,
+            13129,
+            &mock_script,
+        ),
+    )
+    .await
+    .unwrap();
+    tokio::fs::write(&cookbook_b_path, COOKBOOK_B).await.unwrap();
+
+    let mut proxy_a = tokio::process::Command::new(&proxy_bin)
+        .arg("--config")
+        .arg(&config_a_path)
+        .arg("--cookbook")
+        .arg(&cookbook_a_path)
+        .kill_on_drop(true)
+        .spawn()
+        .expect("failed to start proxy A");
+    let mut proxy_b = tokio::process::Command::new(&proxy_bin)
+        .arg("--config")
+        .arg(&config_b_path)
+        .arg("--cookbook")
+        .arg(&cookbook_b_path)
+        .kill_on_drop(true)
+        .spawn()
+        .expect("failed to start proxy B");
+
+    assert!(wait_for_ready(NODE_A_URL).await, "node A failed to ready");
+    assert!(wait_for_ready(NODE_B_URL).await, "node B failed to ready");
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .unwrap();
+
+    // Wait for gossip to propagate A's identity to B.
+    assert!(
+        wait_for_peer_discovery(&client, NODE_B_URL, "node-a-cancel", Duration::from_secs(15))
+            .await,
+        "node B should discover node A within 15s"
+    );
+
+    assert_eq!(
+        current_requests(&client, NODE_B_URL).await,
+        0,
+        "node B should have 0 in-flight requests before the test"
+    );
+
+    // Short-timeout client abort while B is inside `client_req.send().await`
+    // forwarding to A. The mock's default random 500-2000ms header delay is
+    // long enough to land cancellation in the send phase with a 300ms timeout.
+    let cancel_client = reqwest::Client::builder()
+        .timeout(Duration::from_millis(300))
+        .build()
+        .unwrap();
+    let body = serde_json::json!({
+        "model": "peer-model:default",
+        "messages": [{"role": "user", "content": "hi"}],
+    });
+    let _ = cancel_client
+        .post(format!("{NODE_B_URL}/v1/chat/completions"))
+        .json(&body)
+        .send()
+        .await;
+    // Don't assert on the result — the request is expected to fail (timeout).
+
+    // With the fix: RequestGuard::Drop decrements current_requests when the
+    // B-side handler future is dropped. Poll briefly to absorb any remaining
+    // inflight work from background tasks.
+    assert!(
+        wait_for_current_requests(&client, NODE_B_URL, 0, Duration::from_secs(10)).await,
+        "node B's current_requests should return to 0 within 10s after cancel; \
+         observed {}",
+        current_requests(&client, NODE_B_URL).await
+    );
+
+    // Sanity: a regular (non-cancelled) forward-to-peer request still completes.
+    let ok_client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .unwrap();
+    let resp = ok_client
+        .post(format!("{NODE_B_URL}/v1/chat/completions"))
+        .json(&body)
+        .send()
+        .await
+        .expect("non-cancelled forward should succeed");
+    assert_eq!(resp.status(), StatusCode::OK);
+    let _ = resp.bytes().await;
+
+    assert!(
+        wait_for_current_requests(&client, NODE_B_URL, 0, Duration::from_secs(5)).await,
+        "node B's current_requests should return to 0 after a successful forward"
+    );
+
+    graceful_stop(&mut proxy_a).await;
+    graceful_stop(&mut proxy_b).await;
+    cleanup_procs("mock_server_peer_fwd_cancel.sh").await;
+    cleanup_by_port_range_pattern("1312[0-9]").await;
+    let _ = tokio::fs::remove_file(mock_script).await;
+    let _ = tokio::fs::remove_file(config_a_path).await;
+    let _ = tokio::fs::remove_file(cookbook_a_path).await;
+    let _ = tokio::fs::remove_file(config_b_path).await;
+    let _ = tokio::fs::remove_file(cookbook_b_path).await;
+}


### PR DESCRIPTION
## Summary

- Adds a `RequestGuard` to the forward-to-peer branch in `route_request` so cancellation during `client_req.send().await` (or the error arm) decrements `current_requests` via `Drop` instead of leaking it.
- On the success arm, hands the decrement to a cleanup future wrapped in `CleanupStream` around the response body, so the counter drops when the body fully flushes to the client or is dropped on client disconnect — not when headers arrive.

Fixes #11

## Test plan

- [x] `tests/integration_test_peer_forward_cancellation.rs`: 2-node (A with model, B without) setup. Client sends to B with 300ms timeout while A's mock stalls headers 500-2000ms, so the abort lands inside B's `send().await`. Asserts B's `current_requests` returns to 0. Confirmed failing on unfixed code (stuck at 1), passing with fix. Also asserts a normal non-cancelled forward leaves the gauge at 0.
- [x] Full suite (276 tests, 262 unit + 14 integration): green