### PR TITLE
Release v1.3.0 noise transport hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-04-24
+
+### Added
+
+- Peer forwarding now supports the Noise transport, including streamed response
+  bodies, so inter-node request routing uses the same encrypted channel as
+  cluster gossip.
+- The repository now declares Rust 1.88 as its minimum supported Rust version.
+
+### Changed
+
+- Noise identity keys now use X25519 key material with `noise25519:` public key
+  identifiers. Existing `ed25519:` known-peer entries are normalized for
+  compatibility.
+- Dependency set was refreshed to remove vulnerable or obsolete transitive
+  dependencies, including the legacy Hyper 0.14 stack.
+
+### Fixed
+
+- `/cluster/gossip` rejects plain HTTP when Noise is enabled and cluster mTLS
+  is not configured, preventing accidental unencrypted peer metadata exchange.
+- Peer circuit breakers now distinguish successful and failed peer responses,
+  including failures returned through Noise transport.
+- Request queue cancellation and timeout paths now remove abandoned waiters and
+  pending queue tokens instead of leaving stale queue state behind.
+- Auth checks now consistently protect `/v1/models`, `/metrics`, and
+  `/metrics/json` when API-key auth is enabled.
+- Release-mode port-pool tests no longer depend on ports in the kernel's
+  ephemeral range.
+- Integration tests now prefer Cargo-provided binaries instead of stale
+  `target/release` artifacts.
+
 ## [1.2.0] - 2026-04-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,15 +136,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "arc-swap"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,9 +205,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -224,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -302,28 +293,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum-server"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
-dependencies = [
- "arc-swap",
- "bytes",
- "fs-err",
- "http",
- "http-body",
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "rustls",
- "rustls-pemfile",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,12 +303,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
@@ -542,12 +505,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,26 +531,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -670,7 +607,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -743,16 +679,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "zeroize",
-]
-
-[[package]]
 name = "der-parser"
 version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -840,30 +766,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "serde",
- "sha2",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,7 +787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -899,17 +801,6 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
-name = "filetime"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
-]
 
 [[package]]
 name = "find-msvc-tools"
@@ -951,21 +842,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,16 +855,6 @@ name = "fragile"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
-
-[[package]]
-name = "fs-err"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
-dependencies = [
- "autocfg",
- "tokio",
-]
 
 [[package]]
 name = "fs_extra"
@@ -1324,22 +1190,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,11 +1207,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.3",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -1526,11 +1374,11 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.10.2"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.0",
  "inotify-sys",
  "libc",
 ]
@@ -1551,15 +1399,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -1675,10 +1514,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags 2.11.0",
  "libc",
- "plain",
- "redox_syscall 0.7.3",
 ]
 
 [[package]]
@@ -1701,11 +1537,10 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "axum",
- "axum-server",
  "base64 0.22.1",
  "bytes",
  "chrono",
