### PR TITLE
Support disabling individual model profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Cookbook profiles now support `enabled: false` independently from their
+  parent model, allowing one profile to be hidden, unroutable, and omitted
+  from cluster advertisements while sibling profiles remain available.
 - Optional per-profile `estimated_vram_mb` and `estimated_sysmem_mb` cookbook
   fields provide cold-start admission hints until runtime memory sampling learns
   measured peaks for a launch-args hash.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,23 @@ Request a specific profile with `model:profile` syntax:
 
 Define profiles in the cookbook to trade off speed vs quality, context size, quantization, etc. — each profile maps to a distinct set of `llama-server` args.
 
+Profiles default to enabled. Set `enabled: false` on a profile to keep it in
+the cookbook without listing, routing, prewarming, or advertising that profile:
+
+```yaml
+models:
+  - name: "my-model"
+    enabled: true
+    profiles:
+      - id: "default"
+        model_path: "./models/my-model.gguf"
+        llama_server_args: "-c 32768 -fa on"
+      - id: "experimental"
+        enabled: false
+        model_path: "./models/my-model.gguf"
+        llama_server_args: "-c 65536 -fa on"
+```
+
 ## Hugging Face Models
 
 Download models automatically instead of managing files manually:

--- a/SPEC.md
+++ b/SPEC.md
@@ -323,6 +323,7 @@ models:
     enabled: true                      # optional, default true
     profiles:
       - id: "fast"
+        enabled: true                       # optional, default true
         description: "Lower context, higher throughput"
         model_path: "./models/gpt-oss-20b-q4_K_M.gguf"
         idle_timeout_seconds: 600         # optional, default 300
