### PR TITLE
fix: balance concurrent bursts across cluster via local pending-forwards tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2026-04-21
+
+### Fixed
+
+- Cluster load balancing no longer oscillates between nodes on a ~gossip-period
+  cycle. Concurrent bursts for a model enabled on multiple nodes were all
+  piling onto a single node until gossip caught up, then all piling onto the
+  other — leaving one GPU idle while the other was saturated. Root cause: the
+  routing score in `select_best_node` consumed `peer.current_requests` from
+  the last gossip snapshot (stale by up to `gossip_interval_seconds`), so
+  every decision inside a burst saw the same "idle peer" view and committed
+  en masse to the same node. Additionally, `self.current_requests` is an
+  edge counter that includes requests this node has forwarded away (which
+  don't use local GPU), causing self to look busier than it really is.
+
+  Fix: added a local per-peer `pending_forwards` counter that increments
+  instantly when a request is forwarded and decrements when it completes (via
+  `PeerForwardGuard`'s `Drop` so cancellation/error paths are covered). The
+  scoring function now consumes an `effective_current_requests` that is
+  `peer.current_requests + pending_forwards_to_peer` for peers, and
+  `self.current_requests - total_pending_forwards` for self. Bursts now
+  diversify across nodes within a single dispatch, and self is scored by
+  actual local processing rather than edge traffic.
+
 ## [1.1.2] - 2026-04-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,7 +1701,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -801,7 +801,7 @@ If `cluster.enabled == true`:
 ```
 score = load_score + cold_start_cost - performance_bonus
 
-load_score = (queue_length * 50) + (in_flight_requests * 50)
+load_score = (queue_length * 50) + (effective_current_requests * 50)
 
 cold_start_cost:
   Model already loaded:               0
@@ -811,6 +811,10 @@ cold_start_cost:
 
 performance_bonus = min(tps, 200) * 5 + min(remaining_slots, 4) * 50
 ```
+
+`effective_current_requests` adjusts the gossip-based in-flight count to close the staleness window between gossip ticks:
+  * For peers: `peer.current_requests + pending_forwards_to_peer`, where `pending_forwards_to_peer` is the number of requests this node has forwarded to that peer that have not yet completed. This makes bursts visible to the scorer immediately instead of after the next gossip tick.
+  * For self: `self.current_requests - sum(pending_forwards_to_all_peers)`. The edge counter includes forwarded-out requests that don't consume local GPU, so we subtract them to reflect true local processing load.
 
 Lowest score wins.
 

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -53,7 +53,7 @@ pub enum NodeError {
     Other(#[from] anyhow::Error),
 }
 
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 
 /// NodeState holds all runtime state for a mesh proxy node.
 ///
@@ -131,9 +131,38 @@ pub struct NodeState {
     /// an instance stops, starts, or is drained). Complements the periodic
     /// gossip interval for latency-sensitive state changes.
     pub gossip_trigger: Arc<Notify>,
+    /// Per-peer count of requests this node has forwarded and that haven't
+    /// completed yet. Updated instantly on route decisions and completions so
+    /// routing does not have to wait for the next gossip tick to see that a
+    /// peer just received work. Bridges the up-to-`gossip_interval` staleness
+    /// of `peer.current_requests` during bursts.
+    pub peer_pending_forwards: Arc<RwLock<HashMap<String, Arc<AtomicUsize>>>>,
 }
 
 use crate::security;
+
+/// Drop-guard that decrements a per-peer pending-forward counter. Ensures the
+/// counter is always released on cancellation, error, or normal completion.
+pub struct PeerForwardGuard {
+    counter: Arc<AtomicUsize>,
+    released: bool,
+}
+
+impl PeerForwardGuard {
+    /// Explicitly release the guard without waiting for Drop. Idempotent.
+    pub fn release(&mut self) {
+        if !self.released {
+            self.counter.fetch_sub(1, Ordering::Relaxed);
+            self.released = true;
+        }
+    }
+}
+
+impl Drop for PeerForwardGuard {
+    fn drop(&mut self) {
+        self.release();
+    }
+}
 
 impl NodeState {
     pub async fn new(
@@ -231,6 +260,7 @@ impl NodeState {
             capacity_notify: Arc::new(Notify::new()),
             needs_eviction: Arc::new(RwLock::new(HashSet::new())),
             gossip_trigger: Arc::new(Notify::new()),
+            peer_pending_forwards: Arc::new(RwLock::new(HashMap::new())),
         })
     }
 
@@ -1943,6 +1973,30 @@ impl NodeState {
         !self.draining.load(Ordering::Relaxed) && self.build_manager.can_serve()
     }
 
+    /// Record that this node has just decided to forward a request to `peer_id`.
+    /// The returned guard decrements the counter on drop, so callers can rely
+    /// on scope-based cleanup even on cancellation or error paths.
+    pub async fn track_peer_forward(&self, peer_id: &str) -> PeerForwardGuard {
+        let counter = {
+            let map = self.peer_pending_forwards.read().await;
+            map.get(peer_id).cloned()
+        };
+        let counter = match counter {
+            Some(c) => c,
+            None => {
+                let mut map = self.peer_pending_forwards.write().await;
+                map.entry(peer_id.to_string())
+                    .or_insert_with(|| Arc::new(AtomicUsize::new(0)))
+                    .clone()
+            }
+        };
+        counter.fetch_add(1, Ordering::Relaxed);
+        PeerForwardGuard {
+            counter,
+            released: false,
+        }
+    }
+
     /// Select the best node to handle a request.
     ///
     /// If `prefer_local` is true (e.g., the request was already forwarded from another peer),
@@ -2018,11 +2072,31 @@ impl NodeState {
         // Get local learned memory estimate for this model (used when peer doesn't have stats)
         let local_memory_estimate = self.get_memory_estimate_for_key(&requested_key).await;
 
+        // Snapshot the local pending-forwards map once. This reflects routing
+        // decisions made *since* the last gossip tick, which would otherwise
+        // be invisible until the next gossip cycle (up to
+        // `gossip_interval_seconds`). Using this closes the staleness window
+        // that caused bursty load to pile onto one peer.
+        let pending_snapshot: HashMap<String, usize> = {
+            let map = self.peer_pending_forwards.read().await;
+            map.iter()
+                .map(|(k, v)| (k.clone(), v.load(Ordering::Relaxed)))
+                .collect()
+        };
+        let total_pending: usize = pending_snapshot.values().sum();
+        let self_node_id = self.config.node_id.as_str();
+
         // Intelligent Routing Formula:
         // Score = load_score + cold_start_cost - performance_bonus
         //
         // load_score: Penalizes busy nodes
-        //   = (queue_length × 50) + (in_flight_requests × 50)
+        //   = (queue_length × 50) + (effective_current_requests × 50)
+        //
+        // effective_current_requests adjusts the gossip-based count for staleness:
+        //   - For peers: peer.current_requests + pending_forwards_from_self_to_peer
+        //   - For self:  current_requests - sum(pending_forwards_to_peers)
+        //                (subtract out requests we're forwarding — those don't
+        //                 use our GPU, they just keep our edge counter busy)
         //
         // cold_start_cost: Penalizes nodes that need to start/evict instances
         //   - Model loaded: 0
@@ -2037,7 +2111,22 @@ impl NodeState {
         let mut scored: Vec<(PeerState, f64)> = candidates
             .into_iter()
             .map(|c| {
-                let score = calculate_node_score(&c, &requested_key, local_memory_estimate);
+                let is_self = c.node_id == self_node_id;
+                let effective_current = if is_self {
+                    c.current_requests.saturating_sub(total_pending as u64)
+                } else {
+                    let pending = pending_snapshot
+                        .get(&c.node_id)
+                        .copied()
+                        .unwrap_or(0) as u64;
+                    c.current_requests.saturating_add(pending)
+                };
+                let score = calculate_node_score(
+                    &c,
+                    &requested_key,
+                    local_memory_estimate,
+                    effective_current,
+                );
                 (c, score)
             })
             .collect();
@@ -2450,13 +2539,20 @@ fn peer_supports_profile(peer: &PeerState, model_name: &str, profile_id: &str) -
 ///   score = load_score + cold_start_cost - performance_bonus
 ///
 /// Where:
-/// - load_score = (queue_length × 50) + (in_flight_requests × 50)
+/// - load_score = (queue_length × 50) + (effective_current_requests × 50)
 /// - cold_start_cost depends on whether model is loaded and memory availability
 /// - performance_bonus = min(tps, 200) × 5 + (remaining_slots × 50)
+///
+/// `effective_current_requests` is the caller-adjusted in-flight count. For
+/// peers, it's `peer.current_requests + local_pending_forwards_to_peer` so
+/// bursts get reflected instantly instead of waiting for gossip. For self,
+/// it's `current_requests - sum_of_local_pending_forwards` so forwarded
+/// requests (which don't use local GPU) don't inflate self's load score.
 fn calculate_node_score(
     peer: &PeerState,
     model_key: &str,
     local_memory_estimate: (u64, u64),
+    effective_current_requests: u64,
 ) -> f64 {
     let stats = peer.model_stats.get(model_key);
 
@@ -2474,7 +2570,8 @@ fn calculate_node_score(
     // Calculate base load score (penalizes busy nodes)
     // Per-request penalty increased from 10 to 50 so that 1 busy instance
     // on a warm node makes cold-starting on an idle node more attractive.
-    let load_score = (peer.total_queue_length as f64 * 50.0) + (peer.current_requests as f64 * 50.0);
+    let load_score = (peer.total_queue_length as f64 * 50.0)
+        + (effective_current_requests as f64 * 50.0);
 
     // Calculate cold start cost
     let cold_start_cost = if model_loaded {
@@ -3308,8 +3405,18 @@ mod tests {
         };
 
         let local_mem = (8000, 16000);
-        let loaded_score = calculate_node_score(&loaded_idle_peer, model_key, local_mem);
-        let unloaded_score = calculate_node_score(&unloaded_peer, model_key, local_mem);
+        let loaded_score = calculate_node_score(
+            &loaded_idle_peer,
+            model_key,
+            local_mem,
+            loaded_idle_peer.current_requests,
+        );
+        let unloaded_score = calculate_node_score(
+            &unloaded_peer,
+            model_key,
+            local_mem,
+            unloaded_peer.current_requests,
+        );
 
         // IDLE loaded node should still win (TPS bonus + no cold start)
         assert!(
@@ -3375,8 +3482,18 @@ mod tests {
         };
 
         let local_mem = (8000, 16000);
-        let loaded_score = calculate_node_score(&loaded_busy_peer, model_key, local_mem);
-        let unloaded_score = calculate_node_score(&unloaded_peer, model_key, local_mem);
+        let loaded_score = calculate_node_score(
+            &loaded_busy_peer,
+            model_key,
+            local_mem,
+            loaded_busy_peer.current_requests,
+        );
+        let unloaded_score = calculate_node_score(
+            &unloaded_peer,
+            model_key,
+            local_mem,
+            unloaded_peer.current_requests,
+        );
 
         // Busy loaded node should LOSE to idle unloaded node
         // Cold-starting on idle node is better than queuing behind busy instance
@@ -3433,8 +3550,18 @@ mod tests {
             loaded_models: vec!["gpt:fast".into()],
         };
 
-        let idle_score = calculate_node_score(&idle_peer, model_key, local_mem);
-        let busy_score = calculate_node_score(&busy_peer, model_key, local_mem);
+        let idle_score = calculate_node_score(
+            &idle_peer,
+            model_key,
+            local_mem,
+            idle_peer.current_requests,
+        );
+        let busy_score = calculate_node_score(
+            &busy_peer,
+            model_key,
+            local_mem,
+            busy_peer.current_requests,
+        );
 
         // Idle should score better (lower)
         assert!(
@@ -3494,8 +3621,18 @@ mod tests {
             },
         );
 
-        let slow_score = calculate_node_score(&slow_peer, model_key, local_mem);
-        let fast_score = calculate_node_score(&fast_peer, model_key, local_mem);
+        let slow_score = calculate_node_score(
+            &slow_peer,
+            model_key,
+            local_mem,
+            slow_peer.current_requests,
+        );
+        let fast_score = calculate_node_score(
+            &fast_peer,
+            model_key,
+            local_mem,
+            fast_peer.current_requests,
+        );
 
         // Fast should score better (lower)
         assert!(
@@ -3503,6 +3640,101 @@ mod tests {
             "Fast node ({}) should score better than slow ({})",
             fast_score,
             slow_score
+        );
+    }
+
+    #[test]
+    fn test_node_score_effective_current_adjusts_for_pending_forwards() {
+        // Models the fix: a peer that *gossip* reports as idle but to which
+        // we've already forwarded 5 requests since the last gossip tick
+        // should score as "5 in-flight" for routing purposes.
+        let model_key = "gpt:fast";
+        let local_mem = (8000, 16000);
+
+        let peer = PeerState {
+            node_id: "peer".into(),
+            address: "http://peer".into(),
+            version: "0.1.0".into(),
+            last_seen: 0,
+            supported_models: vec!["gpt:fast".into()],
+            active_instances: 1,
+            max_instances: 8,
+            current_requests: 0, // stale gossip value — peer *looks* idle
+            available_vram: 8000,
+            available_sysmem: 32000,
+            max_vram: 16000,
+            max_sysmem: 64000,
+            total_queue_length: 0,
+            model_stats: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "gpt:fast".into(),
+                    PeerModelStats {
+                        tps: 50.0,
+                        queue_len: 0,
+                        vram_mb: 8000,
+                        sysmem_mb: 16000,
+                        instance_count: 1,
+                    },
+                );
+                m
+            },
+            ready: true,
+            loaded_models: vec!["gpt:fast".into()],
+        };
+
+        // Score as if gossip were the only truth: peer looks empty.
+        let naive_score = calculate_node_score(&peer, model_key, local_mem, 0);
+        // Score with 5 pending local forwards layered on top.
+        let effective_score = calculate_node_score(&peer, model_key, local_mem, 5);
+
+        // 5 extra requests × 50 = +250 to load_score. Effective score must
+        // be strictly higher so routing will diversify to other candidates.
+        assert!(
+            effective_score > naive_score,
+            "pending-forward adjustment must raise score: naive={} effective={}",
+            naive_score,
+            effective_score
+        );
+        assert!(
+            (effective_score - naive_score - 250.0).abs() < 1e-6,
+            "5 pending forwards should add exactly 250 (= 5×50) to load_score, got delta {}",
+            effective_score - naive_score
+        );
+    }
+
+    #[test]
+    fn test_peer_forward_guard_releases_on_drop() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        {
+            counter.fetch_add(1, Ordering::Relaxed);
+            let _g = PeerForwardGuard {
+                counter: counter.clone(),
+                released: false,
+            };
+            assert_eq!(counter.load(Ordering::Relaxed), 1);
+        }
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            0,
+            "Drop must decrement the counter"
+        );
+    }
+
+    #[test]
+    fn test_peer_forward_guard_release_is_idempotent() {
+        let counter = Arc::new(AtomicUsize::new(1));
+        let mut g = PeerForwardGuard {
+            counter: counter.clone(),
+            released: false,
+        };
+        g.release();
+        g.release();
+        g.release();
+        assert_eq!(
+            counter.load(Ordering::Relaxed),
+            0,
+            "Repeated release() calls must not underflow"
         );
     }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -280,6 +280,9 @@ pub async fn route_request(
                 // cleanup below. Without it, a client disconnect during
                 // `client_req.send().await` would leak the gauge monotonically.
                 let guard = RequestGuard::new(state.clone());
+                // Track this forward locally so concurrent routing decisions
+                // see the peer's load before its next gossip tick.
+                let peer_forward_guard = state.track_peer_forward(&peer.node_id).await;
 
                 let base = peer.address.trim_end_matches('/');
                 let url = format!("{}{}", base, path_and_query);
@@ -343,8 +346,10 @@ pub async fn route_request(
                         // arriving and the body fully flushing.
                         let cleanup_fut: BoxFuture<'static, ()> = {
                             let state = state.clone();
+                            let mut peer_forward_guard = peer_forward_guard;
                             Box::pin(async move {
                                 state.metrics.dec_current_requests();
+                                peer_forward_guard.release();
                             })
                         };
 
@@ -637,6 +642,8 @@ pub async fn route_request(
                                 "Local spawn failures exhausted, falling back to peer"
                             );
 
+                            let peer_forward_guard =
+                                state.track_peer_forward(&peer.node_id).await;
                             let base = peer.address.trim_end_matches('/');
                             let url = format!("{}{}", base, path_and_query);
 
@@ -691,8 +698,10 @@ pub async fn route_request(
                                     let cleanup_fut: BoxFuture<'static, ()> = {
                                         let state = state.clone();
                                         let hash_metrics = hash_metrics.clone();
+                                        let mut peer_forward_guard = peer_forward_guard;
                                         Box::pin(async move {
                                             state.metrics.dec_current_requests();
+                                            peer_forward_guard.release();
                                             let duration = start_time.elapsed().as_millis() as u64;
                                             hash_metrics
                                                 .total_latency_ms
@@ -714,6 +723,8 @@ pub async fn route_request(
                                     });
                                 }
                                 Err(peer_err) => {
+                                    // peer_forward_guard drops on fall-through,
+                                    // releasing the counter.
                                     state.circuit_breaker.record_failure(&peer.node_id).await;
                                     warn!(
                                         peer = %peer.node_id,
@@ -767,6 +778,11 @@ pub async fn route_request(
         } else {
             // Remote routing
             info!("Forwarding remotely to peer {}", best_node.node_id);
+            // Track this forward locally so subsequent routing decisions reflect
+            // it instantly rather than waiting up to `gossip_interval_seconds`
+            // for the peer's next gossip tick. Guard is released in the cleanup
+            // future (success) or on function return (error).
+            let peer_forward_guard = state.track_peer_forward(&best_node.node_id).await;
             let base = best_node.address.trim_end_matches('/');
             let url = format!("{}{}", base, path_and_query);
 
@@ -829,8 +845,12 @@ pub async fn route_request(
                     let cleanup_fut: BoxFuture<'static, ()> = {
                         let state = state.clone();
                         let hash_metrics = hash_metrics.clone();
+                        // Move the peer-forward guard into the cleanup future so
+                        // it's decremented exactly when the response completes.
+                        let mut peer_forward_guard = peer_forward_guard;
                         Box::pin(async move {
                             state.metrics.dec_current_requests();
+                            peer_forward_guard.release();
                             let duration = start_time.elapsed().as_millis() as u64;
                             hash_metrics
                                 .total_latency_ms
@@ -852,6 +872,7 @@ pub async fn route_request(
                     })
                 }
                 Err(e) => {
+                    // peer_forward_guard drops here, releasing the counter.
                     // Record failure for circuit breaker
                     state
                         .circuit_breaker


### PR DESCRIPTION
Fixes #13

## Summary

- `select_best_node`'s peer load score was reading `peer.current_requests` from gossip, stale by up to `gossip_interval_seconds`. Concurrent bursts all saw the same snapshot and piled onto one node until gossip flipped, producing alternating single-node utilization on a gossip-period cycle.
- Adds a local `peer_pending_forwards` counter incremented on route decision and decremented on completion (via `PeerForwardGuard::Drop` for cancellation/error safety). Scoring now uses `effective_current_requests = peer.current_requests + pending_forwards_to_peer` for peers and `self.current_requests - total_pending_forwards` for self (edge counter includes forwarded-out requests that don't use local GPU).
- Wired into all three forwarding paths in `router.rs`: normal remote, unknown-model forward, peer fallback on local spawn failure.

## Test plan

- [x] `cargo test --bin llamesh` — 267 unit tests pass, incl. 3 new scoring/guard tests
- [x] `cargo test --test integration_test` — 8 cluster integration tests pass
- [x] `cargo test --test integration_test_peer_forward_cancellation` — peer-forward cancellation test still passes (guard drops clean)
- [x] `cargo build --release` — compiles clean
- [ ] Live validation post-deploy: pound both-node cluster with 10 concurrent requests for a model enabled on both; expect both GPUs pinned simultaneously instead of alternating.