@@ -1713,12 +1548,12 @@ dependencies = [
  "config",
  "dashmap",
  "dirs",
- "ed25519-dalek",
  "futures",
  "getrandom 0.2.17",
  "hex",
  "hmac",
  "hostname",
+ "http-body-util",
  "hyper",
  "hyper-util",
  "logroller",
@@ -1733,7 +1568,6 @@ dependencies = [
  "regex",
  "reqwest",
  "rustls",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1750,6 +1584,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "ulid",
+ "x25519-dalek",
  "x509-parser",
 ]
 
@@ -1881,23 +1716,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1921,12 +1739,11 @@ dependencies = [
 
 [[package]]
 name = "notify"
-version = "7.0.0"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
  "bitflags 2.11.0",
- "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -1935,16 +1752,16 @@ dependencies = [
  "mio",
  "notify-types",
  "walkdir",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "notify-types"
-version = "1.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "instant",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1953,7 +1770,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1968,9 +1785,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -2041,50 +1858,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl"
-version = "0.10.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.112"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2118,7 +1891,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -2189,28 +1962,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "polling"
@@ -2397,7 +2148,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2423,9 +2174,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -2464,15 +2215,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -2525,21 +2267,16 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2550,7 +2287,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower 0.5.3",
@@ -2647,7 +2383,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2667,15 +2403,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2687,9 +2414,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2719,42 +2446,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "semver"
@@ -2887,15 +2582,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2959,16 +2645,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3024,27 +2700,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3054,7 +2709,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3114,30 +2769,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.41"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.4"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.22"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3203,16 +2858,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -3539,12 +3184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3734,7 +3373,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3777,17 +3416,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
 
 [[package]]
 name = "windows-result"
@@ -4154,6 +3782,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "x509-parser"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4250,6 +3890,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "llamesh"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
+rust-version = "1.88"
 license = "Apache-2.0"
 
 [[bin]]
@@ -19,7 +20,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 tracing-appender = "0.2"
 logroller = "0.1"
-reqwest = { version = "0.12", features = ["json", "rustls-tls", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 clap = { version = "4", features = ["derive"] }
 ulid = "1"
 anyhow = "1"
@@ -31,23 +32,21 @@ dashmap = "5"
 chrono = "0.4"
 thiserror = "1"
 shlex = "1.3.0"
-axum-server = { version = "0.7.3", features = ["tls-rustls"] }
 rustls = "0.23.35"
 tokio-rustls = "0.26.4"
 hyper-util = { version = "0.1", features = ["tokio"] }
 hyper = { version = "1", features = ["server", "http1", "http2"] }
-rustls-pemfile = "2.2.0"
 nix = { version = "0.30.1", features = ["signal"] }
 rand = "0.9.2"
 x509-parser = "0.16"
-notify = { version = "7", features = ["macos_fsevent"] }
+notify = { version = "8", features = ["macos_fsevent"] }
 parking_lot = "0.12"
 nvml-wrapper = "0.10"
 procfs = "0.17"
 
 # Noise Protocol (inter-node encryption)
 snow = "0.9"
-ed25519-dalek = "2"
+x25519-dalek = { version = "2", features = ["static_secrets"] }
 base64 = "0.22"
 hex = "0.4"
 dirs = "5"
@@ -55,6 +54,7 @@ hmac = "0.12"
 sha2 = "0.10"
 getrandom = "0.2"
 hostname = "0.4"
+http-body-util = "0.1"
 
 # mDNS discovery
 mdns-sd = "0.11"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cd llamesh
 cargo build --release
 ```
 
-**Requirements:** Rust 1.80+, CMake, C/C++ compiler, git
+**Requirements:** Rust 1.88+, CMake, C/C++ compiler, git
 
 ### Configure
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -73,7 +73,7 @@ src/
 ├─ protocol_detect.rs — Single-port multiplexing: TLS vs HTTP vs Noise protocol detection
 ├─ noise/
 │  ├─ mod.rs          — Noise Protocol context and error types
-│  ├─ handshake.rs    — Noise_XX server-side handshake with HMAC token verification
+│  ├─ handshake.rs    — Noise_XX handshake with HMAC token verification
 │  ├─ transport.rs    — Encrypted HTTP-over-Noise request/response transport
 │  ├─ keypair.rs      — Ed25519 keypair management
 │  ├─ token.rs        — Cluster shared-secret token generation and storage
@@ -281,8 +281,8 @@ cluster:
   noise:
     tofu: false
     allowed_keys:
-      - "ed25519:xAbC123...="
-      - "ed25519:yDeF456...="
+      - "noise25519:xAbC123...="
+      - "noise25519:yDeF456...="
 ```
 
 **Hybrid (LAN + WAN):** mDNS for local, explicit peers for remote:
@@ -296,7 +296,7 @@ cluster:
   noise:
     tofu: false
     allowed_keys:
-      - "ed25519:xAbC123...="
+      - "noise25519:xAbC123...="
 ```
 
 **Secrets Location:** `~/.llama-mesh/` (mode 700)
@@ -306,7 +306,7 @@ cluster:
 
 **Environment Variable Overrides:**
 - `CLUSTER_TOKEN` - Overrides file-based token
-- `NODE_PRIVATE_KEY` - Base64-encoded Ed25519 key
+- `NODE_PRIVATE_KEY` - Base64-encoded Noise static X25519 private key
 
 `llama_cpp_ports` lets operators constrain which local TCP ports `llama-server` instances may bind to. If omitted, the proxy uses OS-assigned ephemeral ports; if provided, it will choose ports from the configured explicit `ports` list and/or one or more `ranges`, skipping any that are already in use.
 
@@ -467,7 +467,7 @@ The format is internal; stability is not guaranteed, but it must be:
 
 ### Dependencies
 
-* Rust (stable, e.g. 1.80+).
+* Rust (stable, e.g. 1.88+).
 * CMake, a C/C++ compiler, and dependencies for `llama.cpp`.
 * `git` available on PATH.
 * `llama.cpp` repo will be cloned automatically based on config, or you can pre-clone it.
@@ -771,7 +771,7 @@ For full semantics (including drain/shutdown behavior), see **Health, Readiness,
 ### Cluster / Admin
 
 * `GET /cluster/nodes` -> current view of nodes and their capacities.
-* `POST /cluster/gossip` -> internal peer gossip endpoint (used by nodes to exchange state). Reachable over both Noise-encrypted connections and plain HTTP.
+* `POST /cluster/gossip` -> internal peer gossip endpoint (used by nodes to exchange state). When Noise is enabled without cluster mTLS, plain HTTP gossip is rejected.
 * `POST /admin/prewarm` -> request pre-warming of a model/profile.
 * `POST /admin/rebuild-llama` -> trigger on-demand `llama.cpp` rebuild.
 
@@ -1116,7 +1116,7 @@ The proxy attaches a `X-Llama-Mesh-Hops` header to forwarded requests. This is i
 
 The proxy uses the Noise Protocol Framework (`Noise_XX_25519_ChaChaPoly_SHA256`) for encrypted inter-node communication:
 
-* **Zero-config encryption**: Ed25519 keys are auto-generated on first run.
+* **Zero-config encryption**: Noise static X25519 keys are auto-generated on first run.
 * **Perfect forward secrecy**: Each session uses ephemeral keys.
 * **HMAC-SHA256 cluster token**: Shared secret proves cluster membership during handshake.
 * **TOFU (Trust-On-First-Use)**: SSH-style peer trust model. New peer keys are automatically accepted on first connection.
@@ -1125,10 +1125,10 @@ The proxy uses the Noise Protocol Framework (`Noise_XX_25519_ChaChaPoly_SHA256`)
 
 Secrets are stored in `~/.llama-mesh/` with strict permissions (mode 600 for files, mode 700 for directory):
 - `cluster_token` — Auto-generated shared secret, must be copied to other nodes.
-- `node.key` — Auto-generated Ed25519 keypair, unique per node.
+- `node.key` — Auto-generated Noise static X25519 private key, unique per node.
 - `known_peers` — TOFU-managed list of trusted peer public keys.
 
-**Note:** Noise encryption is currently inbound-only (server-side handshake). Outbound gossip uses HTTP or mTLS, not Noise.
+When enabled, Noise is used for cluster gossip and peer request forwarding. mTLS remains available as the legacy fallback when Noise is disabled.
 
 **mTLS (Legacy, Deprecated)**
 
@@ -1137,7 +1137,7 @@ mTLS is still supported but deprecated in favor of Noise Protocol:
 * TLS 1.3 with mutual TLS.
 * Nodes trust a common CA.
 * Node identity is derived from certificate subject (e.g. `CN=node-a`) and strictly enforced against the sender's claimed node ID.
-* When both `noise` and `cluster_tls` are enabled, Noise is preferred for new inbound connections.
+* When both `noise` and `cluster_tls` are enabled, Noise is preferred for cluster gossip and peer request forwarding.
 
 ---
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -159,11 +159,11 @@ cluster:
     # previous_key_path: "/path/to/old-node.key"  # For key rotation
 
     # Enterprise: only accept connections from these public keys
-    # Format: "ed25519:<base64-encoded-key>"
+    # Format: "noise25519:<base64-encoded-key>"
     # If non-empty, TOFU is effectively disabled
     allowed_keys: []
-      # - "ed25519:xAbC123...="
-      # - "ed25519:yDeF456...="
+      # - "noise25519:xAbC123...="
+      # - "noise25519:yDeF456...="
 
     # Session cache TTL in seconds (default: 3600)
     session_ttl_seconds: 3600

--- a/src/api.rs
+++ b/src/api.rs
@@ -6,6 +6,8 @@ use crate::node_state::{NodeState, PeerState};
 use crate::protocol_detect::{self, DetectedProtocol};
 use crate::router;
 use crate::security::{self, PeerIdentity};
+use axum::body::Body;
+use axum::http::HeaderName;
 use axum::http::Request;
 use axum::{
     extract::State,
@@ -14,6 +16,7 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
+use http_body_util::BodyExt;
 use hyper_util::rt::TokioTimer;
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -29,10 +32,17 @@ use tower::Service;
 use tracing::{Instrument, Span};
 
 // ... [Handlers remain unchanged, skipped for brevity] ...
-async fn metrics_handler(State(state): State<Arc<NodeState>>) -> String {
+async fn metrics_handler(
+    State(state): State<Arc<NodeState>>,
+    headers: HeaderMap,
+) -> Result<String, (StatusCode, Json<serde_json::Value>)> {
+    check_auth(&state, &headers)?;
     let _ = state.calculate_resource_snapshot().await;
-    metrics::render_prometheus_with_circuit_breaker(&state.metrics, Some(&state.circuit_breaker))
-        .await
+    Ok(metrics::render_prometheus_with_circuit_breaker(
+        &state.metrics,
+        Some(&state.circuit_breaker),
+    )
+    .await)
 }
 
 async fn version_handler() -> Json<serde_json::Value> {
@@ -133,16 +143,18 @@ fn spawn_force_exit_listener() {
 
 async fn metrics_json_handler(
     State(state): State<Arc<NodeState>>,
-) -> Json<metrics::MetricsSnapshot> {
+    headers: HeaderMap,
+) -> Result<Json<metrics::MetricsSnapshot>, (StatusCode, Json<serde_json::Value>)> {
+    check_auth(&state, &headers)?;
     let _ = state.calculate_resource_snapshot().await;
     let version = state.build_manager.get_version().await;
     let build_status = state.build_manager.build_status();
-    Json(
+    Ok(Json(
         state
             .metrics
             .snapshot(state.config.node_id.clone(), version, Some(build_status))
             .await,
-    )
+    ))
 }
 
 async fn cluster_nodes_handler(
@@ -587,7 +599,7 @@ async fn handle_noise_connection(
 
     // Verify peer identity via TOFU/allowed_keys
     let peer_pubkey_display = format!(
-        "ed25519:{}",
+        "noise25519:{}",
         base64::Engine::encode(
             &base64::engine::general_purpose::STANDARD,
             session.peer_public_key()
@@ -646,66 +658,14 @@ async fn handle_noise_connection(
             "Received request over Noise"
         );
 
-        // Route based on method and path
-        let (status, status_text, response_body) =
-            match (request.method.as_str(), request.path.as_str()) {
-                ("POST", "/cluster/gossip") => {
-                    // Parse gossip message
-                    match serde_json::from_slice::<cluster::GossipMessage>(&request.body) {
-                        Ok(msg) => {
-                            // Verify peer identity matches message
-                            if msg.origin.node_id != peer_node_id {
-                                (
-                                    403,
-                                    "Forbidden",
-                                    serde_json::json!({"error": "Peer node_id mismatch"})
-                                        .to_string(),
-                                )
-                            } else {
-                                // Process the gossip message
-                                cluster::process_gossip_message(&state, msg, Some(remote_addr))
-                                    .await;
-                                (200, "OK", serde_json::json!({"status": "ok"}).to_string())
-                            }
-                        }
-                        Err(e) => {
-                            tracing::warn!(error = %e, "Failed to parse gossip message over Noise");
-                            (
-                                400,
-                                "Bad Request",
-                                serde_json::json!({"error": format!("Invalid JSON: {}", e)})
-                                    .to_string(),
-                            )
-                        }
-                    }
-                }
-                _ => {
-                    // Unknown endpoint
-                    tracing::debug!(
-                        method = %request.method,
-                        path = %request.path,
-                        "Unknown Noise endpoint"
-                    );
-                    (
-                        404,
-                        "Not Found",
-                        serde_json::json!({"error": "Endpoint not found"}).to_string(),
-                    )
-                }
-            };
+        let response = match (request.method.as_str(), request.path.as_str()) {
+            ("POST", "/cluster/gossip") => {
+                handle_noise_gossip(&state, request.body.as_ref(), &peer_node_id, remote_addr).await
+            }
+            _ => handle_noise_http_request(state.clone(), request).await,
+        };
 
-        // Send encrypted response
-        let headers = [("Content-Type", "application/json")];
-        if let Err(e) = crate::noise::transport::send_response(
-            &mut session,
-            &mut tcp_stream,
-            status,
-            status_text,
-            &headers,
-            response_body.as_bytes(),
-        )
-        .await
-        {
+        if let Err(e) = send_noise_response(&mut session, &mut tcp_stream, response).await {
             tracing::debug!(
                 remote_addr = %remote_addr,
                 error = %e,
@@ -714,6 +674,102 @@ async fn handle_noise_connection(
             break;
         }
     }
+}
+
+async fn handle_noise_gossip(
+    state: &Arc<NodeState>,
+    body: &[u8],
+    peer_node_id: &str,
+    remote_addr: SocketAddr,
+) -> axum::response::Response {
+    match serde_json::from_slice::<cluster::GossipMessage>(body) {
+        Ok(msg) => {
+            if msg.origin.node_id != peer_node_id {
+                return (
+                    StatusCode::FORBIDDEN,
+                    Json(serde_json::json!({"error": "Peer node_id mismatch"})),
+                )
+                    .into_response();
+            }
+
+            cluster::process_gossip_message(state, msg, Some(remote_addr)).await;
+            Json(serde_json::json!({"status": "ok"})).into_response()
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "Failed to parse gossip message over Noise");
+            (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": format!("Invalid JSON: {}", e)})),
+            )
+                .into_response()
+        }
+    }
+}
+
+async fn handle_noise_http_request(
+    state: Arc<NodeState>,
+    request: crate::noise::transport::NoiseRequest,
+) -> axum::response::Response {
+    let mut builder = Request::builder()
+        .method(request.method.as_str())
+        .uri(request.path.as_str());
+
+    if let Some(headers) = builder.headers_mut() {
+        for (name, value) in request.headers {
+            if let (Ok(name), Ok(value)) = (
+                HeaderName::from_bytes(name.as_bytes()),
+                axum::http::HeaderValue::from_str(&value),
+            ) {
+                headers.insert(name, value);
+            }
+        }
+    }
+
+    let req = match builder.body(Body::from(request.body)) {
+        Ok(req) => req,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": format!("Invalid request: {}", e)})),
+            )
+                .into_response()
+        }
+    };
+
+    match router::route_request(State(state), req).await {
+        Ok(resp) => resp.into_response(),
+        Err(err) => err.into_response(),
+    }
+}
+
+async fn send_noise_response(
+    session: &mut crate::noise::handshake::NoiseSession,
+    stream: &mut tokio::net::TcpStream,
+    response: axum::response::Response,
+) -> crate::noise::Result<()> {
+    let status = response.status();
+    let status_text = status.canonical_reason().unwrap_or("");
+    let (parts, mut body) = response.into_parts();
+
+    crate::noise::transport::send_response_head(
+        session,
+        stream,
+        status.as_u16(),
+        status_text,
+        &parts.headers,
+    )
+    .await?;
+
+    while let Some(frame) = body.frame().await {
+        let frame = frame.map_err(|e| crate::noise::NoiseError::Transport(e.to_string()))?;
+        if let Some(data) = frame.data_ref() {
+            if !data.is_empty() {
+                crate::noise::transport::send_body_chunk(session, stream, data).await?;
+            }
+        }
+    }
+
+    crate::noise::transport::send_body_end(session, stream).await
 }
 
 async fn wait_for_drain(state: &NodeState) {

--- a/src/bin/mock_llama_server.rs
+++ b/src/bin/mock_llama_server.rs
@@ -75,7 +75,7 @@ async fn auth_middleware(State(state): State<Arc<AppState>>, req: Request, next:
             .get("Authorization")
             .and_then(|h| h.to_str().ok());
 
-        let expected_header = format!("Bearer {}", expected_key);
+        let expected_header = format!("Bearer {expected_key}");
 
         if auth_header != Some(&expected_header) {
             return (
@@ -129,15 +129,12 @@ async fn main() {
         .with_state(state);
 
     let addr: SocketAddr = format!("{}:{}", args.host, args.port).parse().unwrap();
-    println!(
-        "Starting mock llama-server on {} with {} slots",
-        addr, num_slots
-    );
+    println!("Starting mock llama-server on {addr} with {num_slots} slots");
 
     let listener = match tokio::net::TcpListener::bind(addr).await {
         Ok(l) => l,
         Err(e) => {
-            eprintln!("Failed to bind to {}: {}", addr, e);
+            eprintln!("Failed to bind to {addr}: {e}");
             std::process::exit(1);
         }
     };
@@ -196,17 +193,16 @@ async fn metrics(State(state): State<Arc<AppState>>) -> String {
     format!(
         "# HELP llama_server_uptime_seconds Uptime of the server\n\
          # TYPE llama_server_uptime_seconds gauge\n\
-         llama_server_uptime_seconds {}\n\
+         llama_server_uptime_seconds {uptime}\n\
          # HELP llama_server_requests_total Total number of requests\n\
          # TYPE llama_server_requests_total counter\n\
-         llama_server_requests_total {}\n\
+         llama_server_requests_total {requests}\n\
          # HELP llama_server_slots_idle Number of idle slots\n\
          # TYPE llama_server_slots_idle gauge\n\
-         llama_server_slots_idle {}\n\
+         llama_server_slots_idle {idle}\n\
          # HELP llama_server_slots_processing Number of processing slots\n\
          # TYPE llama_server_slots_processing gauge\n\
-         llama_server_slots_processing {}\n",
-        uptime, requests, idle, busy
+         llama_server_slots_processing {busy}\n"
     )
 }
 

--- a/src/build_manager.rs
+++ b/src/build_manager.rs
@@ -277,7 +277,7 @@ impl BuildManager {
                     build_base.display()
                 )
             })?;
-        let build_dir_name = format!("{}-{}", base_name, commit_hash);
+        let build_dir_name = format!("{base_name}-{commit_hash}");
         let build_dir = build_base
             .parent()
             .unwrap_or(Path::new("."))
@@ -369,7 +369,7 @@ impl BuildManager {
                 return Ok(());
             }
         };
-        let prefix = format!("{}-", base_name);
+        let prefix = format!("{base_name}-");
 
         let mut entries = tokio::fs::read_dir(parent_dir).await?;
         let mut builds = Vec::new();
@@ -422,7 +422,7 @@ impl BuildManager {
                 let new_path = if existing.is_empty() {
                     lib_dir.to_string()
                 } else {
-                    format!("{}:{}", lib_dir, existing)
+                    format!("{lib_dir}:{existing}")
                 };
                 cmd.env("LD_LIBRARY_PATH", new_path);
             }
@@ -547,7 +547,7 @@ impl BuildManager {
 async fn run_command(cmd: &mut Command) -> Result<()> {
     let status = cmd.status().await?;
     if !status.success() {
-        return Err(anyhow!("Command failed: {:?}", cmd));
+        return Err(anyhow!("Command failed: {cmd:?}"));
     }
     Ok(())
 }
@@ -666,7 +666,7 @@ fi
         }
 
         if let Err(e) = &result {
-            println!("BuildManager Error: {}", e);
+            println!("BuildManager Error: {e}");
         }
         assert!(result.is_ok());
 

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -3,9 +3,10 @@ use crate::node_state::PeerState;
 use crate::security::PeerIdentity;
 use axum::{
     extract::{ConnectInfo, State},
-    http::StatusCode,
+    http::{HeaderMap, HeaderValue, StatusCode},
     Json,
 };
+use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::Semaphore;
@@ -65,7 +66,7 @@ pub async fn start_gossip_loop(state: Arc<NodeState>) {
                 let url = if addr.contains("://") {
                     addr
                 } else {
-                    format!("http://{}", addr)
+                    format!("http://{addr}")
                 };
                 targets.insert(url);
             }
@@ -100,6 +101,7 @@ pub async fn start_gossip_loop(state: Arc<NodeState>) {
             debug!("Gossiping to peer {}", peer_url);
             let url = format!("{}/cluster/gossip", peer_url.trim_end_matches('/'));
             let client = client.clone();
+            let noise_context = state.noise_context.clone();
 
             let message = GossipMessage {
                 origin: my_state.clone(),
@@ -126,20 +128,82 @@ pub async fn start_gossip_loop(state: Arc<NodeState>) {
                 .get(&peer_url)
                 .cloned()
                 .unwrap_or_else(|| peer_url.clone());
+            let expected_node_id = url_to_node_id.get(&peer_url).cloned();
             let circuit_breaker = state.circuit_breaker.clone();
 
             // Spawn each gossip request to avoid head-of-line blocking in the loop
             tokio::spawn(async move {
                 let _permit = permit; // Hold permit until task completes
-                match client.post(&url).json(&message).send().await {
-                    Ok(_) => {
-                        // Record success - resets failure count and closes circuit if half-open
-                        circuit_breaker.record_success(&cb_key).await;
+                if let Some(noise_context) = noise_context {
+                    let mut headers = HeaderMap::new();
+                    headers.insert(
+                        axum::http::header::CONTENT_TYPE,
+                        HeaderValue::from_static("application/json"),
+                    );
+                    match serde_json::to_vec(&message) {
+                        Ok(body) => {
+                            match crate::noise::transport::request(
+                                &noise_context,
+                                crate::noise::transport::OutboundNoiseRequest {
+                                    peer_base_url: &peer_url,
+                                    expected_peer_node_id: expected_node_id.as_deref(),
+                                    method: "POST",
+                                    path: "/cluster/gossip",
+                                    headers: &headers,
+                                    body: &body,
+                                    timeout_duration: Some(std::time::Duration::from_secs(10)),
+                                },
+                            )
+                            .await
+                            {
+                                Ok(resp) => {
+                                    let status = resp.head.status;
+                                    let mut body = resp.into_body_stream();
+                                    while let Some(chunk) = body.next().await {
+                                        if let Err(e) = chunk {
+                                            debug!(
+                                                "Failed to drain Noise gossip response from {}: {}",
+                                                peer_url, e
+                                            );
+                                            break;
+                                        }
+                                    }
+                                    if (200..300).contains(&status) {
+                                        circuit_breaker.record_success(&cb_key).await;
+                                    } else {
+                                        circuit_breaker.record_failure(&cb_key).await;
+                                        debug!(
+                                            "Failed to gossip to {} over Noise: HTTP {}",
+                                            peer_url, status
+                                        );
+                                    }
+                                }
+                                Err(e) => {
+                                    circuit_breaker.record_failure(&cb_key).await;
+                                    debug!("Failed to gossip to {} over Noise: {}", peer_url, e);
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            circuit_breaker.record_failure(&cb_key).await;
+                            debug!("Failed to serialize gossip for {}: {}", peer_url, e);
+                        }
                     }
-                    Err(e) => {
-                        // Record failure - circuit breaker handles escalation and logging
-                        circuit_breaker.record_failure(&cb_key).await;
-                        debug!("Failed to gossip to {}: {}", url, e);
+                } else {
+                    match client.post(&url).json(&message).send().await {
+                        Ok(resp) if resp.status().is_success() => {
+                            // Record success - resets failure count and closes circuit if half-open
+                            circuit_breaker.record_success(&cb_key).await;
+                        }
+                        Ok(resp) => {
+                            circuit_breaker.record_failure(&cb_key).await;
+                            debug!("Failed to gossip to {}: HTTP {}", url, resp.status());
+                        }
+                        Err(e) => {
+                            // Record failure - circuit breaker handles escalation and logging
+                            circuit_breaker.record_failure(&cb_key).await;
+                            debug!("Failed to gossip to {}: {}", url, e);
+                        }
                     }
                 }
             });
@@ -153,6 +217,19 @@ pub async fn handle_gossip(
     maybe_socket: Option<ConnectInfo<std::net::SocketAddr>>,
     Json(msg): Json<GossipMessage>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let cluster_tls_enabled = state
+        .config
+        .cluster_tls
+        .as_ref()
+        .map(|c| c.enabled)
+        .unwrap_or(false);
+    if state.config.cluster.noise.enabled && !cluster_tls_enabled {
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            "Noise transport required for gossip".into(),
+        ));
+    }
+
     if state
         .config
         .cluster_tls

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,8 +16,7 @@ where
     }
     shlex::split(&s).ok_or_else(|| {
         de::Error::custom(format!(
-            "Invalid shell syntax in llama_server_args: '{}'. Check for unmatched quotes.",
-            s
+            "Invalid shell syntax in llama_server_args: '{s}'. Check for unmatched quotes."
         ))
     })
 }
@@ -643,7 +642,7 @@ impl Profile {
         iter.any(|arg| {
             let normalized = arg.trim().to_ascii_lowercase();
             needles.iter().any(|needle| {
-                normalized == *needle || normalized.starts_with(&format!("{}=", needle))
+                normalized == *needle || normalized.starts_with(&format!("{needle}="))
             })
         })
     }

--- a/src/discovery/mdns.rs
+++ b/src/discovery/mdns.rs
@@ -39,7 +39,7 @@ impl MdnsDiscovery {
         // Input might be "_llama-mesh._tcp.local" or "_llama-mesh._tcp"
         let service_type = service_type.trim_end_matches('.');
         let service_type = service_type.trim_end_matches(".local");
-        let service_type = format!("{}.local.", service_type);
+        let service_type = format!("{service_type}.local.");
 
         // Get hostname and ensure it ends with .local. as required by mdns-sd
         let hostname = hostname::get()
@@ -48,9 +48,9 @@ impl MdnsDiscovery {
         let hostname = if hostname.ends_with(".local.") {
             hostname
         } else if hostname.ends_with(".local") {
-            format!("{}.", hostname)
+            format!("{hostname}.")
         } else {
-            format!("{}.local.", hostname)
+            format!("{hostname}.local.")
         };
 
         // Create service info
@@ -148,7 +148,7 @@ impl MdnsDiscovery {
                 Err(e) => {
                     // Timeout - check shutdown flag and continue
                     // Disconnected - break
-                    let err_str = format!("{:?}", e);
+                    let err_str = format!("{e:?}");
                     if err_str.contains("Disconnected") {
                         break;
                     }

--- a/src/discovery/mod.rs
+++ b/src/discovery/mod.rs
@@ -89,7 +89,7 @@ mod tests {
             cluster_addr: "10.0.0.1:9000".to_string(),
             public_key: Some("abc123".to_string()),
         };
-        let debug_str = format!("{:?}", peer);
+        let debug_str = format!("{peer:?}");
         assert!(debug_str.contains("test-node"));
         assert!(debug_str.contains("10.0.0.1:9000"));
         assert!(debug_str.contains("abc123"));
@@ -156,7 +156,7 @@ impl Discovery {
         // Add explicit peers
         for peer_addr in &config.peers {
             peers.write().insert(DiscoveredPeer {
-                node_id: format!("explicit:{}", peer_addr),
+                node_id: format!("explicit:{peer_addr}"),
                 cluster_addr: peer_addr.clone(),
                 public_key: None,
             });
@@ -201,7 +201,7 @@ impl Discovery {
     #[allow(dead_code)] // Reserved for peer management API
     pub fn add_peer(&self, addr: &str) {
         self.peers.write().insert(DiscoveredPeer {
-            node_id: format!("explicit:{}", addr),
+            node_id: format!("explicit:{addr}"),
             cluster_addr: addr.to_string(),
             public_key: None,
         });

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -272,7 +272,7 @@ impl Instance {
                 let new_path = if existing.is_empty() {
                     lib_dir.to_string()
                 } else {
-                    format!("{}:{}", lib_dir, existing)
+                    format!("{lib_dir}:{existing}")
                 };
                 cmd.env("LD_LIBRARY_PATH", new_path);
             }
@@ -406,7 +406,7 @@ impl Instance {
             // a reliable indicator of readiness for serving requests.
             let mut health_req = client.get(&health_addr);
             if let Some(ref key) = api_key {
-                health_req = health_req.header("Authorization", format!("Bearer {}", key));
+                health_req = health_req.header("Authorization", format!("Bearer {key}"));
             }
 
             match health_req.send().await {

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,13 +195,13 @@ async fn main() -> anyhow::Result<()> {
             ) {
                 Ok(w) => w,
                 Err(e) => {
-                    eprintln!("Failed to create cookbook file watcher: {}", e);
+                    eprintln!("Failed to create cookbook file watcher: {e}");
                     return;
                 }
             };
 
             if let Err(e) = watcher.watch(&watched_dir, RecursiveMode::NonRecursive) {
-                eprintln!("Failed to watch cookbook directory: {}", e);
+                eprintln!("Failed to watch cookbook directory: {e}");
                 return;
             }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -607,8 +607,7 @@ pub async fn render_prometheus_with_circuit_breaker(
         };
 
         out.push_str(&format!(
-            "proxy_hash_p95_latency_ms{{hash=\"{}\",names=\"{}\"}} {}\n",
-            escaped_hash, escaped_names, p95
+            "proxy_hash_p95_latency_ms{{hash=\"{escaped_hash}\",names=\"{escaped_names}\"}} {p95}\n"
         ));
 
         out.push_str(&format!(

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -102,7 +102,7 @@ pub struct NodeState {
     pub noise_context: Option<Arc<NoiseContext>>,
     pub metrics: Arc<Metrics>,
     pub peers: Arc<RwLock<HashMap<String, PeerState>>>,
-    pub queues: Arc<RwLock<HashMap<String, VecDeque<oneshot::Sender<u64>>>>>,
+    pub queues: Arc<RwLock<HashMap<String, VecDeque<QueueEntry>>>>,
     /// Pending tokens for waiters who have been notified but haven't acquired a slot yet.
     /// Prevents fresh requests from bypassing queued waiters during the notification-to-acquisition window.
     pub pending_tokens: Arc<RwLock<HashMap<String, HashSet<u64>>>>,
@@ -140,6 +140,11 @@ pub struct NodeState {
 }
 
 use crate::security;
+
+pub struct QueueEntry {
+    token: u64,
+    tx: oneshot::Sender<u64>,
+}
 
 /// Drop-guard that decrements a per-peer pending-forward counter. Ensures the
 /// counter is always released on cancellation, error, or normal completion.
@@ -220,9 +225,9 @@ impl NodeState {
             config.cluster.circuit_breaker.clone(),
         ));
 
-        // Initialize noise protocol if enabled (server-side only)
+        // Initialize Noise protocol if enabled for cluster communication.
         let noise_context = if config.cluster.enabled && config.cluster.noise.enabled {
-            match crate::noise::initialize(&config.cluster.noise).await {
+            match crate::noise::initialize(&config.cluster.noise, config.node_id.clone()).await {
                 Ok(ctx) => {
                     info!(
                         pubkey = %ctx.public_key_display(),
@@ -231,8 +236,8 @@ impl NodeState {
                     Some(Arc::new(ctx))
                 }
                 Err(e) => {
-                    error!(error = %e, "Failed to initialize Noise Protocol, falling back to mTLS");
-                    None
+                    error!(error = %e, "Failed to initialize Noise Protocol");
+                    return Err(e.into());
                 }
             }
         } else {
@@ -383,7 +388,7 @@ impl NodeState {
             }
 
             let reason = match self
-                .resolve_model(&format!("{}:{}", model_name, profile_id))
+                .resolve_model(&format!("{model_name}:{profile_id}"))
                 .await
             {
                 // Whole model missing, model disabled, or profile removed: model_index
@@ -501,7 +506,7 @@ impl NodeState {
 
         // Pick best candidate: prefer one with model already loaded, then lowest queue
         candidates.sort_by(|a, b| {
-            let requested_key = format!("{}:{}", base_model, profile_id).to_lowercase();
+            let requested_key = format!("{base_model}:{profile_id}").to_lowercase();
             let loaded_a = a
                 .loaded_models
                 .iter()
@@ -647,7 +652,7 @@ impl NodeState {
     // Helper to update peak memory for instances of a model (based on learned/live values)
     async fn update_peak_memory(&self, model_name: &str, profile_id: &str) {
         let instances = self.instances.read().await;
-        let display_name = format!("{}:{}", model_name, profile_id);
+        let display_name = format!("{model_name}:{profile_id}");
 
         for inst_lock in instances.values() {
             let inst = inst_lock.read().await;
@@ -1089,6 +1094,7 @@ impl NodeState {
                 // There are waiters ahead of us - join the queue instead of trying to grab slot
                 let key = format!("{}:{}", model_name, profile.id);
                 let (tx, rx) = oneshot::channel();
+                let queue_token;
 
                 {
                     // LOCK_ORDER: queues (2)
@@ -1110,7 +1116,11 @@ impl NodeState {
                         info!(event = "queue_drop", reason = "full", model = %model_name);
                         return Err(NodeError::QueueFull);
                     }
-                    queue.push_back(tx);
+                    queue_token = self.pending_token_counter.fetch_add(1, Ordering::SeqCst);
+                    queue.push_back(QueueEntry {
+                        token: queue_token,
+                        tx,
+                    });
                     // Start queue wait timer on first enqueue
                     if queue_start.is_none() {
                         queue_start = Some(std::time::Instant::now());
@@ -1130,6 +1140,9 @@ impl NodeState {
                         let elapsed = loop_start.elapsed();
                         if elapsed >= timeout {
                             info!(event = "queue_drop", reason = "timeout", model = %model_name);
+                            self.remove_queue_entry(&key, queue_token).await;
+                            self.remove_pending_token(model_name, &profile.id, queue_token)
+                                .await;
                             return Err(NodeError::QueueTimeout);
                         }
                         let remaining = timeout - elapsed;
@@ -1137,6 +1150,9 @@ impl NodeState {
                             Ok(result) => result,
                             Err(_) => {
                                 info!(event = "queue_drop", reason = "timeout", model = %model_name);
+                                self.remove_queue_entry(&key, queue_token).await;
+                                self.remove_pending_token(model_name, &profile.id, queue_token)
+                                    .await;
                                 return Err(NodeError::QueueTimeout);
                             }
                         }
@@ -1149,7 +1165,12 @@ impl NodeState {
                         my_token = Some(token);
                         continue; // Now retry with priority token
                     }
-                    Err(_) => return Err(NodeError::QueueError),
+                    Err(_) => {
+                        self.remove_queue_entry(&key, queue_token).await;
+                        self.remove_pending_token(model_name, &profile.id, queue_token)
+                            .await;
+                        return Err(NodeError::QueueError);
+                    }
                 }
             }
 
@@ -1332,6 +1353,7 @@ impl NodeState {
 
                         let key = format!("{}:{}", model_name, profile.id);
                         let (tx, rx) = oneshot::channel();
+                        let queue_token;
 
                         {
                             // LOCK_ORDER: queues (2)
@@ -1354,7 +1376,11 @@ impl NodeState {
                                 info!(event = "queue_drop", reason = "full", model = %model_name);
                                 return Err(NodeError::QueueFull);
                             }
-                            queue.push_back(tx);
+                            queue_token = self.pending_token_counter.fetch_add(1, Ordering::SeqCst);
+                            queue.push_back(QueueEntry {
+                                token: queue_token,
+                                tx,
+                            });
                             // Start queue wait timer on first enqueue
                             if queue_start.is_none() {
                                 queue_start = Some(std::time::Instant::now());
@@ -1382,6 +1408,9 @@ impl NodeState {
                                 let elapsed = loop_start.elapsed();
                                 if elapsed >= timeout {
                                     info!(event = "queue_drop", reason = "timeout", model = %model_name);
+                                    self.remove_queue_entry(&key, queue_token).await;
+                                    self.remove_pending_token(model_name, &profile.id, queue_token)
+                                        .await;
                                     return Err(NodeError::QueueTimeout);
                                 }
                                 let remaining = timeout - elapsed;
@@ -1389,6 +1418,13 @@ impl NodeState {
                                     Ok(result) => result,
                                     Err(_) => {
                                         info!(event = "queue_drop", reason = "timeout", model = %model_name);
+                                        self.remove_queue_entry(&key, queue_token).await;
+                                        self.remove_pending_token(
+                                            model_name,
+                                            &profile.id,
+                                            queue_token,
+                                        )
+                                        .await;
                                         return Err(NodeError::QueueTimeout);
                                     }
                                 }
@@ -1401,7 +1437,12 @@ impl NodeState {
                                 my_token = Some(token);
                                 continue;
                             }
-                            Err(_) => return Err(NodeError::QueueError),
+                            Err(_) => {
+                                self.remove_queue_entry(&key, queue_token).await;
+                                self.remove_pending_token(model_name, &profile.id, queue_token)
+                                    .await;
+                                return Err(NodeError::QueueError);
+                            }
                         }
                     } else {
                         // Clean up token for non-retriable errors
@@ -2035,9 +2076,9 @@ impl NodeState {
                 };
                 if addr.starts_with("0.0.0.0") {
                     let port = addr.split(':').nth(1).unwrap_or("8080");
-                    format!("{}://127.0.0.1:{}", scheme, port)
+                    format!("{scheme}://127.0.0.1:{port}")
                 } else {
-                    format!("{}://{}", scheme, addr)
+                    format!("{scheme}://{addr}")
                 }
             });
 
@@ -2144,7 +2185,7 @@ impl NodeState {
     ) -> Option<PeerState> {
         let mut candidates = Vec::new();
         let requested_profile = profile.id.clone();
-        let requested_key = format!("{}:{}", model_name, requested_profile);
+        let requested_key = format!("{model_name}:{requested_profile}");
 
         // Add self only if we can serve requests locally
         // This excludes us when: draining or binary missing
@@ -2286,7 +2327,7 @@ impl NodeState {
     /// Check if there are pending waiters (either in queue or notified-but-not-yet-acquired)
     /// for a given model:profile. Used to ensure fresh requests don't bypass queued waiters.
     async fn has_pending_waiters(&self, model_name: &str, profile_id: &str) -> bool {
-        let key = format!("{}:{}", model_name, profile_id);
+        let key = format!("{model_name}:{profile_id}");
 
         // Check queue
         {
@@ -2313,7 +2354,7 @@ impl NodeState {
 
     /// Remove a pending token after waiter successfully acquires slot or times out.
     async fn remove_pending_token(&self, model_name: &str, profile_id: &str, token: u64) {
-        let key = format!("{}:{}", model_name, profile_id);
+        let key = format!("{model_name}:{profile_id}");
         let mut pending = self.pending_tokens.write().await;
         if let Some(set) = pending.get_mut(&key) {
             if set.remove(&token) {
@@ -2322,19 +2363,40 @@ impl NodeState {
         }
     }
 
+    /// Remove a queued waiter by its preassigned token. This is used on timeout
+    /// to avoid dead queue entries consuming per-model or global queue slots.
+    async fn remove_queue_entry(&self, key: &str, token: u64) -> bool {
+        let mut queues = self.queues.write().await;
+        let mut remove_empty_queue = false;
+        let removed = if let Some(queue) = queues.get_mut(key) {
+            let before = queue.len();
+            queue.retain(|entry| entry.token != token);
+            remove_empty_queue = queue.is_empty();
+            queue.len() != before
+        } else {
+            false
+        };
+
+        if remove_empty_queue {
+            queues.remove(key);
+        }
+
+        removed
+    }
+
     /// Notify one waiter for a specific model that capacity is available.
     /// Pops waiters from the queue until one successfully receives the notification.
-    /// Dropped/closed receivers are skipped. Generates a pending token for the notified waiter.
+    /// Dropped/closed receivers are skipped. Promotes the queued token to pending
+    /// for the notified waiter.
     pub async fn notify_queue(&self, model_name: &str, profile_id: &str) {
-        let key = format!("{}:{}", model_name, profile_id);
+        let key = format!("{model_name}:{profile_id}");
         // LOCK_ORDER: queues (2) - will release before pending_tokens (3)
         let mut queues = self.queues.write().await;
         if let Some(queue) = queues.get_mut(&key) {
-            while let Some(tx) = queue.pop_front() {
-                // Generate unique token for this notification (atomic, no lock needed)
-                let token = self.pending_token_counter.fetch_add(1, Ordering::SeqCst);
+            while let Some(entry) = queue.pop_front() {
+                let token = entry.token;
 
-                if tx.send(token).is_ok() {
+                if entry.tx.send(token).is_ok() {
                     // Successfully sent - add token to pending set
                     // LOCK_ORDER: Must drop queues (2) before acquiring pending_tokens (3)
                     drop(queues);
@@ -2357,9 +2419,9 @@ impl NodeState {
         let mut tokens_to_add: Vec<(String, u64)> = Vec::new();
 
         for (key, queue) in queues.iter_mut() {
-            while let Some(tx) = queue.pop_front() {
-                let token = self.pending_token_counter.fetch_add(1, Ordering::SeqCst);
-                if tx.send(token).is_ok() {
+            while let Some(entry) = queue.pop_front() {
+                let token = entry.token;
+                if entry.tx.send(token).is_ok() {
                     tokens_to_add.push((key.clone(), token));
                     info!(event = "queue_dequeue", model_key = %key, token = token);
                     break; // Wake one waiter per model
@@ -2407,7 +2469,7 @@ impl NodeState {
 
     /// Check if the given model has pending requests (in queue or pending tokens).
     pub async fn has_pending_for_model(&self, model: &str, profile: &str) -> bool {
-        let key = format!("{}:{}", model, profile);
+        let key = format!("{model}:{profile}");
         let queues = self.queues.read().await;
         let has_queue = queues.get(&key).map(|q| !q.is_empty()).unwrap_or(false);
         if has_queue {
@@ -2669,7 +2731,7 @@ impl NodeState {
 }
 
 fn peer_supports_profile(peer: &PeerState, model_name: &str, profile_id: &str) -> bool {
-    let requested = format!("{}:{}", model_name, profile_id);
+    let requested = format!("{model_name}:{profile_id}");
     peer.supported_models.iter().any(|entry| {
         entry.eq_ignore_ascii_case(&requested)
             || (entry.eq_ignore_ascii_case(model_name) && profile_id == "default")
@@ -3110,6 +3172,56 @@ mod tests {
         assert!(result.is_some());
         let picked = result.unwrap();
         assert_eq!(picked.node_id, "remote-peer");
+    }
+
+    #[tokio::test]
+    async fn notify_queue_promotes_preassigned_queue_token() {
+        let mut config = minimal_node_config();
+        config.cluster.enabled = false;
+        let build_manager = BuildManager::new(config.llama_cpp.clone());
+        let state = NodeState::new(config, Cookbook { models: vec![] }, build_manager)
+            .await
+            .unwrap();
+
+        let key = "test:default".to_string();
+        let token = 42;
+        let (tx, rx) = oneshot::channel();
+        {
+            let mut queues = state.queues.write().await;
+            queues.insert(key.clone(), VecDeque::from([QueueEntry { token, tx }]));
+        }
+
+        state.notify_queue("test", "default").await;
+
+        assert_eq!(rx.await.unwrap(), token);
+        let queues = state.queues.read().await;
+        assert!(queues.get(&key).is_some_and(|queue| queue.is_empty()));
+        drop(queues);
+
+        let pending = state.pending_tokens.read().await;
+        assert!(pending.get(&key).is_some_and(|set| set.contains(&token)));
+    }
+
+    #[tokio::test]
+    async fn remove_queue_entry_drops_empty_queue() {
+        let mut config = minimal_node_config();
+        config.cluster.enabled = false;
+        let build_manager = BuildManager::new(config.llama_cpp.clone());
+        let state = NodeState::new(config, Cookbook { models: vec![] }, build_manager)
+            .await
+            .unwrap();
+
+        let key = "test:default".to_string();
+        let token = 43;
+        let (tx, _rx) = oneshot::channel();
+        {
+            let mut queues = state.queues.write().await;
+            queues.insert(key.clone(), VecDeque::from([QueueEntry { token, tx }]));
+        }
+
+        assert!(state.remove_queue_entry(&key, token).await);
+        let queues = state.queues.read().await;
+        assert!(!queues.contains_key(&key));
     }
 
     #[tokio::test]
@@ -3649,8 +3761,7 @@ mod tests {
         let cost = calculate_cold_start_cost(&peer, 4000, 8000);
         assert!(
             (cost - 30.0).abs() < 0.1,
-            "Expected 30 for cold start, got {}",
-            cost
+            "Expected 30 for cold start, got {cost}"
         );
     }
 
@@ -3685,8 +3796,7 @@ mod tests {
         let cost = calculate_cold_start_cost(&peer, 0, 0);
         assert!(
             (cost - 30.0).abs() < 0.1,
-            "Expected 30 for unknown memory, got {}",
-            cost
+            "Expected 30 for unknown memory, got {cost}"
         );
     }
 
@@ -3722,8 +3832,7 @@ mod tests {
         // Should be: 500 (base) + N * 200 (per instance)
         assert!(
             cost >= 500.0,
-            "Expected eviction penalty >= 500, got {}",
-            cost
+            "Expected eviction penalty >= 500, got {cost}"
         );
         assert!(cost < 10000.0, "Should not be cannot-fit penalty");
     }
@@ -3759,8 +3868,7 @@ mod tests {
         let cost = calculate_cold_start_cost(&peer, 32000, 0);
         assert!(
             (cost - 10000.0).abs() < 0.1,
-            "Expected 10000 for cannot-fit, got {}",
-            cost
+            "Expected 10000 for cannot-fit, got {cost}"
         );
     }
 
@@ -3847,9 +3955,7 @@ mod tests {
         // IDLE loaded node should still win (TPS bonus + no cold start)
         assert!(
             loaded_score < unloaded_score,
-            "Idle loaded node ({}) should score better than idle unloaded ({})",
-            loaded_score,
-            unloaded_score
+            "Idle loaded node ({loaded_score}) should score better than idle unloaded ({unloaded_score})"
         );
     }
 
@@ -3937,9 +4043,7 @@ mod tests {
         // Cold-starting on idle node is better than queuing behind busy instance
         assert!(
             unloaded_score < loaded_score,
-            "Idle unloaded node ({}) should score better than busy loaded ({})",
-            unloaded_score,
-            loaded_score
+            "Idle unloaded node ({unloaded_score}) should score better than busy loaded ({loaded_score})"
         );
     }
 
@@ -4008,9 +4112,7 @@ mod tests {
         // Idle should score better (lower)
         assert!(
             idle_score < busy_score,
-            "Idle node ({}) should score better than busy ({})",
-            idle_score,
-            busy_score
+            "Idle node ({idle_score}) should score better than busy ({busy_score})"
         );
     }
 
@@ -4077,9 +4179,7 @@ mod tests {
         // Fast should score better (lower)
         assert!(
             fast_score < slow_score,
-            "Fast node ({}) should score better than slow ({})",
-            fast_score,
-            slow_score
+            "Fast node ({fast_score}) should score better than slow ({slow_score})"
         );
     }
 
@@ -4138,9 +4238,7 @@ mod tests {
         // be strictly higher so routing will diversify to other candidates.
         assert!(
             effective_score > naive_score,
-            "pending-forward adjustment must raise score: naive={} effective={}",
-            naive_score,
-            effective_score
+            "pending-forward adjustment must raise score: naive={naive_score} effective={effective_score}"
         );
         assert!(
             (effective_score - naive_score - 250.0).abs() < 1e-6,

--- a/src/node_state/port_pool.rs
+++ b/src/node_state/port_pool.rs
@@ -19,6 +19,8 @@ pub enum PortError {
 pub struct PortPool {
     used_ports: Arc<RwLock<HashSet<u16>>>,
     ports_config: Option<LlamaCppPorts>,
+    #[cfg(test)]
+    check_os_ports: bool,
 }
 
 impl PortPool {
@@ -27,6 +29,17 @@ impl PortPool {
         Self {
             used_ports: Arc::new(RwLock::new(HashSet::new())),
             ports_config,
+            #[cfg(test)]
+            check_os_ports: true,
+        }
+    }
+
+    #[cfg(test)]
+    fn new_without_os_port_check(ports_config: Option<LlamaCppPorts>) -> Self {
+        Self {
+            used_ports: Arc::new(RwLock::new(HashSet::new())),
+            ports_config,
+            check_os_ports: false,
         }
     }
 
@@ -38,7 +51,7 @@ impl PortPool {
             // Check explicit ports first
             if let Some(explicit_ports) = &ports_config.ports {
                 for port in explicit_ports {
-                    if !used.contains(port) && Self::is_port_available(*port).await {
+                    if !used.contains(port) && self.is_port_available(*port).await {
                         used.insert(*port);
                         return Ok(*port);
                     }
@@ -48,7 +61,7 @@ impl PortPool {
             if let Some(ranges) = &ports_config.ranges {
                 for range in ranges {
                     for port in range.start..=range.end {
-                        if !used.contains(&port) && Self::is_port_available(port).await {
+                        if !used.contains(&port) && self.is_port_available(port).await {
                             used.insert(port);
                             return Ok(port);
                         }
@@ -65,7 +78,7 @@ impl PortPool {
             };
 
             for port in (start..20000).chain(10000..start) {
-                if !used.contains(&port) && Self::is_port_available(port).await {
+                if !used.contains(&port) && self.is_port_available(port).await {
                     used.insert(port);
                     return Ok(port);
                 }
@@ -83,7 +96,12 @@ impl PortPool {
     /// 1. The instance spawn will fail with "address in use"
     /// 2. try_get_or_spawn() retries with a different port
     /// 3. The port pool correctly releases failed allocations
-    async fn is_port_available(port: u16) -> bool {
+    async fn is_port_available(&self, port: u16) -> bool {
+        #[cfg(test)]
+        if !self.check_os_ports {
+            return true;
+        }
+
         tokio::net::TcpListener::bind(("127.0.0.1", port))
             .await
             .is_ok()
@@ -117,6 +135,40 @@ impl PortPool {
 mod tests {
     use super::*;
     use crate::config::PortRange;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static NEXT_TEST_PORT: AtomicUsize = AtomicUsize::new(20_000);
+
+    async fn free_test_port() -> u16 {
+        free_test_ports(1).await.remove(0)
+    }
+
+    async fn free_test_ports(count: usize) -> Vec<u16> {
+        loop {
+            let start = NEXT_TEST_PORT.fetch_add(count + 1, Ordering::SeqCst);
+            if start + count >= 32_000 {
+                panic!("exhausted low test port range");
+            }
+
+            let ports: Vec<u16> = (start..start + count).map(|port| port as u16).collect();
+            let mut listeners = Vec::with_capacity(count);
+
+            for port in &ports {
+                match tokio::net::TcpListener::bind(("127.0.0.1", *port)).await {
+                    Ok(listener) => listeners.push(listener),
+                    Err(_) => {
+                        listeners.clear();
+                        break;
+                    }
+                }
+            }
+
+            if listeners.len() == count {
+                drop(listeners);
+                return ports;
+            }
+        }
+    }
 
     #[tokio::test]
     async fn test_get_available_port_ephemeral() {
@@ -138,51 +190,43 @@ mod tests {
     #[tokio::test]
     async fn test_reserve_specific_port() {
         let pool = PortPool::new(None);
-        pool.reserve_specific_port(30000).await.unwrap();
-        assert!(pool.is_reserved(30000).await);
+        let port = free_test_port().await;
+        pool.reserve_specific_port(port).await.unwrap();
+        assert!(pool.is_reserved(port).await);
 
         // Second reservation should fail
-        let result = pool.reserve_specific_port(30000).await;
-        assert!(matches!(result, Err(PortError::PortInUse(30000))));
+        let result = pool.reserve_specific_port(port).await;
+        assert!(matches!(result, Err(PortError::PortInUse(p)) if p == port));
     }
 
     #[tokio::test]
     async fn test_configured_port_range() {
+        let port = free_test_port().await;
         let config = LlamaCppPorts {
             ports: None,
             ranges: Some(vec![PortRange {
-                start: 31000,
-                end: 31005,
+                start: port,
+                end: port,
             }]),
         };
-        let pool = PortPool::new(Some(config));
+        let pool = PortPool::new_without_os_port_check(Some(config));
 
-        let port = pool.get_available_port().await.unwrap();
-        assert!((31000..=31005).contains(&port));
+        assert_eq!(pool.get_available_port().await.unwrap(), port);
     }
 
     #[tokio::test]
     async fn test_port_exhaustion() {
+        let ports = free_test_ports(3).await;
         let config = LlamaCppPorts {
-            ports: None,
-            ranges: Some(vec![PortRange {
-                start: 32000,
-                end: 32002, // Only 3 ports
-            }]),
+            ports: Some(ports.clone()),
+            ranges: None,
         };
-        let pool = PortPool::new(Some(config));
+        let pool = PortPool::new_without_os_port_check(Some(config));
 
-        // Reserve all available ports
-        let p1 = pool.get_available_port().await.unwrap();
-        let p2 = pool.get_available_port().await.unwrap();
-        let p3 = pool.get_available_port().await.unwrap();
+        for port in &ports {
+            pool.reserve_specific_port(*port).await.unwrap();
+        }
 
-        // All ports should be different
-        assert_ne!(p1, p2);
-        assert_ne!(p2, p3);
-        assert_ne!(p1, p3);
-
-        // Next allocation should fail
         let result = pool.get_available_port().await;
         assert!(matches!(result, Err(PortError::NoAvailablePorts)));
     }
@@ -190,25 +234,26 @@ mod tests {
     #[tokio::test]
     async fn test_release_nonexistent_port() {
         let pool = PortPool::new(None);
+        let port = free_test_port().await;
         // Releasing a never-reserved port should not panic
-        pool.release_port(60000).await;
+        pool.release_port(port).await;
         // And it should still not be reserved
-        assert!(!pool.is_reserved(60000).await);
+        assert!(!pool.is_reserved(port).await);
     }
 
     #[tokio::test]
     async fn test_single_port_range() {
+        let port = free_test_port().await;
         let config = LlamaCppPorts {
             ports: None,
             ranges: Some(vec![PortRange {
-                start: 33000,
-                end: 33000, // Single port
+                start: port,
+                end: port,
             }]),
         };
-        let pool = PortPool::new(Some(config));
+        let pool = PortPool::new_without_os_port_check(Some(config));
 
-        let port = pool.get_available_port().await.unwrap();
-        assert_eq!(port, 33000);
+        assert_eq!(pool.get_available_port().await.unwrap(), port);
 
         // Second allocation should fail
         let result = pool.get_available_port().await;
@@ -217,14 +262,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_port_reuse_after_release() {
+        let port = free_test_port().await;
         let config = LlamaCppPorts {
             ports: None,
             ranges: Some(vec![PortRange {
-                start: 36000,
-                end: 36000, // Single port
+                start: port,
+                end: port,
             }]),
         };
-        let pool = PortPool::new(Some(config));
+        let pool = PortPool::new_without_os_port_check(Some(config));
 
         let port1 = pool.get_available_port().await.unwrap();
         pool.release_port(port1).await;

--- a/src/noise/handshake.rs
+++ b/src/noise/handshake.rs
@@ -1,4 +1,4 @@
-//! Noise Protocol XX handshake implementation (server-side only).
+//! Noise Protocol XX handshake implementation.
 //!
 //! Pattern: Noise_XX_25519_ChaChaPoly_SHA256
 //! - XX: Mutual authentication, both sides prove identity
@@ -6,9 +6,8 @@
 //! - ChaChaPoly: ChaCha20-Poly1305 AEAD
 //! - SHA256: Hash function
 //!
-//! This module provides server-side (responder) handshake for accepting
-//! incoming Noise connections. Client-side (initiator) code is only
-//! compiled for tests, as production cluster gossip uses HTTP/mTLS.
+//! This module provides both responder and initiator handshakes for
+//! encrypted inter-node traffic.
 //!
 //! Token verification:
 //! After handshake completes, both sides compute HMAC(token, handshake_hash)
@@ -58,7 +57,7 @@ impl NoiseSession {
         let len = self
             .transport
             .write_message(plaintext, &mut buffer)
-            .map_err(|e| NoiseError::Transport(format!("Encrypt failed: {}", e)))?;
+            .map_err(|e| NoiseError::Transport(format!("Encrypt failed: {e}")))?;
         buffer.truncate(len);
         Ok(buffer)
     }
@@ -69,7 +68,7 @@ impl NoiseSession {
         let len = self
             .transport
             .read_message(ciphertext, &mut buffer)
-            .map_err(|e| NoiseError::Transport(format!("Decrypt failed: {}", e)))?;
+            .map_err(|e| NoiseError::Transport(format!("Decrypt failed: {e}")))?;
         buffer.truncate(len);
         Ok(buffer)
     }
@@ -81,11 +80,24 @@ fn build_responder(keypair: &NodeKeypair) -> Result<snow::HandshakeState> {
     Builder::new(
         NOISE_PATTERN
             .parse()
-            .map_err(|e| NoiseError::Handshake(format!("Invalid noise pattern: {}", e)))?,
+            .map_err(|e| NoiseError::Handshake(format!("Invalid noise pattern: {e}")))?,
     )
     .local_private_key(&key_bytes)
     .build_responder()
-    .map_err(|e| NoiseError::Handshake(format!("Failed to build responder: {}", e)))
+    .map_err(|e| NoiseError::Handshake(format!("Failed to build responder: {e}")))
+}
+
+/// Build an initiator handshake state.
+fn build_initiator(keypair: &NodeKeypair) -> Result<snow::HandshakeState> {
+    let key_bytes = keypair.private_key_bytes();
+    Builder::new(
+        NOISE_PATTERN
+            .parse()
+            .map_err(|e| NoiseError::Handshake(format!("Invalid noise pattern: {e}")))?,
+    )
+    .local_private_key(&key_bytes)
+    .build_initiator()
+    .map_err(|e| NoiseError::Handshake(format!("Failed to build initiator: {e}")))
 }
 
 /// Compute token verification HMAC
@@ -124,19 +136,19 @@ pub async fn respond(
     let msg = recv_message(stream, &mut read_buf).await?;
     handshake
         .read_message(&msg, &mut buffer)
-        .map_err(|e| NoiseError::Handshake(format!("Read e failed: {}", e)))?;
+        .map_err(|e| NoiseError::Handshake(format!("Read e failed: {e}")))?;
 
     // -> e, ee, s, es
     let len = handshake
         .write_message(&[], &mut buffer)
-        .map_err(|e| NoiseError::Handshake(format!("Write e,ee,s,es failed: {}", e)))?;
+        .map_err(|e| NoiseError::Handshake(format!("Write e,ee,s,es failed: {e}")))?;
     send_message(stream, &buffer[..len]).await?;
 
     // <- s, se
     let msg = recv_message(stream, &mut read_buf).await?;
     handshake
         .read_message(&msg, &mut buffer)
-        .map_err(|e| NoiseError::Handshake(format!("Read s,se failed: {}", e)))?;
+        .map_err(|e| NoiseError::Handshake(format!("Read s,se failed: {e}")))?;
 
     // Handshake complete - get peer's static key
     let peer_public_key: [u8; 32] = handshake
@@ -151,14 +163,14 @@ pub async fn respond(
     // Convert to transport mode
     let mut transport = handshake
         .into_transport_mode()
-        .map_err(|e| NoiseError::Handshake(format!("Transport mode failed: {}", e)))?;
+        .map_err(|e| NoiseError::Handshake(format!("Transport mode failed: {e}")))?;
 
     // Receive peer's token verification first
     let msg = recv_message(stream, &mut read_buf).await?;
     let mut dec_buf = vec![0u8; msg.len()];
     let len = transport
         .read_message(&msg, &mut dec_buf)
-        .map_err(|e| NoiseError::Handshake(format!("Token recv failed: {}", e)))?;
+        .map_err(|e| NoiseError::Handshake(format!("Token recv failed: {e}")))?;
 
     if len < 32 {
         return Err(NoiseError::Handshake("Token message too short".into()));
@@ -183,13 +195,97 @@ pub async fn respond(
     let mut enc_buf = vec![0u8; payload.len() + 16];
     let len = transport
         .write_message(&payload, &mut enc_buf)
-        .map_err(|e| NoiseError::Handshake(format!("Token send failed: {}", e)))?;
+        .map_err(|e| NoiseError::Handshake(format!("Token send failed: {e}")))?;
     send_message(stream, &enc_buf[..len]).await?;
 
     tracing::debug!(
         peer_node_id = %peer_node_id,
-        peer_key = %format!("ed25519:{}", base64::engine::general_purpose::STANDARD.encode(peer_public_key)),
+        peer_key = %format!("noise25519:{}", base64::engine::general_purpose::STANDARD.encode(peer_public_key)),
         "Handshake complete (responder)"
+    );
+
+    Ok(NoiseSession {
+        transport,
+        peer_public_key,
+        peer_node_id: Some(peer_node_id),
+    })
+}
+
+/// Perform initiator (client) handshake.
+pub async fn initiate(
+    stream: &mut tokio::net::TcpStream,
+    keypair: &NodeKeypair,
+    cluster_token: &str,
+    our_node_id: &str,
+) -> Result<NoiseSession> {
+    let mut handshake = build_initiator(keypair)?;
+
+    let mut buffer = vec![0u8; HANDSHAKE_BUFFER_SIZE];
+    let mut read_buf = vec![0u8; HANDSHAKE_BUFFER_SIZE];
+
+    // -> e
+    let len = handshake
+        .write_message(&[], &mut buffer)
+        .map_err(|e| NoiseError::Handshake(format!("Write e failed: {e}")))?;
+    send_message(stream, &buffer[..len]).await?;
+
+    // <- e, ee, s, es
+    let msg = recv_message(stream, &mut read_buf).await?;
+    handshake
+        .read_message(&msg, &mut buffer)
+        .map_err(|e| NoiseError::Handshake(format!("Read e,ee,s,es failed: {e}")))?;
+
+    // -> s, se
+    let len = handshake
+        .write_message(&[], &mut buffer)
+        .map_err(|e| NoiseError::Handshake(format!("Write s,se failed: {e}")))?;
+    send_message(stream, &buffer[..len]).await?;
+
+    let peer_public_key: [u8; 32] = handshake
+        .get_remote_static()
+        .ok_or_else(|| NoiseError::Handshake("No remote static key".into()))?
+        .try_into()
+        .map_err(|_| NoiseError::Handshake("Invalid remote static key length".into()))?;
+
+    let handshake_hash = handshake.get_handshake_hash().to_vec();
+    let mut transport = handshake
+        .into_transport_mode()
+        .map_err(|e| NoiseError::Handshake(format!("Transport mode failed: {e}")))?;
+
+    let token_bytes = crate::noise::token::decode(cluster_token)?;
+    let our_hmac = compute_token_verification(&token_bytes, &handshake_hash);
+    let mut payload = our_hmac;
+    payload.extend_from_slice(our_node_id.as_bytes());
+
+    let mut enc_buf = vec![0u8; payload.len() + 16];
+    let len = transport
+        .write_message(&payload, &mut enc_buf)
+        .map_err(|e| NoiseError::Handshake(format!("Token send failed: {e}")))?;
+    send_message(stream, &enc_buf[..len]).await?;
+
+    let msg = recv_message(stream, &mut read_buf).await?;
+    let mut dec_buf = vec![0u8; msg.len()];
+    let len = transport
+        .read_message(&msg, &mut dec_buf)
+        .map_err(|e| NoiseError::Handshake(format!("Token recv failed: {e}")))?;
+
+    if len < 32 {
+        return Err(NoiseError::Handshake("Token response too short".into()));
+    }
+
+    let peer_hmac = &dec_buf[..32];
+    let expected_hmac = compute_token_verification(&token_bytes, &handshake_hash);
+
+    if !verify_token(&expected_hmac, peer_hmac) {
+        return Err(NoiseError::TokenVerificationFailed);
+    }
+
+    let peer_node_id = String::from_utf8_lossy(&dec_buf[32..len]).to_string();
+
+    tracing::debug!(
+        peer_node_id = %peer_node_id,
+        peer_key = %format!("noise25519:{}", base64::engine::general_purpose::STANDARD.encode(peer_public_key)),
+        "Handshake complete (initiator)"
     );
 
     Ok(NoiseSession {
@@ -235,13 +331,7 @@ mod tests {
     use super::*;
     use crate::noise::keypair::NodeKeypair;
     use crate::noise::token;
-    use snow::Builder;
     use tokio::net::TcpListener;
-
-    // =========================================================================
-    // Client-side (initiator) code - only needed for tests
-    // Production cluster gossip uses HTTP/mTLS for outbound communication.
-    // =========================================================================
 
     /// Test-only methods for NoiseSession
     #[cfg(test)]
@@ -250,7 +340,7 @@ mod tests {
         /// Get the peer's public key in display format (test-only)
         pub fn peer_public_key_display(&self) -> String {
             format!(
-                "ed25519:{}",
+                "noise25519:{}",
                 base64::engine::general_purpose::STANDARD.encode(self.peer_public_key)
             )
         }
@@ -260,113 +350,6 @@ mod tests {
             self.peer_node_id = Some(node_id);
         }
     }
-
-    /// Build an initiator handshake state (test-only)
-    fn build_initiator(keypair: &NodeKeypair) -> Result<snow::HandshakeState> {
-        let key_bytes = keypair.private_key_bytes();
-        Builder::new(
-            NOISE_PATTERN
-                .parse()
-                .map_err(|e| NoiseError::Handshake(format!("Invalid noise pattern: {}", e)))?,
-        )
-        .local_private_key(&key_bytes)
-        .build_initiator()
-        .map_err(|e| NoiseError::Handshake(format!("Failed to build initiator: {}", e)))
-    }
-
-    /// Perform initiator (client) handshake (test-only)
-    ///
-    /// This is the client-side handshake used to test the responder.
-    /// Production code only uses the responder (server) side.
-    async fn initiate(
-        stream: &mut tokio::net::TcpStream,
-        keypair: &NodeKeypair,
-        cluster_token: &str,
-        our_node_id: &str,
-    ) -> Result<NoiseSession> {
-        let mut handshake = build_initiator(keypair)?;
-
-        let mut buffer = vec![0u8; HANDSHAKE_BUFFER_SIZE];
-        let mut read_buf = vec![0u8; HANDSHAKE_BUFFER_SIZE];
-
-        // -> e
-        let len = handshake
-            .write_message(&[], &mut buffer)
-            .map_err(|e| NoiseError::Handshake(format!("Write e failed: {}", e)))?;
-        send_message(stream, &buffer[..len]).await?;
-
-        // <- e, ee, s, es
-        let msg = recv_message(stream, &mut read_buf).await?;
-        handshake
-            .read_message(&msg, &mut buffer)
-            .map_err(|e| NoiseError::Handshake(format!("Read e,ee,s,es failed: {}", e)))?;
-
-        // -> s, se
-        let len = handshake
-            .write_message(&[], &mut buffer)
-            .map_err(|e| NoiseError::Handshake(format!("Write s,se failed: {}", e)))?;
-        send_message(stream, &buffer[..len]).await?;
-
-        // Handshake complete - get peer's static key
-        let peer_public_key: [u8; 32] = handshake
-            .get_remote_static()
-            .ok_or_else(|| NoiseError::Handshake("No remote static key".into()))?
-            .try_into()
-            .map_err(|_| NoiseError::Handshake("Invalid remote static key length".into()))?;
-
-        // Get handshake hash for token verification
-        let handshake_hash = handshake.get_handshake_hash().to_vec();
-
-        // Convert to transport mode
-        let mut transport = handshake
-            .into_transport_mode()
-            .map_err(|e| NoiseError::Handshake(format!("Transport mode failed: {}", e)))?;
-
-        // Token verification: send HMAC(token, handshake_hash) + node_id
-        let token_bytes = crate::noise::token::decode(cluster_token)?;
-        let our_hmac = compute_token_verification(&token_bytes, &handshake_hash);
-
-        // Send: hmac (32 bytes) + node_id
-        let mut payload = our_hmac.clone();
-        payload.extend_from_slice(our_node_id.as_bytes());
-
-        let mut enc_buf = vec![0u8; payload.len() + 16];
-        let len = transport
-            .write_message(&payload, &mut enc_buf)
-            .map_err(|e| NoiseError::Handshake(format!("Token send failed: {}", e)))?;
-        send_message(stream, &enc_buf[..len]).await?;
-
-        // Receive peer's token verification
-        let msg = recv_message(stream, &mut read_buf).await?;
-        let mut dec_buf = vec![0u8; msg.len()];
-        let len = transport
-            .read_message(&msg, &mut dec_buf)
-            .map_err(|e| NoiseError::Handshake(format!("Token recv failed: {}", e)))?;
-
-        if len < 32 {
-            return Err(NoiseError::Handshake("Token response too short".into()));
-        }
-
-        let peer_hmac = &dec_buf[..32];
-        let expected_hmac = compute_token_verification(&token_bytes, &handshake_hash);
-
-        if !verify_token(&expected_hmac, peer_hmac) {
-            return Err(NoiseError::TokenVerificationFailed);
-        }
-
-        // Extract peer node_id
-        let peer_node_id = String::from_utf8_lossy(&dec_buf[32..len]).to_string();
-
-        Ok(NoiseSession {
-            transport,
-            peer_public_key,
-            peer_node_id: Some(peer_node_id),
-        })
-    }
-
-    // =========================================================================
-    // Tests
-    // =========================================================================
 
     #[test]
     fn test_token_verification() {
@@ -465,7 +448,7 @@ mod tests {
         assert_eq!(server_session.peer_node_id(), Some("client-node"));
 
         // Verify both sides got a 32-byte public key from the Noise session
-        // Note: These are X25519 keys used by Noise, not the Ed25519 identity keys
+        // Note: These are X25519 static keys used by Noise.
         assert_eq!(client_session.peer_public_key().len(), 32);
         assert_eq!(server_session.peer_public_key().len(), 32);
 

--- a/src/noise/keypair.rs
+++ b/src/noise/keypair.rs
@@ -1,4 +1,4 @@
-//! Ed25519 keypair management for node identity.
+//! Noise static key management for node identity.
 //!
 //! Keys are stored in ~/.llama-mesh/node.key with mode 600.
 //! Supports env var override via NODE_PRIVATE_KEY (base64-encoded).
@@ -6,65 +6,55 @@
 use super::permissions::{self, FILE_MODE};
 use super::{NoiseError, Result};
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
-use ed25519_dalek::{SigningKey, VerifyingKey};
 use std::fs;
 use std::path::Path;
+use x25519_dalek::{PublicKey, StaticSecret};
 
-/// Node keypair wrapper
+/// Node static key wrapper for Noise_XX_25519.
 #[derive(Clone)]
 pub struct NodeKeypair {
-    signing_key: SigningKey,
+    private_key: [u8; 32],
 }
 
 impl NodeKeypair {
-    /// Generate a new random keypair
+    /// Generate a new random static keypair.
     pub fn generate() -> Self {
-        // Generate 32 random bytes for the seed
-        let mut seed = [0u8; 32];
-        getrandom::getrandom(&mut seed).expect("Failed to generate random seed");
-        let signing_key = SigningKey::from_bytes(&seed);
-        Self { signing_key }
+        let mut private_key = [0u8; 32];
+        getrandom::getrandom(&mut private_key).expect("Failed to generate random key");
+        Self { private_key }
     }
 
-    /// Load keypair from bytes (32-byte seed)
+    /// Load keypair from raw 32-byte Noise static private key material.
     pub fn from_seed(seed: &[u8; 32]) -> Self {
-        let signing_key = SigningKey::from_bytes(seed);
-        Self { signing_key }
+        Self { private_key: *seed }
     }
 
-    /// Get the signing key (for noise handshake)
-    #[allow(dead_code)] // Reserved for future signing operations
-    pub fn signing_key(&self) -> &SigningKey {
-        &self.signing_key
-    }
-
-    /// Get the verifying (public) key
-    pub fn verifying_key(&self) -> VerifyingKey {
-        self.signing_key.verifying_key()
-    }
-
-    /// Get public key bytes
-    pub fn public_key_bytes(&self) -> [u8; 32] {
-        self.verifying_key().to_bytes()
-    }
-
-    /// Get private key seed bytes
+    /// Get private key bytes for the Noise handshake.
     pub fn private_key_bytes(&self) -> [u8; 32] {
-        self.signing_key.to_bytes()
+        self.private_key
     }
 
-    /// Get public key in display format: ed25519:base64...
+    /// Get the X25519 public key bytes used by the Noise handshake.
+    pub fn public_key_bytes(&self) -> [u8; 32] {
+        let secret = StaticSecret::from(self.private_key);
+        PublicKey::from(&secret).to_bytes()
+    }
+
+    /// Get public key in display format: noise25519:base64...
     pub fn public_key_display(&self) -> String {
-        format!("ed25519:{}", BASE64.encode(self.public_key_bytes()))
+        format!("noise25519:{}", BASE64.encode(self.public_key_bytes()))
     }
 
     /// Parse a public key from display format
     #[allow(dead_code)] // Used in tests, reserved for key management CLI
     pub fn parse_public_key(s: &str) -> Result<[u8; 32]> {
-        let s = s.strip_prefix("ed25519:").unwrap_or(s);
+        let s = s
+            .strip_prefix("noise25519:")
+            .or_else(|| s.strip_prefix("ed25519:"))
+            .unwrap_or(s);
         let bytes = BASE64
             .decode(s)
-            .map_err(|e| NoiseError::KeyFile(format!("Invalid base64: {}", e)))?;
+            .map_err(|e| NoiseError::KeyFile(format!("Invalid base64: {e}")))?;
         bytes
             .try_into()
             .map_err(|_| NoiseError::KeyFile("Public key must be 32 bytes".into()))
@@ -91,13 +81,13 @@ impl NodeKeypair {
         let encoded = fs::read_to_string(path)?;
         let bytes = BASE64
             .decode(encoded.trim())
-            .map_err(|e| NoiseError::KeyFile(format!("Invalid base64 in key file: {}", e)))?;
+            .map_err(|e| NoiseError::KeyFile(format!("Invalid base64 in key file: {e}")))?;
 
-        let seed: [u8; 32] = bytes
+        let private_key: [u8; 32] = bytes
             .try_into()
             .map_err(|_| NoiseError::KeyFile("Key file must contain 32 bytes".into()))?;
 
-        Ok(Self::from_seed(&seed))
+        Ok(Self::from_seed(&private_key))
     }
 }
 
@@ -111,12 +101,12 @@ pub fn get_or_create(
     if let Ok(env_key) = std::env::var("NODE_PRIVATE_KEY") {
         let bytes = BASE64
             .decode(env_key.trim())
-            .map_err(|e| NoiseError::KeyFile(format!("Invalid NODE_PRIVATE_KEY env var: {}", e)))?;
-        let seed: [u8; 32] = bytes
+            .map_err(|e| NoiseError::KeyFile(format!("Invalid NODE_PRIVATE_KEY env var: {e}")))?;
+        let private_key: [u8; 32] = bytes
             .try_into()
             .map_err(|_| NoiseError::KeyFile("NODE_PRIVATE_KEY must be 32 bytes base64".into()))?;
         tracing::info!("Using node keypair from NODE_PRIVATE_KEY env var");
-        return Ok(NodeKeypair::from_seed(&seed));
+        return Ok(NodeKeypair::from_seed(&private_key));
     }
 
     let key_path = config.effective_private_key_path(config_dir);
@@ -207,7 +197,7 @@ mod tests {
         let keypair = NodeKeypair::generate();
         // Get the base64 part without prefix
         let display = keypair.public_key_display();
-        let base64_only = display.strip_prefix("ed25519:").unwrap();
+        let base64_only = display.strip_prefix("noise25519:").unwrap();
 
         // Should still parse correctly
         let parsed = NodeKeypair::parse_public_key(base64_only).unwrap();
@@ -223,8 +213,16 @@ mod tests {
     #[test]
     fn test_parse_public_key_wrong_length() {
         // Valid base64 but wrong length (only 16 bytes)
-        let result = NodeKeypair::parse_public_key("ed25519:AAAAAAAAAAAAAAAAAAAAAA==");
+        let result = NodeKeypair::parse_public_key("noise25519:AAAAAAAAAAAAAAAAAAAAAA==");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_public_key_legacy_ed25519_prefix() {
+        let keypair = NodeKeypair::generate();
+        let legacy = format!("ed25519:{}", BASE64.encode(keypair.public_key_bytes()));
+        let parsed = NodeKeypair::parse_public_key(&legacy).unwrap();
+        assert_eq!(keypair.public_key_bytes(), parsed);
     }
 
     #[test]

--- a/src/noise/known_peers.rs
+++ b/src/noise/known_peers.rs
@@ -3,7 +3,7 @@
 //! File format (~/.llama-mesh/known_peers):
 //! ```text
 //! # node_id pubkey first_seen
-//! node-b ed25519:xAbC123...= 2024-01-15T10:30:00Z
+//! node-b noise25519:xAbC123...= 2024-01-15T10:30:00Z
 //! ```
 
 use super::permissions::{self, FILE_MODE};
@@ -123,11 +123,24 @@ impl KnownPeers {
         tofu_enabled: bool,
         allowed_keys: &[String],
     ) -> TrustDecision {
+        let presented = normalize_public_key(public_key);
+
+        // Explicit pinning is authoritative. A peer that was previously
+        // accepted by TOFU must still be rejected if it is not now pinned.
+        if !allowed_keys.is_empty() {
+            let allowed = allowed_keys
+                .iter()
+                .any(|key| normalize_public_key(key) == presented);
+            if !allowed {
+                return TrustDecision::Rejected;
+            }
+        }
+
         let peers = self.peers.read();
 
         // Check if peer is already known
         if let Some(known) = peers.get(node_id) {
-            if known.public_key == public_key {
+            if normalize_public_key(&known.public_key) == presented {
                 return TrustDecision::Trusted;
             } else {
                 return TrustDecision::KeyMismatch {
@@ -136,13 +149,8 @@ impl KnownPeers {
             }
         }
 
-        // Peer is new - check allowed_keys first (enterprise mode)
         if !allowed_keys.is_empty() {
-            if allowed_keys.iter().any(|k| k == public_key) {
-                return TrustDecision::TofuAccepted; // Allowed by pinning
-            } else {
-                return TrustDecision::Rejected;
-            }
+            return TrustDecision::TofuAccepted; // Allowed by pinning
         }
 
         // No allowed_keys - use TOFU
@@ -205,6 +213,14 @@ impl KnownPeers {
     }
 }
 
+fn normalize_public_key(key: &str) -> String {
+    if let Some(value) = key.strip_prefix("ed25519:") {
+        format!("noise25519:{value}")
+    } else {
+        key.to_string()
+    }
+}
+
 /// Verify a peer and handle trust decision
 pub fn verify_peer(
     known_peers: &KnownPeers,
@@ -258,49 +274,69 @@ mod tests {
     #[test]
     fn test_new_peer_tofu_enabled() {
         let (_dir, kp) = setup();
-        let decision = kp.check_peer("node-b", "ed25519:abc123", true, &[]);
+        let decision = kp.check_peer("node-b", "noise25519:abc123", true, &[]);
         assert_eq!(decision, TrustDecision::TofuAccepted);
     }
 
     #[test]
     fn test_new_peer_tofu_disabled() {
         let (_dir, kp) = setup();
-        let decision = kp.check_peer("node-b", "ed25519:abc123", false, &[]);
+        let decision = kp.check_peer("node-b", "noise25519:abc123", false, &[]);
         assert_eq!(decision, TrustDecision::Rejected);
     }
 
     #[test]
     fn test_known_peer_trusted() {
         let (_dir, kp) = setup();
-        kp.add_peer("node-b", "ed25519:abc123").unwrap();
+        kp.add_peer("node-b", "noise25519:abc123").unwrap();
 
-        let decision = kp.check_peer("node-b", "ed25519:abc123", true, &[]);
+        let decision = kp.check_peer("node-b", "noise25519:abc123", true, &[]);
         assert_eq!(decision, TrustDecision::Trusted);
     }
 
     #[test]
     fn test_key_mismatch() {
         let (_dir, kp) = setup();
-        kp.add_peer("node-b", "ed25519:abc123").unwrap();
+        kp.add_peer("node-b", "noise25519:abc123").unwrap();
 
-        let decision = kp.check_peer("node-b", "ed25519:different", true, &[]);
+        let decision = kp.check_peer("node-b", "noise25519:different", true, &[]);
         assert!(matches!(decision, TrustDecision::KeyMismatch { .. }));
     }
 
     #[test]
     fn test_allowed_keys_accepts() {
         let (_dir, kp) = setup();
-        let allowed = vec!["ed25519:abc123".to_string()];
-        let decision = kp.check_peer("node-b", "ed25519:abc123", false, &allowed);
+        let allowed = vec!["noise25519:abc123".to_string()];
+        let decision = kp.check_peer("node-b", "noise25519:abc123", false, &allowed);
         assert_eq!(decision, TrustDecision::TofuAccepted);
     }
 
     #[test]
     fn test_allowed_keys_rejects() {
         let (_dir, kp) = setup();
-        let allowed = vec!["ed25519:other".to_string()];
-        let decision = kp.check_peer("node-b", "ed25519:abc123", false, &allowed);
+        let allowed = vec!["noise25519:other".to_string()];
+        let decision = kp.check_peer("node-b", "noise25519:abc123", false, &allowed);
         assert_eq!(decision, TrustDecision::Rejected);
+    }
+
+    #[test]
+    fn test_allowed_keys_override_existing_tofu_peer() {
+        let (_dir, kp) = setup();
+        kp.add_peer("node-b", "noise25519:abc123").unwrap();
+
+        let allowed = vec!["noise25519:other".to_string()];
+        let decision = kp.check_peer("node-b", "noise25519:abc123", true, &allowed);
+        assert_eq!(decision, TrustDecision::Rejected);
+    }
+
+    #[test]
+    fn test_legacy_ed25519_prefix_matches_noise25519_key() {
+        let (_dir, kp) = setup();
+        kp.add_peer("node-b", "ed25519:abc123").unwrap();
+
+        let allowed = vec!["noise25519:abc123".to_string()];
+        let decision = kp.check_peer("node-b", "noise25519:abc123", false, &allowed);
+        assert_eq!(decision, TrustDecision::Trusted);
     }
 
     #[test]
@@ -311,14 +347,14 @@ mod tests {
         // Add peer
         {
             let kp = KnownPeers::load_or_create(&path).unwrap();
-            kp.add_peer("node-b", "ed25519:abc123").unwrap();
+            kp.add_peer("node-b", "noise25519:abc123").unwrap();
         }
 
         // Reload and verify
         {
             let kp = KnownPeers::load_or_create(&path).unwrap();
             let peer = kp.get("node-b").unwrap();
-            assert_eq!(peer.public_key, "ed25519:abc123");
+            assert_eq!(peer.public_key, "noise25519:abc123");
         }
     }
 }

--- a/src/noise/mod.rs
+++ b/src/noise/mod.rs
@@ -1,10 +1,9 @@
 //! Noise Protocol implementation for secure inter-node communication.
 //!
-//! Server-side (responding to incoming Noise connections) is fully integrated.
-//! Cluster gossip uses HTTP/mTLS for outbound communication.
+//! Cluster gossip and peer forwarding use encrypted Noise transport when enabled.
 //!
 //! Uses Noise_XX_25519_ChaChaPoly_SHA256 for:
-//! - Mutual authentication via Ed25519 keypairs
+//! - Mutual authentication via Noise static X25519 keys
 //! - Perfect forward secrecy
 //! - Zero-config encryption (auto-generated keys)
 //!
@@ -80,7 +79,10 @@ pub fn default_config_dir() -> std::path::PathBuf {
 
 /// Initialize the noise subsystem.
 /// Creates config directory and generates keys/token if needed.
-pub async fn initialize(config: &crate::config::ClusterNoiseConfig) -> Result<NoiseContext> {
+pub async fn initialize(
+    config: &crate::config::ClusterNoiseConfig,
+    node_id: String,
+) -> Result<NoiseContext> {
     let config_dir = config.effective_config_dir();
 
     // Ensure config directory exists with correct permissions
@@ -101,6 +103,7 @@ pub async fn initialize(config: &crate::config::ClusterNoiseConfig) -> Result<No
         cluster_token,
         known_peers,
         config: config.clone(),
+        node_id,
     })
 }
 
@@ -111,10 +114,11 @@ pub struct NoiseContext {
     pub cluster_token: String,
     pub known_peers: known_peers::KnownPeers,
     pub config: crate::config::ClusterNoiseConfig,
+    pub node_id: String,
 }
 
 impl NoiseContext {
-    /// Get our public key in display format (ed25519:base64...)
+    /// Get our public key in display format (noise25519:base64...)
     pub fn public_key_display(&self) -> String {
         self.keypair.public_key_display()
     }
@@ -138,7 +142,7 @@ mod tests {
             actual: 0o644,
             expected: 0o600,
         };
-        let msg = format!("{}", err);
+        let msg = format!("{err}");
         assert!(msg.contains("Permission denied"));
         assert!(msg.contains("/some/path"));
     }
@@ -150,7 +154,7 @@ mod tests {
             presented: "key-a".into(),
             known: "key-b".into(),
         };
-        let msg = format!("{}", err);
+        let msg = format!("{err}");
         assert!(msg.contains("node-1"));
         assert!(msg.contains("key-a"));
         assert!(msg.contains("key-b"));
@@ -159,7 +163,7 @@ mod tests {
     #[test]
     fn test_noise_error_display_token_verification() {
         let err = NoiseError::TokenVerificationFailed;
-        let msg = format!("{}", err);
+        let msg = format!("{err}");
         assert!(msg.contains("Token verification failed"));
     }
 
@@ -169,7 +173,7 @@ mod tests {
             node_id: "bad-node".into(),
             key: "bad-key".into(),
         };
-        let msg = format!("{}", err);
+        let msg = format!("{err}");
         assert!(msg.contains("bad-node"));
         assert!(msg.contains("not in allowed_keys"));
     }

--- a/src/noise/token.rs
+++ b/src/noise/token.rs
@@ -47,7 +47,7 @@ pub fn load(path: &Path) -> Result<String> {
     // Validate base64
     BASE64
         .decode(&token)
-        .map_err(|e| NoiseError::Token(format!("Invalid token format: {}", e)))?;
+        .map_err(|e| NoiseError::Token(format!("Invalid token format: {e}")))?;
 
     Ok(token)
 }
@@ -62,7 +62,7 @@ pub fn get_or_create(config_dir: &Path) -> Result<String> {
             // Validate
             BASE64
                 .decode(&token)
-                .map_err(|e| NoiseError::Token(format!("Invalid CLUSTER_TOKEN env var: {}", e)))?;
+                .map_err(|e| NoiseError::Token(format!("Invalid CLUSTER_TOKEN env var: {e}")))?;
             tracing::info!("Using cluster token from CLUSTER_TOKEN env var");
             return Ok(token);
         }
@@ -92,7 +92,7 @@ pub fn get_or_create(config_dir: &Path) -> Result<String> {
 pub fn decode(token: &str) -> Result<Vec<u8>> {
     BASE64
         .decode(token)
-        .map_err(|e| NoiseError::Token(format!("Invalid token: {}", e)))
+        .map_err(|e| NoiseError::Token(format!("Invalid token: {e}")))
 }
 
 #[cfg(test)]

--- a/src/noise/transport.rs
+++ b/src/noise/transport.rs
@@ -1,12 +1,19 @@
 //! Noise-encrypted transport layer for cluster communication.
 //!
-//! Provides server-side functions for handling incoming Noise connections:
-//! - recv_request, send_response for HTTP-over-Noise
+//! Provides helpers for handling HTTP-over-Noise:
+//! - recv_request, send_request, send_response_head for request/response transport
 //! - recv_data, send_data for raw encrypted transport
 
 use super::handshake::NoiseSession;
 use super::{NoiseError, Result};
+use crate::noise::NoiseContext;
+use axum::http::HeaderMap;
 use bytes::Bytes;
+use futures::Stream;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 
@@ -15,6 +22,9 @@ const MAX_FRAME_SIZE: usize = 65535 - 16; // Leave room for AEAD tag
 
 /// Maximum total message size (64 MiB) to prevent OOM from malicious peers
 const MAX_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
+
+type NoiseBodyReadFuture =
+    Pin<Box<dyn Future<Output = Result<(NoiseSession, TcpStream, Vec<u8>)>> + Send>>;
 
 // ============================================================================
 // Server-side helpers for handling incoming Noise connections
@@ -25,9 +35,58 @@ const MAX_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
 pub struct NoiseRequest {
     pub method: String,
     pub path: String,
-    #[allow(dead_code)] // Parsed but not yet used
     pub headers: Vec<(String, String)>,
     pub body: Bytes,
+}
+
+/// Parsed HTTP response head from noise transport.
+#[derive(Debug)]
+pub struct NoiseResponseHead {
+    pub status: u16,
+    pub headers: Vec<(String, String)>,
+    pub first_body: Bytes,
+}
+
+/// Streaming response body received over Noise.
+pub struct NoiseBodyStream {
+    session: Option<NoiseSession>,
+    stream: Option<TcpStream>,
+    first_body: Option<Bytes>,
+    pending: Option<NoiseBodyReadFuture>,
+    done: bool,
+}
+
+/// Client-side response over Noise.
+pub struct NoiseHttpResponse {
+    pub head: NoiseResponseHead,
+    session: NoiseSession,
+    stream: TcpStream,
+}
+
+impl NoiseHttpResponse {
+    pub fn into_body_stream(self) -> NoiseBodyStream {
+        NoiseBodyStream {
+            session: Some(self.session),
+            stream: Some(self.stream),
+            first_body: if self.head.first_body.is_empty() {
+                None
+            } else {
+                Some(self.head.first_body)
+            },
+            pending: None,
+            done: false,
+        }
+    }
+}
+
+pub struct OutboundNoiseRequest<'a> {
+    pub peer_base_url: &'a str,
+    pub expected_peer_node_id: Option<&'a str>,
+    pub method: &'a str,
+    pub path: &'a str,
+    pub headers: &'a HeaderMap,
+    pub body: &'a [u8],
+    pub timeout_duration: Option<Duration>,
 }
 
 /// Receive an encrypted HTTP request from a noise connection (server-side)
@@ -39,27 +98,144 @@ pub async fn recv_request(
     parse_http_request(&data)
 }
 
-/// Send an encrypted HTTP response over a noise connection (server-side)
-pub async fn send_response(
+/// Send an encrypted HTTP request over an already-handshaken Noise connection.
+pub async fn send_request(
+    session: &mut NoiseSession,
+    stream: &mut TcpStream,
+    method: &str,
+    path: &str,
+    headers: &HeaderMap,
+    body: &[u8],
+) -> Result<()> {
+    let mut request = format!("{method} {path} HTTP/1.1\r\n");
+    for (name, value) in headers {
+        if let Ok(value) = value.to_str() {
+            request.push_str(name.as_str());
+            request.push_str(": ");
+            request.push_str(value);
+            request.push_str("\r\n");
+        }
+    }
+    request.push_str(&format!("Content-Length: {}\r\n", body.len()));
+    request.push_str("\r\n");
+
+    let mut payload = request.into_bytes();
+    payload.extend_from_slice(body);
+    send_data(session, stream, &payload).await
+}
+
+/// Open a Noise connection, send one HTTP request, and read the response head.
+pub async fn request(
+    context: &NoiseContext,
+    request: OutboundNoiseRequest<'_>,
+) -> Result<NoiseHttpResponse> {
+    let fut = async {
+        let connect_addr = connect_addr_from_url(request.peer_base_url)?;
+        let mut stream = TcpStream::connect(connect_addr).await?;
+        let mut session = crate::noise::handshake::initiate(
+            &mut stream,
+            &context.keypair,
+            &context.cluster_token,
+            &context.node_id,
+        )
+        .await?;
+
+        let peer_node_id = session.peer_node_id().unwrap_or("unknown");
+        if let Some(expected_peer_node_id) = request.expected_peer_node_id {
+            if peer_node_id != expected_peer_node_id {
+                return Err(NoiseError::Transport(format!(
+                    "Peer node_id mismatch: expected {expected_peer_node_id}, got {peer_node_id}"
+                )));
+            }
+        }
+
+        let peer_public_key = format!(
+            "noise25519:{}",
+            base64::Engine::encode(
+                &base64::engine::general_purpose::STANDARD,
+                session.peer_public_key()
+            )
+        );
+        crate::noise::known_peers::verify_peer(
+            &context.known_peers,
+            peer_node_id,
+            &peer_public_key,
+            &context.config,
+        )?;
+
+        send_request(
+            &mut session,
+            &mut stream,
+            request.method,
+            request.path,
+            request.headers,
+            request.body,
+        )
+        .await?;
+        let head = recv_response_head(&mut session, &mut stream).await?;
+
+        Ok(NoiseHttpResponse {
+            head,
+            session,
+            stream,
+        })
+    };
+
+    match request.timeout_duration {
+        Some(duration) => tokio::time::timeout(duration, fut)
+            .await
+            .map_err(|_| NoiseError::Transport("Noise request timed out".into()))?,
+        None => fut.await,
+    }
+}
+
+/// Send only an encrypted HTTP response head.
+pub async fn send_response_head(
     session: &mut NoiseSession,
     stream: &mut TcpStream,
     status: u16,
     status_text: &str,
-    headers: &[(&str, &str)],
+    headers: &HeaderMap,
+) -> Result<()> {
+    let mut response = format!("HTTP/1.1 {status} {status_text}\r\n");
+    for (name, value) in headers {
+        if name.as_str().eq_ignore_ascii_case("content-length")
+            || name.as_str().eq_ignore_ascii_case("transfer-encoding")
+        {
+            continue;
+        }
+        if let Ok(value) = value.to_str() {
+            response.push_str(name.as_str());
+            response.push_str(": ");
+            response.push_str(value);
+            response.push_str("\r\n");
+        }
+    }
+    response.push_str("\r\n");
+    send_data(session, stream, response.as_bytes()).await
+}
+
+/// Send an encrypted body chunk as one Noise message.
+pub async fn send_body_chunk(
+    session: &mut NoiseSession,
+    stream: &mut TcpStream,
     body: &[u8],
 ) -> Result<()> {
-    // Build HTTP response
-    let mut response = format!("HTTP/1.1 {} {}\r\n", status, status_text);
-    for (name, value) in headers {
-        response.push_str(&format!("{}: {}\r\n", name, value));
-    }
-    response.push_str(&format!("Content-Length: {}\r\n", body.len()));
-    response.push_str("\r\n");
+    send_data(session, stream, body).await
+}
 
-    let mut payload = response.into_bytes();
-    payload.extend_from_slice(body);
+/// Send an encrypted end-of-body marker.
+pub async fn send_body_end(session: &mut NoiseSession, stream: &mut TcpStream) -> Result<()> {
+    send_data(session, stream, &[]).await
+}
 
-    send_data(session, stream, &payload).await
+/// Receive an encrypted HTTP response head.
+pub async fn recv_response_head(
+    session: &mut NoiseSession,
+    stream: &mut TcpStream,
+) -> Result<NoiseResponseHead> {
+    let data = recv_data(session, stream).await?;
+    parse_http_response_head(&data)
 }
 
 /// Low-level: receive encrypted data with length prefix
@@ -159,6 +335,106 @@ fn parse_http_request(data: &[u8]) -> Result<NoiseRequest> {
     })
 }
 
+fn parse_http_response_head(data: &[u8]) -> Result<NoiseResponseHead> {
+    let data_str = String::from_utf8_lossy(data);
+    let header_end = data_str
+        .find("\r\n\r\n")
+        .ok_or_else(|| NoiseError::Transport("Invalid HTTP response: no header boundary".into()))?;
+
+    let header_part = &data_str[..header_end];
+    let body_start = header_end + 4;
+    let mut lines = header_part.lines();
+    let status_line = lines
+        .next()
+        .ok_or_else(|| NoiseError::Transport("No status line".into()))?;
+
+    let mut parts = status_line.splitn(3, ' ');
+    let _version = parts
+        .next()
+        .ok_or_else(|| NoiseError::Transport("Invalid status line".into()))?;
+    let status = parts
+        .next()
+        .ok_or_else(|| NoiseError::Transport("Invalid status line".into()))?
+        .parse::<u16>()
+        .map_err(|_| NoiseError::Transport("Invalid HTTP status".into()))?;
+    let _status_text = parts.next().unwrap_or("");
+
+    let mut headers = Vec::new();
+    for line in lines {
+        if let Some((name, value)) = line.split_once(':') {
+            headers.push((name.trim().to_string(), value.trim().to_string()));
+        }
+    }
+
+    Ok(NoiseResponseHead {
+        status,
+        headers,
+        first_body: Bytes::copy_from_slice(data.get(body_start..).unwrap_or(&[])),
+    })
+}
+
+fn connect_addr_from_url(peer_base_url: &str) -> Result<(String, u16)> {
+    let url_text = if peer_base_url.contains("://") {
+        peer_base_url.to_string()
+    } else {
+        format!("http://{peer_base_url}")
+    };
+    let url = reqwest::Url::parse(&url_text)
+        .map_err(|e| NoiseError::Transport(format!("Invalid peer URL: {e}")))?;
+    let host = url
+        .host_str()
+        .ok_or_else(|| NoiseError::Transport("Peer URL missing host".into()))?
+        .to_string();
+    let port = url
+        .port_or_known_default()
+        .ok_or_else(|| NoiseError::Transport("Peer URL missing port".into()))?;
+    Ok((host, port))
+}
+
+impl Stream for NoiseBodyStream {
+    type Item = Result<Bytes>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.done {
+            return Poll::Ready(None);
+        }
+
+        if let Some(bytes) = self.first_body.take() {
+            return Poll::Ready(Some(Ok(bytes)));
+        }
+
+        if self.pending.is_none() {
+            let mut session = self.session.take().expect("noise session missing");
+            let mut stream = self.stream.take().expect("noise stream missing");
+            self.pending = Some(Box::pin(async move {
+                let bytes = recv_data(&mut session, &mut stream).await?;
+                Ok((session, stream, bytes))
+            }));
+        }
+
+        let pending = self.pending.as_mut().expect("pending future missing");
+        match pending.as_mut().poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Ok((session, stream, bytes))) => {
+                self.pending = None;
+                self.session = Some(session);
+                self.stream = Some(stream);
+                if bytes.is_empty() {
+                    self.done = true;
+                    Poll::Ready(None)
+                } else {
+                    Poll::Ready(Some(Ok(Bytes::from(bytes))))
+                }
+            }
+            Poll::Ready(Err(e)) => {
+                self.pending = None;
+                self.done = true;
+                Poll::Ready(Some(Err(e)))
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -218,7 +494,7 @@ mod tests {
             headers: vec![],
             body: Bytes::new(),
         };
-        let debug_str = format!("{:?}", request);
+        let debug_str = format!("{request:?}");
         assert!(debug_str.contains("GET"));
         assert!(debug_str.contains("/test"));
     }

--- a/src/router.rs
+++ b/src/router.rs
@@ -5,12 +5,12 @@ use crate::node_state::{NodeError, NodeState};
 use axum::{
     body::Body,
     extract::State,
-    http::{header::RETRY_AFTER, HeaderValue, Request, Response, StatusCode},
+    http::{header::RETRY_AFTER, HeaderMap, HeaderValue, Method, Request, Response, StatusCode},
     response::IntoResponse,
     response::Json,
 };
 use bytes::Bytes;
-use futures::{future::BoxFuture, Stream};
+use futures::{future::BoxFuture, Stream, StreamExt, TryStreamExt};
 use serde_json::{json, Value};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
@@ -77,7 +77,153 @@ impl Drop for RequestGuard {
     }
 }
 
-pub async fn list_models(State(state): State<Arc<NodeState>>) -> impl IntoResponse {
+enum PeerResponse {
+    Http(reqwest::Response),
+    Noise {
+        status: StatusCode,
+        headers: HeaderMap,
+        body: Box<crate::noise::transport::NoiseBodyStream>,
+    },
+}
+
+struct PeerRequest<'a> {
+    peer_id: &'a str,
+    peer_address: &'a str,
+    method: Method,
+    path_and_query: &'a str,
+    headers: HeaderMap,
+    body: Bytes,
+    timeout_ms: u64,
+}
+
+fn peer_status_is_failure(status: StatusCode) -> bool {
+    status.is_server_error()
+        || status == StatusCode::UNAUTHORIZED
+        || status == StatusCode::FORBIDDEN
+}
+
+async fn record_peer_status(state: &NodeState, peer_id: &str, status: StatusCode) {
+    if peer_status_is_failure(status) {
+        state.circuit_breaker.record_failure(peer_id).await;
+    } else {
+        state.circuit_breaker.record_success(peer_id).await;
+    }
+}
+
+fn build_forward_headers(source: &HeaderMap, current_hops: usize, request_id: &str) -> HeaderMap {
+    let mut forward_headers = HeaderMap::new();
+    for (name, value) in source.iter() {
+        let name_lower = name.as_str().to_lowercase();
+        if matches!(
+            name_lower.as_str(),
+            "host"
+                | "content-length"
+                | "transfer-encoding"
+                | "connection"
+                | "keep-alive"
+                | "proxy-authenticate"
+                | "proxy-authorization"
+                | "te"
+                | "trailer"
+                | "upgrade"
+        ) {
+            continue;
+        }
+        forward_headers.insert(name.clone(), value.clone());
+    }
+    forward_headers.insert(
+        axum::http::header::HeaderName::from_static("x-llama-mesh-hops"),
+        HeaderValue::from_str(&(current_hops + 1).to_string())
+            .unwrap_or_else(|_| HeaderValue::from_static("1")),
+    );
+    if let Ok(value) = HeaderValue::from_str(request_id) {
+        forward_headers.insert(
+            axum::http::header::HeaderName::from_static("x-request-id"),
+            value,
+        );
+    }
+    forward_headers
+}
+
+async fn send_peer_request(
+    state: &NodeState,
+    request: PeerRequest<'_>,
+) -> Result<PeerResponse, AppError> {
+    if let Some(noise_context) = state.noise_context.as_ref() {
+        let timeout = (request.timeout_ms > 0).then(|| Duration::from_millis(request.timeout_ms));
+        let response = crate::noise::transport::request(
+            noise_context,
+            crate::noise::transport::OutboundNoiseRequest {
+                peer_base_url: request.peer_address,
+                expected_peer_node_id: Some(request.peer_id),
+                method: request.method.as_str(),
+                path: request.path_and_query,
+                headers: &request.headers,
+                body: &request.body,
+                timeout_duration: timeout,
+            },
+        )
+        .await
+        .map_err(|e| {
+            AppError::new(
+                StatusCode::BAD_GATEWAY,
+                e.to_string(),
+                "peer_forward_failed",
+            )
+        })?;
+
+        let status = StatusCode::from_u16(response.head.status).map_err(|e| {
+            AppError::internal_server_error(format!("Invalid peer response status: {e}"))
+        })?;
+        let mut response_headers = HeaderMap::new();
+        for (name, value) in &response.head.headers {
+            if let (Ok(name), Ok(value)) = (
+                axum::http::HeaderName::from_bytes(name.as_bytes()),
+                HeaderValue::from_str(value),
+            ) {
+                response_headers.insert(name, value);
+            }
+        }
+
+        Ok(PeerResponse::Noise {
+            status,
+            headers: response_headers,
+            body: Box::new(response.into_body_stream()),
+        })
+    } else {
+        let base = request.peer_address.trim_end_matches('/');
+        let url = format!("{base}{}", request.path_and_query);
+        let mut client_req = state
+            .cluster_client
+            .request(request.method, &url)
+            .headers(request.headers)
+            .body(request.body);
+
+        if request.timeout_ms > 0 {
+            client_req = client_req.timeout(Duration::from_millis(request.timeout_ms));
+        }
+
+        client_req
+            .send()
+            .await
+            .map(PeerResponse::Http)
+            .map_err(|e| {
+                AppError::new(
+                    StatusCode::BAD_GATEWAY,
+                    format!("Failed to forward to peer {}: {e}", request.peer_id),
+                    "peer_forward_failed",
+                )
+            })
+    }
+}
+
+pub async fn list_models(
+    State(state): State<Arc<NodeState>>,
+    headers: HeaderMap,
+) -> Result<Json<Value>, AppError> {
+    crate::security::check_api_key_auth(state.config.auth.as_ref(), &headers)
+        .map_err(AppError::authentication_error)?;
+
     let mut data = Vec::new();
     let current_time = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -167,10 +313,10 @@ pub async fn list_models(State(state): State<Arc<NodeState>>) -> impl IntoRespon
         }
     }
 
-    Json(json!({
+    Ok(Json(json!({
         "object": "list",
         "data": data
-    }))
+    })))
 }
 
 pub async fn route_request(
@@ -204,7 +350,7 @@ pub async fn route_request(
     )
     .await
     .map_err(|_| AppError::request_timeout("Request body read timed out"))?
-    .map_err(|e| AppError::invalid_request(format!("Body too large or error: {}", e)))?;
+    .map_err(|e| AppError::invalid_request(format!("Body too large or error: {e}")))?;
 
     let json_body: Value =
         serde_json::from_slice(&bytes).map_err(|_| AppError::invalid_request("Invalid JSON"))?;
@@ -287,59 +433,30 @@ pub async fn route_request(
                 // see the peer's load before its next gossip tick.
                 let peer_forward_guard = state.track_peer_forward(&peer.node_id).await;
 
-                let base = peer.address.trim_end_matches('/');
-                let url = format!("{}{}", base, path_and_query);
-
-                // Build headers for forwarding
-                let mut forward_headers = axum::http::HeaderMap::new();
-                for (name, value) in parts.headers.iter() {
-                    let name_lower = name.as_str().to_lowercase();
-                    if matches!(
-                        name_lower.as_str(),
-                        "host"
-                            | "content-length"
-                            | "transfer-encoding"
-                            | "connection"
-                            | "keep-alive"
-                            | "proxy-authenticate"
-                            | "proxy-authorization"
-                            | "te"
-                            | "trailer"
-                            | "upgrade"
-                    ) {
-                        continue;
-                    }
-                    forward_headers.insert(name.clone(), value.clone());
-                }
-                forward_headers.insert(
-                    axum::http::header::HeaderName::from_static("x-llama-mesh-hops"),
-                    axum::http::HeaderValue::from_str(&(current_hops + 1).to_string())
-                        .map_err(|e| AppError::internal_server_error(e.to_string()))?,
-                );
-                forward_headers.insert(
-                    axum::http::header::HeaderName::from_static("x-request-id"),
-                    axum::http::HeaderValue::from_str(&request_id)
-                        .map_err(|e| AppError::internal_server_error(e.to_string()))?,
-                );
-
-                // Use default timeout for unknown models
+                let forward_headers =
+                    build_forward_headers(&parts.headers, current_hops, &request_id);
                 let timeout_ms = state.config.model_defaults.max_request_duration_ms;
-                let mut client_req = state
-                    .cluster_client
-                    .request(parts.method, &url)
-                    .headers(forward_headers)
-                    .body(bytes.clone());
 
-                if timeout_ms > 0 {
-                    client_req = client_req.timeout(Duration::from_millis(timeout_ms));
-                }
-
-                match client_req.send().await {
+                match send_peer_request(
+                    &state,
+                    PeerRequest {
+                        peer_id: &peer.node_id,
+                        peer_address: &peer.address,
+                        method: parts.method.clone(),
+                        path_and_query: &path_and_query,
+                        headers: forward_headers,
+                        body: bytes.clone(),
+                        timeout_ms,
+                    },
+                )
+                .await
+                {
                     Ok(resp) => {
-                        state.circuit_breaker.record_success(&peer.node_id).await;
-
-                        let status = resp.status();
-                        let headers = resp.headers().clone();
+                        let status = match &resp {
+                            PeerResponse::Http(resp) => resp.status(),
+                            PeerResponse::Noise { status, .. } => *status,
+                        };
+                        record_peer_status(&state, &peer.node_id, status).await;
 
                         // Defer the dec_current_requests decrement until the
                         // response body finishes streaming to the client (or is
@@ -362,39 +479,27 @@ pub async fn route_request(
                         guard.complete();
 
                         let tokens_counter = Arc::new(AtomicU64::new(0));
-                        let wrapped =
-                            CleanupStream::new(resp.bytes_stream(), cleanup_fut, tokens_counter);
-                        let body = Body::from_stream(wrapped);
-
-                        let mut response = Response::builder().status(status);
-                        for (name, value) in headers.iter() {
-                            response = response.header(name, value);
-                        }
-                        return response.body(body).map_err(|e| {
-                            AppError::internal_server_error(format!(
-                                "Failed to build forwarded response: {}",
-                                e
-                            ))
-                        });
+                        return Ok(peer_response_to_client(
+                            resp,
+                            stream_requested,
+                            cleanup_fut,
+                            tokens_counter,
+                        )
+                        .await);
                     }
                     Err(e) => {
                         state.circuit_breaker.record_failure(&peer.node_id).await;
                         // guard Drop handles dec_current_requests on return.
                         state.metrics.inc_errors();
-                        error!(peer = %peer.node_id, error = %e, "Failed to forward to peer");
-                        return Err(AppError::new(
-                            StatusCode::BAD_GATEWAY,
-                            format!("Failed to forward to peer {}: {}", peer.node_id, e),
-                            "peer_forward_failed",
-                        ));
+                        error!(peer = %peer.node_id, error = ?e, "Failed to forward to peer");
+                        return Err(e);
                     }
                 }
             }
 
             // No local resolution and no peer found
             return Err(AppError::model_not_found(format!(
-                "Model '{}' not found in local cookbook or any peer",
-                model_to_use
+                "Model '{model_to_use}' not found in local cookbook or any peer"
             )));
         }
 
@@ -485,7 +590,7 @@ pub async fn route_request(
                         (inst.host.clone(), inst.port)
                     };
 
-                    let url = format!("http://{}:{}{}", target_host, target_port, path_and_query);
+                    let url = format!("http://{target_host}:{target_port}{path_and_query}");
 
                     info!("Forwarding locally to {}", url);
 
@@ -495,7 +600,7 @@ pub async fn route_request(
                     // Inject authorization if the profile defines an API key
                     if let Some(api_key) = profile.get_api_key() {
                         let value =
-                            axum::http::HeaderValue::from_str(&format!("Bearer {}", api_key))
+                            axum::http::HeaderValue::from_str(&format!("Bearer {api_key}"))
                                 .map_err(|e| {
                                     error!(
                                         "Failed to create Authorization header from API key: {}. \
@@ -623,7 +728,7 @@ pub async fn route_request(
 
                             Err(AppError::new(
                                 StatusCode::BAD_GATEWAY,
-                                format!("Upstream error: {}", e),
+                                format!("Upstream error: {e}"),
                                 "upstream_error",
                             ))
                         }
@@ -645,55 +750,30 @@ pub async fn route_request(
                                 "Local spawn failures exhausted, falling back to peer"
                             );
 
-                            let peer_forward_guard =
-                                state.track_peer_forward(&peer.node_id).await;
-                            let base = peer.address.trim_end_matches('/');
-                            let url = format!("{}{}", base, path_and_query);
+                            let peer_forward_guard = state.track_peer_forward(&peer.node_id).await;
+                            let forward_headers =
+                                build_forward_headers(&parts.headers, current_hops, &request_id);
 
-                            let mut forward_headers = axum::http::HeaderMap::new();
-                            for (name, value) in parts.headers.iter() {
-                                let name_lower = name.as_str().to_lowercase();
-                                if matches!(
-                                    name_lower.as_str(),
-                                    "host"
-                                        | "content-length"
-                                        | "transfer-encoding"
-                                        | "connection"
-                                        | "keep-alive"
-                                        | "proxy-authenticate"
-                                        | "proxy-authorization"
-                                        | "te"
-                                        | "trailer"
-                                        | "upgrade"
-                                ) {
-                                    continue;
-                                }
-                                forward_headers.insert(name.clone(), value.clone());
-                            }
-                            forward_headers.insert(
-                                axum::http::header::HeaderName::from_static("x-llama-mesh-hops"),
-                                axum::http::HeaderValue::from_str(&(current_hops + 1).to_string())
-                                    .map_err(|e| AppError::internal_server_error(e.to_string()))?,
-                            );
-                            forward_headers.insert(
-                                axum::http::header::HeaderName::from_static("x-request-id"),
-                                axum::http::HeaderValue::from_str(&request_id)
-                                    .map_err(|e| AppError::internal_server_error(e.to_string()))?,
-                            );
-
-                            let mut client_req = state
-                                .cluster_client
-                                .request(parts.method, &url)
-                                .headers(forward_headers)
-                                .body(bytes.clone());
-
-                            if timeout_ms > 0 {
-                                client_req = client_req.timeout(Duration::from_millis(timeout_ms));
-                            }
-
-                            match client_req.send().await {
+                            match send_peer_request(
+                                &state,
+                                PeerRequest {
+                                    peer_id: &peer.node_id,
+                                    peer_address: &peer.address,
+                                    method: parts.method.clone(),
+                                    path_and_query: &path_and_query,
+                                    headers: forward_headers,
+                                    body: bytes.clone(),
+                                    timeout_ms,
+                                },
+                            )
+                            .await
+                            {
                                 Ok(resp) => {
-                                    state.circuit_breaker.record_success(&peer.node_id).await;
+                                    let status = match &resp {
+                                        PeerResponse::Http(resp) => resp.status(),
+                                        PeerResponse::Noise { status, .. } => *status,
+                                    };
+                                    record_peer_status(&state, &peer.node_id, status).await;
 
                                     let tokens_counter = Arc::new(AtomicU64::new(0));
                                     let tokens_for_cleanup = tokens_counter.clone();
@@ -718,12 +798,13 @@ pub async fn route_request(
 
                                     guard.complete();
 
-                                    return Ok(if stream_requested {
-                                        build_streaming_response(resp, cleanup_fut, tokens_counter)
-                                    } else {
-                                        handle_non_streaming_response(resp, cleanup_fut, tokens_counter)
-                                            .await
-                                    });
+                                    return Ok(peer_response_to_client(
+                                        resp,
+                                        stream_requested,
+                                        cleanup_fut,
+                                        tokens_counter,
+                                    )
+                                    .await);
                                 }
                                 Err(peer_err) => {
                                     // peer_forward_guard drops on fall-through,
@@ -731,7 +812,7 @@ pub async fn route_request(
                                     state.circuit_breaker.record_failure(&peer.node_id).await;
                                     warn!(
                                         peer = %peer.node_id,
-                                        error = %peer_err,
+                                        error = ?peer_err,
                                         "Peer fallback also failed"
                                     );
                                     // Fall through to return the original error
@@ -786,61 +867,29 @@ pub async fn route_request(
             // for the peer's next gossip tick. Guard is released in the cleanup
             // future (success) or on function return (error).
             let peer_forward_guard = state.track_peer_forward(&best_node.node_id).await;
-            let base = best_node.address.trim_end_matches('/');
-            let url = format!("{}{}", base, path_and_query);
+            let forward_headers =
+                build_forward_headers(&parts.headers, current_hops, &request_id);
 
-            // Build headers for forwarding, excluding hop-by-hop headers that shouldn't be forwarded
-            // and headers that reqwest manages internally
-            let mut forward_headers = axum::http::HeaderMap::new();
-            for (name, value) in parts.headers.iter() {
-                // Skip headers that shouldn't be forwarded or that reqwest manages
-                let name_lower = name.as_str().to_lowercase();
-                if matches!(
-                    name_lower.as_str(),
-                    "host"
-                        | "content-length"
-                        | "transfer-encoding"
-                        | "connection"
-                        | "keep-alive"
-                        | "proxy-authenticate"
-                        | "proxy-authorization"
-                        | "te"
-                        | "trailer"
-                        | "upgrade"
-                ) {
-                    continue;
-                }
-                forward_headers.insert(name.clone(), value.clone());
-            }
-            forward_headers.insert(
-                axum::http::header::HeaderName::from_static("x-llama-mesh-hops"),
-                axum::http::HeaderValue::from_str(&(current_hops + 1).to_string())
-                    .map_err(|e| AppError::internal_server_error(e.to_string()))?,
-            );
-            // Forward request ID for cross-cluster tracing
-            forward_headers.insert(
-                axum::http::header::HeaderName::from_static("x-request-id"),
-                axum::http::HeaderValue::from_str(&request_id)
-                    .map_err(|e| AppError::internal_server_error(e.to_string()))?,
-            );
-
-            let mut client_req = state
-                .cluster_client
-                .request(parts.method, &url)
-                .headers(forward_headers)
-                .body(bytes.clone());
-
-            if timeout_ms > 0 {
-                client_req = client_req.timeout(Duration::from_millis(timeout_ms));
-            }
-
-            match client_req.send().await {
+            match send_peer_request(
+                &state,
+                PeerRequest {
+                    peer_id: &best_node.node_id,
+                    peer_address: &best_node.address,
+                    method: parts.method.clone(),
+                    path_and_query: &path_and_query,
+                    headers: forward_headers,
+                    body: bytes.clone(),
+                    timeout_ms,
+                },
+            )
+            .await
+            {
                 Ok(resp) => {
-                    // Record success for circuit breaker
-                    state
-                        .circuit_breaker
-                        .record_success(&best_node.node_id)
-                        .await;
+                    let status = match &resp {
+                        PeerResponse::Http(resp) => resp.status(),
+                        PeerResponse::Noise { status, .. } => *status,
+                    };
+                    record_peer_status(&state, &best_node.node_id, status).await;
 
                     let tokens_counter = Arc::new(AtomicU64::new(0));
                     let tokens_for_cleanup = tokens_counter.clone();
@@ -868,11 +917,8 @@ pub async fn route_request(
                     // Transfer responsibility to cleanup_fut
                     guard.complete();
 
-                    Ok(if stream_requested {
-                        build_streaming_response(resp, cleanup_fut, tokens_counter)
-                    } else {
-                        handle_non_streaming_response(resp, cleanup_fut, tokens_counter).await
-                    })
+                    Ok(peer_response_to_client(resp, stream_requested, cleanup_fut, tokens_counter)
+                        .await)
                 }
                 Err(e) => {
                     // peer_forward_guard drops here, releasing the counter.
@@ -884,9 +930,9 @@ pub async fn route_request(
 
                     warn!(
                         peer = %best_node.node_id,
-                        url = %url,
-                        error = %e,
-                        error_debug = ?e,
+                        address = %best_node.address,
+                        path = %path_and_query,
+                        error = ?e,
                         "Peer forwarding failed, waiting for capacity to retry"
                     );
 
@@ -1041,6 +1087,117 @@ fn build_streaming_response(
     response
 }
 
+fn build_streaming_response_from_parts<S, E>(
+    status: StatusCode,
+    headers: HeaderMap,
+    stream: S,
+    cleanup: BoxFuture<'static, ()>,
+    tokens_generated: Arc<AtomicU64>,
+) -> Response<Body>
+where
+    S: Stream<Item = Result<Bytes, E>> + Send + 'static,
+    E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
+{
+    let stream = CleanupStream::new(stream, cleanup, tokens_generated);
+    let mut response = Response::new(Body::from_stream(stream));
+    *response.status_mut() = status;
+    *response.headers_mut() = headers;
+    response
+}
+
+async fn handle_non_streaming_body(
+    status: StatusCode,
+    headers: HeaderMap,
+    bytes: Bytes,
+    cleanup: BoxFuture<'static, ()>,
+    tokens_generated: Arc<AtomicU64>,
+) -> Response<Body> {
+    let _cleanup_guard = AutoCleanup::new(cleanup);
+
+    if let Ok(val) = serde_json::from_slice::<Value>(&bytes) {
+        if let Some(usage) = val.get("usage") {
+            if let Some(completion_tokens) = usage.get("completion_tokens").and_then(|v| v.as_u64())
+            {
+                info!(
+                    "Counted {} tokens from non-streaming response",
+                    completion_tokens
+                );
+                tokens_generated.fetch_add(completion_tokens, Ordering::Relaxed);
+            }
+        } else {
+            info!("No usage field in response");
+        }
+    } else {
+        info!("Failed to parse response as JSON");
+    }
+
+    let mut response = Response::new(Body::from(bytes));
+    *response.status_mut() = status;
+    *response.headers_mut() = headers;
+    response
+}
+
+async fn peer_response_to_client(
+    response: PeerResponse,
+    stream_requested: bool,
+    cleanup: BoxFuture<'static, ()>,
+    tokens_generated: Arc<AtomicU64>,
+) -> Response<Body> {
+    match response {
+        PeerResponse::Http(resp) => {
+            if stream_requested {
+                build_streaming_response(resp, cleanup, tokens_generated)
+            } else {
+                handle_non_streaming_response(resp, cleanup, tokens_generated).await
+            }
+        }
+        PeerResponse::Noise {
+            status,
+            headers,
+            body,
+        } => {
+            let body = *body;
+            if stream_requested {
+                build_streaming_response_from_parts(
+                    status,
+                    headers,
+                    body,
+                    cleanup,
+                    tokens_generated,
+                )
+            } else {
+                match body
+                    .map(|chunk| chunk.map_err(|e| std::io::Error::other(e.to_string())))
+                    .try_fold(Vec::new(), |mut acc, chunk| async move {
+                        acc.extend_from_slice(&chunk);
+                        Ok(acc)
+                    })
+                    .await
+                {
+                    Ok(bytes) => {
+                        handle_non_streaming_body(
+                            status,
+                            headers,
+                            Bytes::from(bytes),
+                            cleanup,
+                            tokens_generated,
+                        )
+                        .await
+                    }
+                    Err(e) => {
+                        error!("Failed to read peer response body: {}", e);
+                        let _cleanup_guard = AutoCleanup::new(cleanup);
+                        Response::builder()
+                            .status(StatusCode::BAD_GATEWAY)
+                            .body(Body::from("Failed to read peer response"))
+                            .unwrap_or_else(|_| Response::new(Body::from("Internal error")))
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// Maximum buffer size for token counting (16MB).
 /// If exceeded, token counting is disabled but stream continues unaffected.
 const MAX_TOKEN_BUFFER_SIZE: usize = 16 * 1024 * 1024;
@@ -1053,9 +1210,9 @@ pub static SKIPPED_STREAM_CLEANUPS: AtomicU64 = AtomicU64::new(0);
 /// Exposed via metrics endpoint.
 pub static TOKEN_COUNTING_DISABLED: AtomicU64 = AtomicU64::new(0);
 
-struct CleanupStream<S>
+struct CleanupStream<S, E>
 where
-    S: Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
+    S: Stream<Item = Result<Bytes, E>> + Send + 'static,
 {
     inner: Pin<Box<S>>,
     cleanup: Option<BoxFuture<'static, ()>>,
@@ -1065,9 +1222,9 @@ where
     cleanup_executed: bool,
 }
 
-impl<S> CleanupStream<S>
+impl<S, E> CleanupStream<S, E>
 where
-    S: Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
+    S: Stream<Item = Result<Bytes, E>> + Send + 'static,
 {
     fn new(inner: S, cleanup: BoxFuture<'static, ()>, tokens_generated: Arc<AtomicU64>) -> Self {
         Self {
@@ -1125,11 +1282,11 @@ fn process_line(line: &[u8], counter: &AtomicU64) {
     }
 }
 
-impl<S> Stream for CleanupStream<S>
+impl<S, E> Stream for CleanupStream<S, E>
 where
-    S: Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
+    S: Stream<Item = Result<Bytes, E>> + Send + 'static,
 {
-    type Item = Result<Bytes, reqwest::Error>;
+    type Item = Result<Bytes, E>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match self.inner.as_mut().poll_next(cx) {
@@ -1226,9 +1383,9 @@ where
     }
 }
 
-impl<S> Drop for CleanupStream<S>
+impl<S, E> Drop for CleanupStream<S, E>
 where
-    S: Stream<Item = Result<Bytes, reqwest::Error>> + Send + 'static,
+    S: Stream<Item = Result<Bytes, E>> + Send + 'static,
 {
     fn drop(&mut self) {
         // Only run cleanup if it wasn't already executed in poll_next
@@ -1291,8 +1448,7 @@ fn ensure_profile_supports_endpoint(
             } else {
                 Err(Box::new(
                     AppError::model_not_found(format!(
-                        "Model '{}' is not configured for embeddings",
-                        requested_model
+                        "Model '{requested_model}' is not configured for embeddings"
                     ))
                     .with_param("model"),
                 ))
@@ -1307,8 +1463,7 @@ fn ensure_profile_supports_endpoint(
             } else {
                 Err(Box::new(
                     AppError::model_not_found(format!(
-                        "Model '{}' is not configured for reranking",
-                        requested_model
+                        "Model '{requested_model}' is not configured for reranking"
                     ))
                     .with_param("model"),
                 ))
@@ -1320,8 +1475,7 @@ fn ensure_profile_supports_endpoint(
             } else {
                 Err(Box::new(
                     AppError::invalid_request(format!(
-                        "Model '{}' is restricted to embeddings or rerank endpoints",
-                        requested_model
+                        "Model '{requested_model}' is restricted to embeddings or rerank endpoints"
                     ))
                     .with_param("model"),
                 ))

--- a/src/security.rs
+++ b/src/security.rs
@@ -2,9 +2,10 @@ use crate::config::{AuthConfig, ClusterTlsConfig, ServerTlsConfig};
 use anyhow::{Context, Result};
 use axum::http::HeaderMap;
 use reqwest::{Client, ClientBuilder};
+use rustls::pki_types::pem::PemObject;
 use rustls::ServerConfig;
 use std::fs::File;
-use std::io::{BufReader, Read};
+use std::io::Read;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, Default)]
@@ -100,11 +101,10 @@ pub async fn load_server_config(
 }
 
 fn load_certs(path: &str) -> Result<Vec<rustls::pki_types::CertificateDer<'static>>> {
-    let file = File::open(path).with_context(|| format!("Failed to open cert file: {}", path))?;
-    let mut reader = BufReader::new(file);
-    let certs: Vec<_> = rustls_pemfile::certs(&mut reader)
+    let certs: Vec<_> = rustls::pki_types::CertificateDer::pem_file_iter(path)
+        .with_context(|| format!("Failed to open cert file: {path}"))?
         .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| anyhow::anyhow!("Failed to load certs: {}", e))?;
+        .map_err(|e| anyhow::anyhow!("Failed to load certs: {e}"))?;
 
     // Validate certificate expiry for the first (leaf) certificate
     if let Some(cert) = certs.first() {
@@ -120,8 +120,7 @@ fn load_certs(path: &str) -> Result<Vec<rustls::pki_types::CertificateDer<'stati
                     validity.not_after
                 );
                 return Err(anyhow::anyhow!(
-                    "Certificate at {} is expired or not yet valid",
-                    path
+                    "Certificate at {path} is expired or not yet valid"
                 ));
             }
 
@@ -147,19 +146,8 @@ fn load_certs(path: &str) -> Result<Vec<rustls::pki_types::CertificateDer<'stati
 }
 
 fn load_private_key(path: &str) -> Result<rustls::pki_types::PrivateKeyDer<'static>> {
-    let file = File::open(path).with_context(|| format!("Failed to open key file: {}", path))?;
-    let mut reader = BufReader::new(file);
-
-    for item in rustls_pemfile::read_all(&mut reader) {
-        match item? {
-            rustls_pemfile::Item::Pkcs1Key(key) => return Ok(key.into()),
-            rustls_pemfile::Item::Pkcs8Key(key) => return Ok(key.into()),
-            rustls_pemfile::Item::Sec1Key(key) => return Ok(key.into()),
-            _ => {}
-        }
-    }
-
-    Err(anyhow::anyhow!("No private key found in {}", path))
+    rustls::pki_types::PrivateKeyDer::from_pem_file(path)
+        .with_context(|| format!("Failed to load private key: {path}"))
 }
 
 pub fn build_cluster_client(config: &Option<ClusterTlsConfig>) -> Result<Client> {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,15 +4,31 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tokio::time::sleep;
 
-pub async fn setup_mock_script(root: &Path, suffix: &str) -> PathBuf {
-    let mock_script = root.join(format!("tests/mock_server_{}.sh", suffix));
-    let mut mock_bin = root.join("target/release/mock_llama_server");
-    if !mock_bin.exists() {
-        let debug_bin = root.join("target/debug/mock_llama_server");
-        if debug_bin.exists() {
-            mock_bin = debug_bin;
-        }
+pub fn llamesh_binary(root: &Path) -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_llamesh") {
+        return PathBuf::from(path);
     }
+
+    let debug_bin = root.join("target/debug/llamesh");
+    if debug_bin.exists() {
+        debug_bin
+    } else {
+        root.join("target/release/llamesh")
+    }
+}
+
+pub async fn setup_mock_script(root: &Path, suffix: &str) -> PathBuf {
+    let mock_script = root.join(format!("tests/mock_server_{suffix}.sh"));
+    let mock_bin = std::env::var_os("CARGO_BIN_EXE_mock_llama_server")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            let debug_bin = root.join("target/debug/mock_llama_server");
+            if debug_bin.exists() {
+                debug_bin
+            } else {
+                root.join("target/release/mock_llama_server")
+            }
+        });
     let script_content = format!(
         r#"#!/bin/bash
 BIN="{}"
@@ -51,7 +67,7 @@ pub async fn cleanup_by_port_range_pattern(port_pattern: &str) {
     // Kill mock_llama_server processes that match the port pattern
     // e.g. port_pattern = "1300[0-9]"
     // match "--port 1300[0-9]"
-    let full_pattern = format!("mock_llama_server.*--port {}", port_pattern);
+    let full_pattern = format!("mock_llama_server.*--port {port_pattern}");
     let _ = tokio::process::Command::new("pkill")
         .arg("-f")
         .arg(&full_pattern)
@@ -80,7 +96,7 @@ pub async fn wait_for_ready(base_url: &str) -> bool {
         .unwrap();
 
     for _ in 0..60 {
-        if let Ok(resp) = client.get(format!("{}/healthz", base_url)).send().await {
+        if let Ok(resp) = client.get(format!("{base_url}/healthz")).send().await {
             if resp.status().is_success() {
                 return true;
             }
@@ -123,9 +139,9 @@ pub async fn load_config_from_template(params: &TestConfigParams<'_>) -> String 
 /// Load a cookbook fixture by name (without .yaml extension)
 #[allow(dead_code)]
 pub async fn load_cookbook_fixture(name: &str) -> String {
-    tokio::fs::read_to_string(format!("tests/fixtures/{}.yaml", name))
+    tokio::fs::read_to_string(format!("tests/fixtures/{name}.yaml"))
         .await
-        .unwrap_or_else(|_| panic!("Failed to read cookbook fixture: {}", name))
+        .unwrap_or_else(|_| panic!("Failed to read cookbook fixture: {name}"))
 }
 
 /// Find an available port in the given range

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4,7 +4,8 @@ use tokio::time::sleep;
 
 mod common;
 use common::{
-    cleanup_by_port_range_pattern, cleanup_procs, graceful_stop, setup_mock_script, wait_for_ready,
+    cleanup_by_port_range_pattern, cleanup_procs, graceful_stop, llamesh_binary, setup_mock_script,
+    wait_for_ready,
 };
 
 #[tokio::test]
@@ -16,13 +17,7 @@ async fn test_standalone_proxy() {
     let mock_script = setup_mock_script(&root, "standalone").await;
     let config_path = root.join("tests/config_standalone.yaml");
     let cookbook_path = root.join("tests/cookbook_standalone.yaml");
-    let mut proxy_bin = root.join("target/release/llamesh");
-    if !proxy_bin.exists() {
-        let debug_bin = root.join("target/debug/llamesh");
-        if debug_bin.exists() {
-            proxy_bin = debug_bin;
-        }
-    }
+    let proxy_bin = llamesh_binary(&root);
 
     let config_content = format!(
         r#"
@@ -130,13 +125,7 @@ async fn test_cluster_proxy() {
     cleanup_by_port_range_pattern("130[12][0-9]").await;
     let root = std::env::current_dir().unwrap();
     let mock_script = setup_mock_script(&root, "cluster").await;
-    let mut proxy_bin = root.join("target/release/llamesh");
-    if !proxy_bin.exists() {
-        let debug_bin = root.join("target/debug/llamesh");
-        if debug_bin.exists() {
-            proxy_bin = debug_bin;
-        }
-    }
+    let proxy_bin = llamesh_binary(&root);
 
     let config_a_path = root.join("tests/config_node_a.yaml");
     let cookbook_a_path = root.join("tests/cookbook_node_a.yaml");
@@ -337,13 +326,7 @@ async fn test_disabled_model() {
     let mock_script = setup_mock_script(&root, "disabled").await;
     let config_path = root.join("tests/config_disabled.yaml");
     let cookbook_path = root.join("tests/cookbook_disabled.yaml");
-    let mut proxy_bin = root.join("target/release/llamesh");
-    if !proxy_bin.exists() {
-        let debug_bin = root.join("target/debug/llamesh");
-        if debug_bin.exists() {
-            proxy_bin = debug_bin;
-        }
-    }
+    let proxy_bin = llamesh_binary(&root);
 
     let config_content = format!(
         r#"
@@ -508,13 +491,7 @@ async fn test_token_counting() {
     let mock_script = setup_mock_script(&root, "tokens").await;
     let config_path = root.join("tests/config_tokens.yaml");
     let cookbook_path = root.join("tests/cookbook_tokens.yaml");
-    let mut proxy_bin = root.join("target/release/llamesh");
-    if !proxy_bin.exists() {
-        let debug_bin = root.join("target/debug/llamesh");
-        if debug_bin.exists() {
-            proxy_bin = debug_bin;
-        }
-    }
+    let proxy_bin = llamesh_binary(&root);
 
     let config_content = format!(
         r#"
@@ -688,13 +665,7 @@ async fn test_instance_auth() {
     let mock_script = setup_mock_script(&root, "auth").await;
     let config_path = root.join("tests/config_auth.yaml");
     let cookbook_path = root.join("tests/cookbook_auth.yaml");
-    let mut proxy_bin = root.join("target/release/llamesh");
-    if !proxy_bin.exists() {
-        let debug_bin = root.join("target/debug/llamesh");
-        if debug_bin.exists() {
-            proxy_bin = debug_bin;
-        }
-    }
+    let proxy_bin = llamesh_binary(&root);
 
     let config_content = format!(
         r#"
@@ -801,13 +772,7 @@ async fn test_crash_recovery() {
     let mock_script = setup_mock_script(&root, "crash").await;
     let config_path = root.join("tests/config_crash.yaml");
     let cookbook_path = root.join("tests/cookbook_crash.yaml");
-    let mut proxy_bin = root.join("target/release/llamesh");
-    if !proxy_bin.exists() {
-        let debug_bin = root.join("target/debug/llamesh");
-        if debug_bin.exists() {
-            proxy_bin = debug_bin;
-        }
-    }
+    let proxy_bin = llamesh_binary(&root);
 
     let config_content = format!(
         r#"
@@ -951,13 +916,7 @@ async fn test_queueing() {
     let mock_script = setup_mock_script(&root, "queue").await;
     let config_path = root.join("tests/config_queue.yaml");
     let cookbook_path = root.join("tests/cookbook_queue.yaml");
-    let mut proxy_bin = root.join("target/release/llamesh");
-    if !proxy_bin.exists() {
-        let debug_bin = root.join("target/debug/llamesh");
-        if debug_bin.exists() {
-            proxy_bin = debug_bin;
-        }
-    }
+    let proxy_bin = llamesh_binary(&root);
 
     let config_content = format!(
         r#"
@@ -1075,8 +1034,8 @@ models:
     assert_eq!(status1, StatusCode::OK);
     assert_eq!(status2, StatusCode::OK);
 
-    println!("Req 1 duration: {:?}", dur1);
-    println!("Req 2 duration: {:?}", dur2);
+    println!("Req 1 duration: {dur1:?}");
+    println!("Req 2 duration: {dur2:?}");
 
     // Mock server delays ~100-500ms + 500-2000ms.
     // Req 2 should be roughly 2x Req 1 duration if queued, or at least significantly longer than Req 1 if they were parallel (but they aren't parallel).
@@ -1107,13 +1066,7 @@ async fn test_hop_counter_validation() {
     let mock_script = setup_mock_script(&root, "hops").await;
     let config_path = root.join("tests/config_hops.yaml");
     let cookbook_path = root.join("tests/cookbook_hops.yaml");
-    let mut proxy_bin = root.join("target/release/llamesh");
-    if !proxy_bin.exists() {
-        let debug_bin = root.join("target/debug/llamesh");
-        if debug_bin.exists() {
-            proxy_bin = debug_bin;
-        }
-    }
+    let proxy_bin = llamesh_binary(&root);
 
     let config_content = format!(
         r#"

--- a/tests/integration_test_admin_auth.rs
+++ b/tests/integration_test_admin_auth.rs
@@ -1,7 +1,7 @@
 use reqwest::StatusCode;
 
 mod common;
-use common::{cleanup_procs, graceful_stop, setup_mock_script, wait_for_ready};
+use common::{cleanup_procs, graceful_stop, llamesh_binary, setup_mock_script, wait_for_ready};
 
 #[tokio::test]
 async fn test_admin_auth() {
@@ -12,13 +12,7 @@ async fn test_admin_auth() {
     let mock_script = setup_mock_script(&root, "admin_auth").await;
     let config_path = root.join("tests/config_admin_auth.yaml");
     let cookbook_path = root.join("tests/cookbook_admin_auth.yaml");
-    let mut proxy_bin = root.join("target/release/llamesh");
-    if !proxy_bin.exists() {
-        let debug_bin = root.join("target/debug/llamesh");
-        if debug_bin.exists() {
-            proxy_bin = debug_bin;
-        }
-    }
+    let proxy_bin = llamesh_binary(&root);
 
     let config_content = format!(
         r#"

--- a/tests/integration_test_cancellation.rs
+++ b/tests/integration_test_cancellation.rs
@@ -15,7 +15,9 @@ use std::time::Duration;
 use tokio::time::sleep;
 
 mod common;
-use common::{cleanup_by_port_range_pattern, cleanup_procs, graceful_stop, wait_for_ready};
+use common::{
+    cleanup_by_port_range_pattern, cleanup_procs, graceful_stop, llamesh_binary, wait_for_ready,
+};
 
 const LISTEN_ADDR: &str = "127.0.0.1:9220";
 const BASE_URL: &str = "http://127.0.0.1:9220";
@@ -80,7 +82,7 @@ async fn setup_slow_body_mock_script(
     suffix: &str,
     body_delay_ms: u64,
 ) -> std::path::PathBuf {
-    let mock_script = root.join(format!("tests/mock_server_{}.sh", suffix));
+    let mock_script = root.join(format!("tests/mock_server_{suffix}.sh"));
     let mut mock_bin = root.join("target/release/mock_llama_server");
     if !mock_bin.exists() {
         let debug_bin = root.join("target/debug/mock_llama_server");
@@ -150,13 +152,7 @@ async fn cancelled_request_does_not_leak_in_flight_counter() {
     let mock_script = setup_slow_body_mock_script(&root, "cancellation", 5000).await;
     let config_path = root.join("tests/config_cancellation.yaml");
     let cookbook_path = root.join("tests/cookbook_cancellation.yaml");
-    let mut proxy_bin = root.join("target/release/llamesh");
-    if !proxy_bin.exists() {
-        let debug_bin = root.join("target/debug/llamesh");
-        if debug_bin.exists() {
-            proxy_bin = debug_bin;
-        }
-    }
+    let proxy_bin = llamesh_binary(&root);
 
     tokio::fs::write(&config_path, config_yaml(&mock_script))
         .await

--- a/tests/integration_test_features.rs
+++ b/tests/integration_test_features.rs
@@ -2,7 +2,8 @@ use reqwest::StatusCode;
 
 mod common;
 use common::{
-    cleanup_by_port_range_pattern, cleanup_procs, graceful_stop, setup_mock_script, wait_for_ready,
+    cleanup_by_port_range_pattern, cleanup_procs, graceful_stop, llamesh_binary, setup_mock_script,
+    wait_for_ready,
 };
 
 #[tokio::test]
@@ -14,13 +15,7 @@ async fn test_embeddings_and_rerank() {
     let mock_script = setup_mock_script(&root, "features").await;
     let config_path = root.join("tests/config_features.yaml");
     let cookbook_path = root.join("tests/cookbook_features.yaml");
-    let mut proxy_bin = root.join("target/release/llamesh");
-    if !proxy_bin.exists() {
-        let debug_bin = root.join("target/debug/llamesh");
-        if debug_bin.exists() {
-            proxy_bin = debug_bin;
-        }
-    }
+    let proxy_bin = llamesh_binary(&root);
 
     let config_content = format!(
         r#"

--- a/tests/integration_test_peer_forward_cancellation.rs
+++ b/tests/integration_test_peer_forward_cancellation.rs
@@ -20,7 +20,8 @@ use tokio::time::sleep;
 
 mod common;
 use common::{
-    cleanup_by_port_range_pattern, cleanup_procs, graceful_stop, setup_mock_script, wait_for_ready,
+    cleanup_by_port_range_pattern, cleanup_procs, graceful_stop, llamesh_binary, setup_mock_script,
+    wait_for_ready,
 };
 
 const NODE_A_ADDR: &str = "127.0.0.1:9230";
@@ -163,13 +164,7 @@ async fn cancelled_peer_forward_does_not_leak_current_requests() {
     let config_b_path = root.join("tests/config_peer_fwd_cancel_b.yaml");
     let cookbook_b_path = root.join("tests/cookbook_peer_fwd_cancel_b.yaml");
 
-    let mut proxy_bin = root.join("target/release/llamesh");
-    if !proxy_bin.exists() {
-        let debug_bin = root.join("target/debug/llamesh");
-        if debug_bin.exists() {
-            proxy_bin = debug_bin;
-        }
-    }
+    let proxy_bin = llamesh_binary(&root);
 
     tokio::fs::write(
         &config_a_path,
@@ -273,6 +268,10 @@ async fn cancelled_peer_forward_does_not_leak_current_requests() {
         "node B's current_requests should return to 0 within 10s after cancel; \
          observed {}",
         current_requests(&client, NODE_B_URL).await
+    );
+    assert!(
+        wait_for_current_requests(&client, NODE_A_URL, 0, Duration::from_secs(10)).await,
+        "node A should finish any peer work that was already accepted before the sanity request"
     );
 
     // Sanity: a regular (non-cancelled) forward-to-peer request still completes.

--- a/tests/integration_test_reload_eviction.rs
+++ b/tests/integration_test_reload_eviction.rs
@@ -8,7 +8,8 @@ use tokio::time::sleep;
 
 mod common;
 use common::{
-    cleanup_by_port_range_pattern, cleanup_procs, graceful_stop, setup_mock_script, wait_for_ready,
+    cleanup_by_port_range_pattern, cleanup_procs, graceful_stop, llamesh_binary, setup_mock_script,
+    wait_for_ready,
 };
 
 const LISTEN_ADDR: &str = "127.0.0.1:9210";
@@ -170,11 +171,7 @@ models:
 async fn wait_for_unload(client: &reqwest::Client, model_key: &str, timeout: Duration) -> bool {
     let deadline = std::time::Instant::now() + timeout;
     while std::time::Instant::now() < deadline {
-        if let Ok(resp) = client
-            .get(format!("{}/cluster/nodes", BASE_URL))
-            .send()
-            .await
-        {
+        if let Ok(resp) = client.get(format!("{BASE_URL}/cluster/nodes")).send().await {
             if let Ok(json) = resp.json::<serde_json::Value>().await {
                 let loaded = json["nodes"]["test-reload-drain"]["loaded_models"]
                     .as_array()
@@ -199,7 +196,7 @@ async fn wait_for_model_unlisted(
 ) -> bool {
     let deadline = std::time::Instant::now() + timeout;
     while std::time::Instant::now() < deadline {
-        if let Ok(resp) = client.get(format!("{}/v1/models", BASE_URL)).send().await {
+        if let Ok(resp) = client.get(format!("{BASE_URL}/v1/models")).send().await {
             if let Ok(json) = resp.json::<serde_json::Value>().await {
                 let data = json["data"].as_array().cloned().unwrap_or_default();
                 if !data.iter().any(|m| m["id"].as_str() == Some(model_id)) {
@@ -221,7 +218,7 @@ async fn wait_for_model_listed(
 ) -> bool {
     let deadline = std::time::Instant::now() + timeout;
     while std::time::Instant::now() < deadline {
-        if let Ok(resp) = client.get(format!("{}/v1/models", BASE_URL)).send().await {
+        if let Ok(resp) = client.get(format!("{BASE_URL}/v1/models")).send().await {
             if let Ok(json) = resp.json::<serde_json::Value>().await {
                 let data = json["data"].as_array().cloned().unwrap_or_default();
                 if data.iter().any(|m| m["id"].as_str() == Some(model_id)) {
@@ -240,7 +237,7 @@ async fn spawn_instance_for(client: &reqwest::Client, model: &str) {
         "messages": [{"role": "user", "content": "hi"}],
     });
     let resp = client
-        .post(format!("{}/v1/chat/completions", BASE_URL))
+        .post(format!("{BASE_URL}/v1/chat/completions"))
         .json(&body)
         .send()
         .await
@@ -248,8 +245,7 @@ async fn spawn_instance_for(client: &reqwest::Client, model: &str) {
     assert_eq!(
         resp.status(),
         StatusCode::OK,
-        "request to spawn {} failed",
-        model
+        "request to spawn {model} failed"
     );
 }
 
@@ -279,13 +275,7 @@ async fn reload_drains_orphaned_instances() {
     let mock_script = setup_mock_script(&root, "reload_eviction").await;
     let config_path = root.join("tests/config_reload_eviction.yaml");
     let cookbook_path = root.join("tests/cookbook_reload_eviction.yaml");
-    let mut proxy_bin = root.join("target/release/llamesh");
-    if !proxy_bin.exists() {
-        let debug_bin = root.join("target/debug/llamesh");
-        if debug_bin.exists() {
-            proxy_bin = debug_bin;
-        }
-    }
+    let proxy_bin = llamesh_binary(&root);
 
     tokio::fs::write(&config_path, config_yaml(&mock_script))
         .await
@@ -317,7 +307,7 @@ async fn reload_drains_orphaned_instances() {
     spawn_instance_for(&client, "mock-model:default").await;
 
     let resp = client
-        .get(format!("{}/cluster/nodes", BASE_URL))
+        .get(format!("{BASE_URL}/cluster/nodes"))
         .send()
         .await
         .unwrap();
@@ -330,8 +320,7 @@ async fn reload_drains_orphaned_instances() {
         loaded
             .iter()
             .any(|m| m.as_str() == Some("mock-model:default")),
-        "expected mock-model:default to be loaded, got {:?}",
-        loaded
+        "expected mock-model:default to be loaded, got {loaded:?}"
     );
 
     // Case 1 uses an in-place write (the OpenAI-text-editor path).

--- a/tests/loop_prevention_test.rs
+++ b/tests/loop_prevention_test.rs
@@ -3,24 +3,18 @@ use common::*;
 use reqwest::StatusCode;
 
 async fn start_mock_node(suffix: &str, port_offset: u16) -> (tokio::process::Child, String) {
-    let id = format!("loop-{}", suffix);
+    let id = format!("loop-{suffix}");
     let port = 14000 + port_offset;
-    let listen = format!("127.0.0.1:{}", port);
+    let listen = format!("127.0.0.1:{port}");
 
-    cleanup_procs(&format!("config_{}.yaml", id)).await;
-    cleanup_by_port_range_pattern(&format!("150{}", port_offset)).await; // Mock server ports
+    cleanup_procs(&format!("config_{id}.yaml")).await;
+    cleanup_by_port_range_pattern(&format!("150{port_offset}")).await; // Mock server ports
 
     let root = std::env::current_dir().unwrap();
     let mock_script = setup_mock_script(&root, &id).await;
-    let config_path = root.join(format!("tests/config_{}.yaml", id));
-    let cookbook_path = root.join(format!("tests/cookbook_{}.yaml", id));
-    let mut proxy_bin = root.join("target/release/llamesh");
-    if !proxy_bin.exists() {
-        let debug_bin = root.join("target/debug/llamesh");
-        if debug_bin.exists() {
-            proxy_bin = debug_bin;
-        }
-    }
+    let config_path = root.join(format!("tests/config_{id}.yaml"));
+    let cookbook_path = root.join(format!("tests/cookbook_{id}.yaml"));
+    let proxy_bin = llamesh_binary(&root);
 
     let config_content = format!(
         r#"
@@ -90,7 +84,7 @@ models:
         .spawn()
         .expect("Failed to start proxy");
 
-    let addr = format!("http://{}", listen);
+    let addr = format!("http://{listen}");
     assert!(wait_for_ready(&addr).await, "Proxy failed to become ready");
 
     (proxy_process, addr)
@@ -102,7 +96,7 @@ async fn test_loop_prevention_rejects_too_many_hops() {
     let client = reqwest::Client::new();
 
     let resp = client
-        .post(format!("{}/v1/chat/completions", addr))
+        .post(format!("{addr}/v1/chat/completions"))
         .header("X-Llama-Mesh-Hops", "11")
         .json(&serde_json::json!({
             "model": "mock-model:default",
@@ -130,7 +124,7 @@ async fn test_loop_prevention_allows_few_hops() {
     let client = reqwest::Client::new();
 
     let resp = client
-        .post(format!("{}/v1/chat/completions", addr))
+        .post(format!("{addr}/v1/chat/completions"))
         .header("X-Llama-Mesh-Hops", "5")
         .json(&serde_json::json!({
             "model": "mock-model:default",

--- a/tests/stress_test.rs
+++ b/tests/stress_test.rs
@@ -4,8 +4,8 @@ use std::time::{Duration, Instant};
 
 mod common;
 use common::{
-    cleanup_by_port_range_pattern, cleanup_procs, graceful_stop, load_cookbook_fixture,
-    setup_mock_script, wait_for_ready,
+    cleanup_by_port_range_pattern, cleanup_procs, graceful_stop, llamesh_binary,
+    load_cookbook_fixture, setup_mock_script, wait_for_ready,
 };
 
 /// Retry a request up to `max_retries` times on transient errors
@@ -44,13 +44,7 @@ async fn test_stress_basic() {
     let mock_script = setup_mock_script(&root, "stress").await;
     let config_path = root.join("tests/config_stress.yaml");
     let cookbook_path = root.join("tests/cookbook_stress.yaml");
-    let mut proxy_bin = root.join("target/release/llamesh");
-    if !proxy_bin.exists() {
-        let debug_bin = root.join("target/debug/llamesh");
-        if debug_bin.exists() {
-            proxy_bin = debug_bin;
-        }
-    }
+    let proxy_bin = llamesh_binary(&root);
 
     let config_content = format!(
         r#"
@@ -163,7 +157,7 @@ http:
 
     let duration = start.elapsed();
     println!("Total time: {:.2}s", duration.as_secs_f64());
-    println!("Successful: {}/{}", success, num_requests);
+    println!("Successful: {success}/{num_requests}");
     if success > 0 {
         println!(
             "Avg Latency: {:.2}ms",
@@ -179,11 +173,7 @@ http:
     let min_success = (num_requests * 3) / 4;
     assert!(
         success >= min_success,
-        "Expected at least 75% success ({}/{}), got {}/{}",
-        min_success,
-        num_requests,
-        success,
-        num_requests
+        "Expected at least 75% success ({min_success}/{num_requests}), got {success}/{num_requests}"
     );
 
     graceful_stop(&mut proxy_process).await;


### PR DESCRIPTION
## Summary
- Release llamesh v1.3.0 with Noise-backed authenticated peer forwarding, including streaming support.
- Harden cluster transport so plain HTTP gossip is rejected when Noise is required, peer keys can be pinned with TOFU disabled, and X25519 `noise25519:` identities are first-class while retaining legacy compatibility.
- Fix stale queue accounting across cancellation, timeout, and shutdown paths, and make port-pool tests deterministic without weakening runtime OS-port checks.
- Refresh dependencies, remove vulnerable/obsolete stacks, update docs/config examples, and record the release in the changelog.

## Validation
- `cargo +1.88.0 fmt --all --check`
- `cargo audit`
- `git diff --check`
- `cargo +1.88.0 metadata --locked --no-deps`
- `cargo +1.88.0 clippy --locked --all-targets --all-features -- -D warnings`
- `cargo +1.88.0 test --locked --all-targets --all-features`
- `cargo +1.88.0 test --release --locked --all-targets --all-features`

Closes #19
Closes #20
Closes #21