@@ -388,11 +389,18 @@ You can also specify model source directly in `llama_server_args` using `-m`/`--
 
 `llama_server_args` is merged with proxy-managed connection settings. By default the proxy appends `--host 127.0.0.1`, an auto-chosen `--port`, `-c 0` (max context size), and `--fit off` (disable auto-optimization) for each instance; if you explicitly include `--host`, `--port`, `-c`/`--ctx-size`, or `--fit` in `llama_server_args`, those values override the defaults. The `-c 0` default tells llama-server to use the model's maximum trained context length. The `--fit off` default ensures your hand-crafted cookbook settings are not overridden by llama-server's automatic optimization feature.
 
+Model and profile `enabled` fields are independent. A profile is available only
+when both its parent model and the profile are enabled. `enabled: false` on a
+profile removes that profile from local routing, `/v1/models`, prewarm, and
+cluster advertisements while leaving sibling profiles available. If a cookbook
+reload disables a profile, existing instances for that profile are drained
+gracefully and stopped once idle.
+
 To mirror upstream `llama-server` behaviors ([docs](https://github.com/ggml-org/llama.cpp/tree/master/tools/server)), you typically configure different profiles with appropriate flags:
 
 * **Speculative decoding**: Add an additional "draft" model/profile in the cookbook and reference it via `llama_server_args` (for example `-md /models/draft.gguf`); the proxy will manage such instances like any other.
 * **Embeddings**: Create a profile whose `llama_server_args` include `--embedding` (and optionally `--pooling`, `-ub`, etc.), matching the upstream examples. That profile will then be addressable via the OpenAI `/v1/embeddings` endpoint on the proxy; there is no node-level `--embedding` toggle.
-* **Reranking (optional / version-dependent)**: When the deployed `llama-server` version exposes reranking support, create a profile with the documented reranking flag(s) from `tools/server`; the proxy can then route dedicated reranking requests to those instances. If reranking is not available in your `llama-server` build, keep such profiles disabled; there is no node-level `--reranking` toggle.
+* **Reranking (optional / version-dependent)**: When the deployed `llama-server` version exposes reranking support, create a profile with the documented reranking flag(s) from `tools/server`; the proxy can then route dedicated reranking requests to those instances. If reranking is not available in your `llama-server` build, keep such profiles disabled with `enabled: false`; there is no node-level `--reranking` toggle.
 * **Grammar-constrained outputs**: Configure profiles whose `llama_server_args` enable grammars (e.g. `--grammar-file` or other grammar-related flags supported by your `llama-server` build). The proxy does not have a node-level grammar setting; grammar is entirely per-instance via the underlying `llama-server` CLI.
 
 **Endpoint-Type Enforcement:**

--- a/cookbook.example.yaml
+++ b/cookbook.example.yaml
@@ -2,7 +2,7 @@
 # llamesh Cookbook (Model Definitions)
 # =============================================================================
 # Models are requested via: POST /v1/chat/completions { "model": "name:profile" }
-# If profile omitted, first enabled profile is used.
+# If profile is omitted, the "default" profile is used.
 #
 # llama_server_args is a shell-style string. Quote args with spaces:
 #   llama_server_args: "-c 4096 --api-key 'secret key'"
@@ -13,6 +13,7 @@
 #     llama_server_args: ""
 #
 # Profile defaults:
+#   enabled: true                    # set false to hide/disable one profile
 #   idle_timeout_seconds: 300        # 5 minutes
 #   startup_timeout_seconds: 60      # 60s local, 3600s for HF downloads
 #   max_instances: (from model_defaults)
@@ -47,11 +48,18 @@ models:
         llama_server_args: "--alias gpt-oss-20b-fast -c 32768 -b 2048 -fa on --kv-unified"
 
       - id: "quality"
+        enabled: true                 # default: true
         description: "Larger context, more careful settings"
         model_path: "./models/gpt-oss-20b-q6_K.gguf"
         idle_timeout_seconds: 900
         max_instances: 2
         llama_server_args: "--alias gpt-oss-20b-quality -c 131072 -b 1024 -fa on --kv-unified"
+
+      # Keep alternate profiles in the cookbook without advertising or serving them.
+      # - id: "experimental"
+      #   enabled: false
+      #   model_path: "./models/gpt-oss-20b-q4_K_M.gguf"
+      #   llama_server_args: "--alias gpt-oss-20b-experimental -c 65536"
 
   # ---------------------------------------------------------------------------
   # Vision-language model

--- a/src/config.rs
+++ b/src/config.rs
@@ -476,12 +476,12 @@ impl Cookbook {
 pub struct Model {
     pub name: String,
     pub description: Option<String>,
-    #[serde(default = "default_model_enabled")]
+    #[serde(default = "default_enabled")]
     pub enabled: bool,
     pub profiles: Vec<Profile>,
 }
 
-fn default_model_enabled() -> bool {
+fn default_enabled() -> bool {
     true
 }
 
@@ -501,6 +501,8 @@ fn default_protocol_detect_timeout_ms() -> u64 {
 pub struct Profile {
     pub id: String,
     pub description: Option<String>,
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
     /// Path to a local model file. Either `model_path` or `hf_repo` must be specified.
     #[serde(default)]
     pub model_path: Option<String>,
@@ -709,6 +711,7 @@ mod tests {
         Profile {
             id: "p".into(),
             description: None,
+            enabled: true,
             model_path: Some("/tmp/model.gguf".into()),
             hf_repo: None,
             hf_file: None,
@@ -896,6 +899,7 @@ mod tests {
         let profile = Profile {
             id: "test".into(),
             description: None,
+            enabled: true,
             model_path: None,
             hf_repo: None,
             hf_file: None,
@@ -919,6 +923,7 @@ mod tests {
         let profile = Profile {
             id: "test".into(),
             description: None,
+            enabled: true,
             model_path: Some("/path/to/model.gguf".into()),
             hf_repo: Some("org/model-GGUF".into()),
             hf_file: None,
@@ -942,6 +947,7 @@ mod tests {
         let profile = Profile {
             id: "test".into(),
             description: None,
+            enabled: true,
             model_path: None,
             hf_repo: None,
             hf_file: None,
@@ -965,6 +971,7 @@ mod tests {
         let profile = Profile {
             id: "test".into(),
             description: None,
+            enabled: true,
             model_path: None,
             hf_repo: None,
             hf_file: None,
@@ -1180,6 +1187,37 @@ models:
             let cookbook = parse_cookbook(yaml).unwrap();
             let profile = &cookbook.models[0].profiles[0];
             assert_eq!(profile.max_queue_size, None);
+        }
+
+        #[test]
+        fn profile_enabled_defaults_to_true() {
+            let yaml = r#"
+models:
+  - name: test
+    profiles:
+      - id: default
+        model_path: /tmp/model.gguf
+        idle_timeout_seconds: 10
+        llama_server_args: ""
+"#;
+            let cookbook = parse_cookbook(yaml).unwrap();
+            assert!(cookbook.models[0].profiles[0].enabled);
+        }
+
+        #[test]
+        fn parses_profile_enabled_false() {
+            let yaml = r#"
+models:
+  - name: test
+    profiles:
+      - id: default
+        enabled: false
+        model_path: /tmp/model.gguf
+        idle_timeout_seconds: 10
+        llama_server_args: ""
+"#;
+            let cookbook = parse_cookbook(yaml).unwrap();
+            assert!(!cookbook.models[0].profiles[0].enabled);
         }
     }
 }

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -2050,6 +2050,9 @@ impl NodeState {
                 .flat_map(|model| {
                     let model_defaults = &self.config.model_defaults;
                     model.profiles.iter().filter_map(move |profile| {
+                        if !profile.enabled {
+                            return None;
+                        }
                         if profile.effective_max_instances(model_defaults) == 0 {
                             return None;
                         }
@@ -2904,6 +2907,7 @@ mod tests {
         Profile {
             id: "default".into(),
             description: None,
+            enabled: true,
             model_path: Some("/tmp/model.gguf".into()),
             hf_repo: None,
             hf_file: None,
@@ -3106,6 +3110,56 @@ mod tests {
         assert!(result.is_some());
         let picked = result.unwrap();
         assert_eq!(picked.node_id, "remote-peer");
+    }
+
+    #[tokio::test]
+    async fn self_peer_state_excludes_disabled_profiles_from_supported_models() {
+        let mut config = minimal_node_config();
+        config.cluster.enabled = false;
+
+        let default_profile = sample_profile();
+
+        let mut fast_profile = sample_profile();
+        fast_profile.id = "fast".into();
+
+        let mut disabled_profile = sample_profile();
+        disabled_profile.id = "disabled".into();
+        disabled_profile.enabled = false;
+
+        let mut zero_capacity_profile = sample_profile();
+        zero_capacity_profile.id = "zero-capacity".into();
+        zero_capacity_profile.max_instances = Some(0);
+
+        let cookbook = Cookbook {
+            models: vec![Model {
+                name: "local-model".into(),
+                description: None,
+                enabled: true,
+                profiles: vec![
+                    default_profile,
+                    fast_profile,
+                    disabled_profile,
+                    zero_capacity_profile,
+                ],
+            }],
+        };
+        let build_manager = BuildManager::new(config.llama_cpp.clone());
+        let state = NodeState::new(config, cookbook, build_manager)
+            .await
+            .unwrap();
+
+        let self_peer = state.get_self_peer_state().await;
+
+        assert!(self_peer.supported_models.contains(&"local-model".into()));
+        assert!(self_peer
+            .supported_models
+            .contains(&"local-model:fast".into()));
+        assert!(!self_peer
+            .supported_models
+            .contains(&"local-model:disabled".into()));
+        assert!(!self_peer
+            .supported_models
+            .contains(&"local-model:zero-capacity".into()));
     }
 
     #[tokio::test]

--- a/src/node_state/model_index.rs
+++ b/src/node_state/model_index.rs
@@ -15,6 +15,9 @@ pub fn build_model_index(cookbook: &Cookbook) -> HashMap<String, (String, Profil
             continue;
         }
         for profile in &model.profiles {
+            if !profile.enabled {
+                continue;
+            }
             let key = format!(
                 "{}:{}",
                 model.name.to_lowercase(),
@@ -152,8 +155,14 @@ pub async fn get_args_hash_for_key(cookbook: &RwLock<Cookbook>, key: &str) -> Op
     };
 
     let cookbook = cookbook.read().await;
-    let model = cookbook.models.iter().find(|m| m.name == model_name)?;
-    let profile = model.profiles.iter().find(|p| p.id == profile_id)?;
+    let model = cookbook
+        .models
+        .iter()
+        .find(|m| m.enabled && m.name == model_name)?;
+    let profile = model
+        .profiles
+        .iter()
+        .find(|p| p.enabled && p.id == profile_id)?;
 
     let (pre_args, _, _) = build_pre_args(profile);
     Some(compute_args_hash(&pre_args))
@@ -175,6 +184,7 @@ mod tests {
                         Profile {
                             id: "default".to_string(),
                             description: None,
+                            enabled: true,
                             model_path: Some("/path/to/model.gguf".to_string()),
                             hf_repo: None,
                             hf_file: None,
@@ -193,6 +203,26 @@ mod tests {
                         Profile {
                             id: "fast".to_string(),
                             description: None,
+                            enabled: true,
+                            model_path: Some("/path/to/model.gguf".to_string()),
+                            hf_repo: None,
+                            hf_file: None,
+                            idle_timeout_seconds: 60,
+                            max_instances: Some(4),
+                            llama_server_args: vec![],
+                            estimated_vram_mb: None,
+                            estimated_sysmem_mb: None,
+                            max_wait_in_queue_ms: None,
+                            max_request_duration_ms: None,
+                            startup_timeout_seconds: None,
+                            download_timeout_seconds: None,
+                            max_queue_size: None,
+                            min_eviction_tenure_secs: None,
+                        },
+                        Profile {
+                            id: "disabled-profile".to_string(),
+                            description: None,
+                            enabled: false,
                             model_path: Some("/path/to/model.gguf".to_string()),
                             hf_repo: None,
                             hf_file: None,
@@ -227,6 +257,7 @@ mod tests {
 
         assert!(index.contains_key("gpt:default"));
         assert!(index.contains_key("gpt:fast"));
+        assert!(!index.contains_key("gpt:disabled-profile"));
         assert!(!index.contains_key("disabled:default"));
     }
 
@@ -256,6 +287,35 @@ mod tests {
         // Not found
         let result = model_index.resolve("nonexistent").await;
         assert!(result.is_none());
+
+        // Disabled profile
+        let result = model_index.resolve("gpt:disabled-profile").await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn bare_model_requires_enabled_default_profile() {
+        let mut cookbook = sample_cookbook();
+        cookbook.models[0].profiles[0].enabled = false;
+
+        let model_index = ModelIndex::new(&cookbook);
+
+        assert!(model_index.resolve("gpt").await.is_none());
+        assert!(model_index.resolve("gpt:default").await.is_none());
+        assert!(model_index.resolve("gpt:fast").await.is_some());
+    }
+
+    #[tokio::test]
+    async fn args_hash_requires_enabled_model_and_profile() {
+        let cookbook = RwLock::new(sample_cookbook());
+
+        assert!(get_args_hash_for_key(&cookbook, "gpt:fast").await.is_some());
+        assert!(get_args_hash_for_key(&cookbook, "gpt:disabled-profile")
+            .await
+            .is_none());
+        assert!(get_args_hash_for_key(&cookbook, "disabled:default")
+            .await
+            .is_none());
     }
 
     #[test]
@@ -263,6 +323,7 @@ mod tests {
         let profile = Profile {
             id: "test".to_string(),
             description: None,
+            enabled: true,
             model_path: Some("/path/to/model.gguf".to_string()),
             hf_repo: None,
             hf_file: None,
@@ -292,6 +353,7 @@ mod tests {
         let profile = Profile {
             id: "test".to_string(),
             description: None,
+            enabled: true,
             model_path: None,
             hf_repo: Some("TheBloke/Llama-2-7B-GGUF".to_string()),
             hf_file: Some("llama-2-7b.Q4_K_M.gguf".to_string()),
@@ -339,6 +401,7 @@ mod tests {
         let profile = Profile {
             id: "test".to_string(),
             description: None,
+            enabled: true,
             model_path: Some("/model.gguf".to_string()),
             hf_repo: None,
             hf_file: None,
@@ -366,6 +429,7 @@ mod tests {
         let profile = Profile {
             id: "test".to_string(),
             description: None,
+            enabled: true,
             model_path: Some("/default.gguf".to_string()),
             hf_repo: None,
             hf_file: None,
@@ -394,6 +458,7 @@ mod tests {
         let profile = Profile {
             id: "test".to_string(),
             description: None,
+            enabled: true,
             model_path: Some("/model.gguf".to_string()),
             hf_repo: None,
             hf_file: None,
@@ -421,6 +486,7 @@ mod tests {
         let profile = Profile {
             id: "test".to_string(),
             description: None,
+            enabled: true,
             model_path: Some("/model.gguf".to_string()),
             hf_repo: None,
             hf_file: None,
@@ -449,6 +515,7 @@ mod tests {
         let profile = Profile {
             id: "test".to_string(),
             description: None,
+            enabled: true,
             model_path: Some("/model.gguf".to_string()),
             hf_repo: None,
             hf_file: None,
@@ -477,6 +544,7 @@ mod tests {
         let profile = Profile {
             id: "test".to_string(),
             description: None,
+            enabled: true,
             model_path: Some("/model.gguf".to_string()),
             hf_repo: None,
             hf_file: None,
@@ -505,6 +573,7 @@ mod tests {
         let profile = Profile {
             id: "test".to_string(),
             description: None,
+            enabled: true,
             model_path: Some("/model.gguf".to_string()),
             hf_repo: None,
             hf_file: None,
@@ -533,6 +602,7 @@ mod tests {
         let profile = Profile {
             id: "test".to_string(),
             description: None,
+            enabled: true,
             model_path: Some("/model.gguf".to_string()),
             hf_repo: None,
             hf_file: None,
@@ -560,6 +630,7 @@ mod tests {
         let profile = Profile {
             id: "test".to_string(),
             description: None,
+            enabled: true,
             model_path: Some("/model.gguf".to_string()),
             hf_repo: None,
             hf_file: None,
@@ -589,6 +660,7 @@ mod tests {
         let profile = Profile {
             id: "test".to_string(),
             description: None,
+            enabled: true,
             model_path: Some("/model.gguf".to_string()),
             hf_repo: None,
             hf_file: None,

--- a/src/router.rs
+++ b/src/router.rs
@@ -92,6 +92,9 @@ pub async fn list_models(State(state): State<Arc<NodeState>>) -> impl IntoRespon
             continue;
         }
         for profile in &model.profiles {
+            if !profile.enabled {
+                continue;
+            }
             let is_default = profile.id == "default";
             // Use bare model name for default profile, otherwise model:profile
             let id = if is_default {
@@ -1336,6 +1339,7 @@ mod tests {
         Profile {
             id: "p".into(),
             description: None,
+            enabled: true,
             model_path: Some("/tmp/model.gguf".into()),
             hf_repo: None,
             hf_file: None,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -395,6 +395,12 @@ models:
         idle_timeout_seconds: 5
         max_instances: 1
         llama_server_args: ""
+      - id: "disabled-profile"
+        enabled: false
+        model_path: "./models/mock-disabled-profile.gguf"
+        idle_timeout_seconds: 5
+        max_instances: 1
+        llama_server_args: ""
   - name: "disabled-model"
     enabled: false
     profiles:
@@ -437,9 +443,40 @@ models:
 
     // Default profiles are listed with bare model name (not "model:default")
     assert!(data.iter().any(|m| m["id"] == "enabled-model"));
+    assert!(!data
+        .iter()
+        .any(|m| m["id"] == "enabled-model:disabled-profile"));
     assert!(!data.iter().any(|m| m["id"] == "disabled-model"));
 
-    // 2. Try to invoke disabled model - should fail
+    // 2. Try to invoke disabled profile - should fail
+    let body = serde_json::json!({
+        "model": "enabled-model:disabled-profile",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "stream": false
+    });
+    let resp = client
+        .post("http://127.0.0.1:9094/v1/chat/completions")
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    // 3. Try to prewarm disabled profile - should fail
+    let body = serde_json::json!({
+        "model": "enabled-model:disabled-profile"
+    });
+    let resp = client
+        .post("http://127.0.0.1:9094/admin/prewarm")
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+    // 4. Try to invoke disabled model - should fail
     let body = serde_json::json!({
         "model": "disabled-model:default",
         "messages": [{"role": "user", "content": "Hello"}],

--- a/tests/integration_test_reload_eviction.rs
+++ b/tests/integration_test_reload_eviction.rs
@@ -114,6 +114,57 @@ models:
         llama_server_args: ""
 "#;
 
+const COOKBOOK_PROFILES_ENABLED: &str = r#"
+models:
+  - name: "mock-model"
+    enabled: true
+    profiles:
+      - id: "default"
+        model_path: "./models/mock.gguf"
+        idle_timeout_seconds: 600
+        max_instances: 1
+        llama_server_args: ""
+      - id: "alt"
+        model_path: "./models/mock-alt.gguf"
+        idle_timeout_seconds: 600
+        max_instances: 1
+        llama_server_args: "--alias mock-alt"
+  - name: "other-model"
+    enabled: true
+    profiles:
+      - id: "default"
+        model_path: "./models/other.gguf"
+        idle_timeout_seconds: 600
+        max_instances: 1
+        llama_server_args: ""
+"#;
+
+const COOKBOOK_ALT_PROFILE_DISABLED: &str = r#"
+models:
+  - name: "mock-model"
+    enabled: true
+    profiles:
+      - id: "default"
+        model_path: "./models/mock.gguf"
+        idle_timeout_seconds: 600
+        max_instances: 1
+        llama_server_args: ""
+      - id: "alt"
+        enabled: false
+        model_path: "./models/mock-alt.gguf"
+        idle_timeout_seconds: 600
+        max_instances: 1
+        llama_server_args: "--alias mock-alt"
+  - name: "other-model"
+    enabled: true
+    profiles:
+      - id: "default"
+        model_path: "./models/other.gguf"
+        idle_timeout_seconds: 600
+        max_instances: 1
+        llama_server_args: ""
+"#;
+
 /// Poll `/cluster/nodes` until `mock-model:default` is no longer present in the
 /// local node's `loaded_models`, or the deadline elapses.
 async fn wait_for_unload(client: &reqwest::Client, model_key: &str, timeout: Duration) -> bool {
@@ -135,6 +186,28 @@ async fn wait_for_unload(client: &reqwest::Client, model_key: &str, timeout: Dur
             }
         }
         sleep(Duration::from_millis(250)).await;
+    }
+    false
+}
+
+/// Poll `/v1/models` until `model_id` is absent from the listed models, or the
+/// deadline elapses. Used to synchronize with cookbook hot-reload.
+async fn wait_for_model_unlisted(
+    client: &reqwest::Client,
+    model_id: &str,
+    timeout: Duration,
+) -> bool {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        if let Ok(resp) = client.get(format!("{}/v1/models", BASE_URL)).send().await {
+            if let Ok(json) = resp.json::<serde_json::Value>().await {
+                let data = json["data"].as_array().cloned().unwrap_or_default();
+                if !data.iter().any(|m| m["id"].as_str() == Some(model_id)) {
+                    return true;
+                }
+            }
+        }
+        sleep(Duration::from_millis(100)).await;
     }
     false
 }
@@ -290,6 +363,29 @@ async fn reload_drains_orphaned_instances() {
         "mock-model:default should have been drained within 30s after args_hash change \
          (regression guard: rename-over must not silence the watcher)"
     );
+
+    // ── Case 3: disabling one profile drains only that profile while sibling
+    //     profiles stay routable. ─────────────────────────────────────────────
+    write_cookbook_rename(&cookbook_path, COOKBOOK_PROFILES_ENABLED).await;
+    assert!(
+        wait_for_model_listed(&client, "mock-model:alt", Duration::from_secs(10)).await,
+        "cookbook reload should make mock-model:alt listed within 10s"
+    );
+
+    spawn_instance_for(&client, "mock-model:alt").await;
+
+    write_cookbook_inplace(&cookbook_path, COOKBOOK_ALT_PROFILE_DISABLED).await;
+
+    assert!(
+        wait_for_model_unlisted(&client, "mock-model:alt", Duration::from_secs(10)).await,
+        "disabled profile should disappear from /v1/models within 10s"
+    );
+    assert!(
+        wait_for_unload(&client, "mock-model:alt", Duration::from_secs(30)).await,
+        "mock-model:alt should have been drained within 30s after profile disable"
+    );
+
+    spawn_instance_for(&client, "mock-model:default").await;
 
     // ── Teardown ────────────────────────────────────────────────────────────
     graceful_stop(&mut proxy_process).await;


### PR DESCRIPTION
## Summary
- add per-profile `enabled` cookbook field with default `true`
- exclude disabled profiles from model resolution, `/v1/models`, prewarm, and cluster advertisements
- drain running instances when a profile is disabled by cookbook reload
- document profile-level enablement in the README, spec, changelog, and example cookbook

Closes #17

## Validation
- `cargo fmt --check`
- `cargo check`
- `cargo test --bins --no-run`
- `cargo test --tests --no-run`
- `cargo test --bins`
- `cargo build --release --bins`
- `cargo test --test integration_test test_disabled_model -- --nocapture`
- `cargo test --test integration_test_reload_eviction reload_drains_orphaned_instances -- --nocapture`
- `cargo test -- --test-threads=1`
- deployed branch to a two-node live cluster; verified hot-disabling a profile removes it from local and cluster listings, chat/prewarm return `404`, sibling profiles remain available, and restore hot-reloads cleanly