### PR TITLE
fix: prevent embedding queue_full on idle backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.2] - 2026-04-27
+
+### Fixed
+
+- Treat `stream: true` as a streaming response only on text-generation
+  endpoints. Embedding and rerank requests now use non-streaming cleanup and
+  strip the unsupported `stream` flag before forwarding, preventing stuck
+  request accounting from keeping an idle embedding instance alive.
+- Request queues now prune abandoned waiters and wake queued requests when an
+  existing ready instance has available capacity before rejecting a fresh
+  request as `queue_full`.
+
 ## [1.3.1] - 2026-04-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.3.1"
+version = "1.3.2"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -1091,6 +1091,24 @@ impl NodeState {
             // FAIRNESS CHECK: Fresh requests must yield to queued/pending waiters
             // Notified waiters (with token) skip this check to claim their priority slot
             if my_token.is_none() && self.has_pending_waiters(model_name, &profile.id).await {
+                let woken = self
+                    .notify_waiters_for_available_slots(model_name, &profile.id)
+                    .await;
+                if woken > 0 {
+                    info!(
+                        event = "queue_wake_available_capacity",
+                        model = %model_name,
+                        profile = %profile.id,
+                        woken = woken
+                    );
+                }
+
+                // If the only waiters were stale closed receivers, the wake pass
+                // has pruned them and this request can try normal dispatch.
+                if !self.has_pending_waiters(model_name, &profile.id).await {
+                    continue;
+                }
+
                 // There are waiters ahead of us - join the queue instead of trying to grab slot
                 let key = format!("{}:{}", model_name, profile.id);
                 let (tx, rx) = oneshot::channel();
@@ -1110,6 +1128,14 @@ impl NodeState {
                     }
 
                     let queue = queues.entry(key.clone()).or_insert_with(VecDeque::new);
+                    let removed = Self::remove_closed_queue_entries(queue);
+                    if removed > 0 {
+                        info!(
+                            event = "queue_prune_closed",
+                            model = %model_name,
+                            removed = removed
+                        );
+                    }
                     let max_queue = profile.effective_max_queue_size(&self.config.model_defaults);
                     // 0 = unlimited queue size
                     if max_queue > 0 && queue.len() >= max_queue {
@@ -1369,6 +1395,14 @@ impl NodeState {
                             }
 
                             let queue = queues.entry(key.clone()).or_insert_with(VecDeque::new);
+                            let removed = Self::remove_closed_queue_entries(queue);
+                            if removed > 0 {
+                                info!(
+                                    event = "queue_prune_closed",
+                                    model = %model_name,
+                                    removed = removed
+                                );
+                            }
                             let max_queue =
                                 profile.effective_max_queue_size(&self.config.model_defaults);
                             // 0 = unlimited queue size
@@ -2382,6 +2416,78 @@ impl NodeState {
         false
     }
 
+    fn remove_closed_queue_entries(queue: &mut VecDeque<QueueEntry>) -> usize {
+        let before = queue.len();
+        queue.retain(|entry| !entry.tx.is_closed());
+        before - queue.len()
+    }
+
+    async fn pending_token_count(&self, key: &str) -> usize {
+        let pending = self.pending_tokens.read().await;
+        pending.get(key).map(|set| set.len()).unwrap_or(0)
+    }
+
+    async fn available_ready_slots_for_model(&self, model_name: &str, profile_id: &str) -> usize {
+        let max_concurrent = self
+            .config
+            .model_defaults
+            .max_concurrent_requests_per_instance;
+        let instances = self.instances.read().await;
+        let mut available = 0usize;
+
+        for inst_lock in instances.values() {
+            let inst = inst_lock.read().await;
+            if inst.model_name != model_name || inst.profile_id != profile_id {
+                continue;
+            }
+            if !inst.is_alive() || inst.draining.load(Ordering::Relaxed) {
+                continue;
+            }
+            if *inst.status.lock() != InstanceStatus::Ready {
+                continue;
+            }
+
+            if max_concurrent == 0 {
+                available = available.saturating_add(1);
+            } else if inst.in_flight_requests < max_concurrent {
+                available = available.saturating_add(max_concurrent - inst.in_flight_requests);
+            }
+        }
+
+        available
+    }
+
+    async fn notify_waiters_for_available_slots(
+        &self,
+        model_name: &str,
+        profile_id: &str,
+    ) -> usize {
+        let key = format!("{model_name}:{profile_id}");
+        let available = self
+            .available_ready_slots_for_model(model_name, profile_id)
+            .await;
+        if available == 0 {
+            return 0;
+        }
+
+        let pending = self.pending_token_count(&key).await;
+        let wake_budget = available.saturating_sub(pending);
+        if wake_budget == 0 {
+            return 0;
+        }
+
+        let mut woken = 0usize;
+        for _ in 0..wake_budget {
+            if self.notify_queue(model_name, profile_id).await {
+                woken += 1;
+            } else {
+                break;
+            }
+        }
+
+        woken
+    }
+
     /// Remove a pending token after waiter successfully acquires slot or times out.
     async fn remove_pending_token(&self, model_name: &str, profile_id: &str, token: u64) {
         let key = format!("{model_name}:{profile_id}");
@@ -2418,7 +2524,7 @@ impl NodeState {
     /// Pops waiters from the queue until one successfully receives the notification.
     /// Dropped/closed receivers are skipped. Promotes the queued token to pending
     /// for the notified waiter.
-    pub async fn notify_queue(&self, model_name: &str, profile_id: &str) {
+    pub async fn notify_queue(&self, model_name: &str, profile_id: &str) -> bool {
         let key = format!("{model_name}:{profile_id}");
         // LOCK_ORDER: queues (2) - will release before pending_tokens (3)
         let mut queues = self.queues.write().await;
@@ -2434,11 +2540,12 @@ impl NodeState {
                     pending.entry(key).or_default().insert(token);
                     self.metrics.inc_pending_tokens();
                     info!(event = "queue_dequeue", model = %model_name, token = token);
-                    return;
+                    return true;
                 }
                 // Receiver dropped, try next waiter (token not added to pending)
             }
         }
+        false
     }
 
     /// Notify one waiter per model that capacity is available.
@@ -3028,6 +3135,14 @@ mod tests {
         }
     }
 
+    fn attach_live_test_child(inst: &Instance) {
+        let child = tokio::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .expect("spawn sleep test child");
+        *inst.child.lock() = Some(child);
+    }
+
     fn gpu_snapshot(used_mb: u64, total_mb: u64) -> GpuMemorySnapshot {
         GpuMemorySnapshot {
             used_mb,
@@ -3230,6 +3345,103 @@ mod tests {
 
         let pending = state.pending_tokens.read().await;
         assert!(pending.get(&key).is_some_and(|set| set.contains(&token)));
+    }
+
+    #[tokio::test]
+    async fn notify_waiters_for_available_slots_wakes_queued_waiter() {
+        let mut config = minimal_node_config();
+        config.cluster.enabled = false;
+        config.model_defaults.max_concurrent_requests_per_instance = 1;
+        let build_manager = BuildManager::new(config.llama_cpp.clone());
+        let state = NodeState::new(config, Cookbook { models: vec![] }, build_manager)
+            .await
+            .unwrap();
+
+        let inst = Instance::new(
+            "inst-a".into(),
+            "test".into(),
+            "default".into(),
+            "127.0.0.1".into(),
+            8000,
+            "hash".into(),
+            false,
+        );
+        *inst.status.lock() = InstanceStatus::Ready;
+        attach_live_test_child(&inst);
+        state
+            .instances
+            .write()
+            .await
+            .insert("inst-a".into(), Arc::new(RwLock::new(inst)));
+
+        let key = "test:default".to_string();
+        let token = 44;
+        let (tx, rx) = oneshot::channel();
+        {
+            let mut queues = state.queues.write().await;
+            queues.insert(key.clone(), VecDeque::from([QueueEntry { token, tx }]));
+        }
+
+        let woken = state
+            .notify_waiters_for_available_slots("test", "default")
+            .await;
+
+        assert_eq!(woken, 1);
+        assert_eq!(rx.await.unwrap(), token);
+        let queues = state.queues.read().await;
+        assert!(queues.get(&key).is_some_and(|queue| queue.is_empty()));
+        drop(queues);
+
+        let pending = state.pending_tokens.read().await;
+        assert!(pending.get(&key).is_some_and(|set| set.contains(&token)));
+    }
+
+    #[tokio::test]
+    async fn get_instance_prunes_closed_waiter_before_queue_full() {
+        let mut config = minimal_node_config();
+        config.cluster.enabled = false;
+        config.model_defaults.max_concurrent_requests_per_instance = 1;
+        config.model_defaults.max_queue_size_per_model = 1;
+        let build_manager = BuildManager::new(config.llama_cpp.clone());
+        let state = NodeState::new(config, Cookbook { models: vec![] }, build_manager)
+            .await
+            .unwrap();
+
+        let profile = sample_profile();
+        let inst = Instance::new(
+            "inst-a".into(),
+            "test".into(),
+            "default".into(),
+            "127.0.0.1".into(),
+            8000,
+            "hash".into(),
+            false,
+        );
+        *inst.status.lock() = InstanceStatus::Ready;
+        attach_live_test_child(&inst);
+        state
+            .instances
+            .write()
+            .await
+            .insert("inst-a".into(), Arc::new(RwLock::new(inst)));
+
+        let key = "test:default".to_string();
+        let (tx, rx) = oneshot::channel();
+        drop(rx);
+        {
+            let mut queues = state.queues.write().await;
+            queues.insert(key.clone(), VecDeque::from([QueueEntry { token: 45, tx }]));
+        }
+
+        let instance = state
+            .get_instance_for_model("test", &profile, true)
+            .await
+            .expect("closed queue entry should be pruned before queue capacity is enforced");
+
+        assert_eq!(instance.read().await.id, "inst-a");
+        assert_eq!(instance.read().await.in_flight_requests, 1);
+        let queues = state.queues.read().await;
+        assert!(queues.get(&key).is_none_or(|queue| queue.is_empty()));
     }
 
     #[tokio::test]

--- a/src/router.rs
+++ b/src/router.rs
@@ -360,11 +360,17 @@ pub async fn route_request(
         .map(|s| s.to_string())
         .unwrap_or_else(|| state.config.default_model.clone());
 
-    // Check if streaming is requested
-    let stream_requested = json_body
+    // Only text-generation endpoints have a streaming response shape. Some
+    // OpenAI clients include `stream` on all requests; embeddings/rerank must
+    // still use non-streaming cleanup semantics.
+    let client_stream_requested = json_body
         .get("stream")
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
+    let response_streaming =
+        response_streaming_for_endpoint(endpoint_kind, client_stream_requested);
+    let forward_body =
+        request_body_for_endpoint(&json_body, endpoint_kind, client_stream_requested, &bytes);
 
     let session_id = parts
         .headers
@@ -445,7 +451,7 @@ pub async fn route_request(
                         method: parts.method.clone(),
                         path_and_query: &path_and_query,
                         headers: forward_headers,
-                        body: bytes.clone(),
+                        body: forward_body.clone(),
                         timeout_ms,
                     },
                 )
@@ -481,7 +487,7 @@ pub async fn route_request(
                         let tokens_counter = Arc::new(AtomicU64::new(0));
                         return Ok(peer_response_to_client(
                             resp,
-                            stream_requested,
+                            response_streaming,
                             cleanup_fut,
                             tokens_counter,
                         )
@@ -596,6 +602,8 @@ pub async fn route_request(
 
                     let mut headers = parts.headers.clone();
                     headers.remove(axum::http::header::HOST);
+                    headers.remove(axum::http::header::CONTENT_LENGTH);
+                    headers.remove(axum::http::header::TRANSFER_ENCODING);
 
                     // Inject authorization if the profile defines an API key
                     if let Some(api_key) = profile.get_api_key() {
@@ -618,7 +626,7 @@ pub async fn route_request(
                         .http_client
                         .request(parts.method, &url)
                         .headers(headers)
-                        .body(bytes);
+                        .body(forward_body.clone());
 
                     if timeout_ms > 0 {
                         client_req = client_req.timeout(Duration::from_millis(timeout_ms));
@@ -713,7 +721,7 @@ pub async fn route_request(
                             // Transfer responsibility to cleanup_fut
                             guard.complete();
 
-                            Ok(if stream_requested {
+                            Ok(if response_streaming {
                                 build_streaming_response(resp, cleanup_fut, tokens_counter)
                             } else {
                                 handle_non_streaming_response(resp, cleanup_fut, tokens_counter)
@@ -762,7 +770,7 @@ pub async fn route_request(
                                     method: parts.method.clone(),
                                     path_and_query: &path_and_query,
                                     headers: forward_headers,
-                                    body: bytes.clone(),
+                                    body: forward_body.clone(),
                                     timeout_ms,
                                 },
                             )
@@ -800,7 +808,7 @@ pub async fn route_request(
 
                                     return Ok(peer_response_to_client(
                                         resp,
-                                        stream_requested,
+                                        response_streaming,
                                         cleanup_fut,
                                         tokens_counter,
                                     )
@@ -878,7 +886,7 @@ pub async fn route_request(
                     method: parts.method.clone(),
                     path_and_query: &path_and_query,
                     headers: forward_headers,
-                    body: bytes.clone(),
+                    body: forward_body.clone(),
                     timeout_ms,
                 },
             )
@@ -917,8 +925,13 @@ pub async fn route_request(
                     // Transfer responsibility to cleanup_fut
                     guard.complete();
 
-                    Ok(peer_response_to_client(resp, stream_requested, cleanup_fut, tokens_counter)
-                        .await)
+                    Ok(peer_response_to_client(
+                        resp,
+                        response_streaming,
+                        cleanup_fut,
+                        tokens_counter,
+                    )
+                    .await)
                 }
                 Err(e) => {
                     // peer_forward_guard drops here, releasing the counter.
@@ -1414,7 +1427,7 @@ where
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum EndpointKind {
     Text,
     Embeddings,
@@ -1434,6 +1447,39 @@ impl EndpointKind {
             EndpointKind::Other
         }
     }
+}
+
+fn response_streaming_for_endpoint(
+    endpoint_kind: EndpointKind,
+    client_stream_requested: bool,
+) -> bool {
+    client_stream_requested && matches!(endpoint_kind, EndpointKind::Text)
+}
+
+fn request_body_for_endpoint(
+    json_body: &Value,
+    endpoint_kind: EndpointKind,
+    client_stream_requested: bool,
+    original: &Bytes,
+) -> Bytes {
+    if !client_stream_requested
+        || !matches!(
+            endpoint_kind,
+            EndpointKind::Embeddings | EndpointKind::Rerank
+        )
+    {
+        return original.clone();
+    }
+
+    let Some(object) = json_body.as_object() else {
+        return original.clone();
+    };
+
+    let mut sanitized = object.clone();
+    sanitized.remove("stream");
+    serde_json::to_vec(&Value::Object(sanitized))
+        .map(Bytes::from)
+        .unwrap_or_else(|_| original.clone())
 }
 
 fn ensure_profile_supports_endpoint(
@@ -1561,6 +1607,35 @@ mod tests {
             EndpointKind::from_path("/other"),
             EndpointKind::Other
         ));
+    }
+
+    #[test]
+    fn test_response_streaming_is_text_endpoint_only() {
+        assert!(response_streaming_for_endpoint(EndpointKind::Text, true));
+        assert!(!response_streaming_for_endpoint(EndpointKind::Text, false));
+        assert!(!response_streaming_for_endpoint(
+            EndpointKind::Embeddings,
+            true
+        ));
+        assert!(!response_streaming_for_endpoint(EndpointKind::Rerank, true));
+        assert!(!response_streaming_for_endpoint(EndpointKind::Other, true));
+    }
+
+    #[test]
+    fn test_request_body_strips_stream_from_non_text_endpoints() {
+        let body = json!({
+            "model": "embedding-model",
+            "input": "hello",
+            "stream": true
+        });
+        let original = Bytes::from(serde_json::to_vec(&body).unwrap());
+
+        let sanitized = request_body_for_endpoint(&body, EndpointKind::Embeddings, true, &original);
+        let sanitized_json: Value = serde_json::from_slice(&sanitized).unwrap();
+        assert!(sanitized_json.get("stream").is_none());
+
+        let text_body = request_body_for_endpoint(&body, EndpointKind::Text, true, &original);
+        assert_eq!(text_body, original);
     }
 
     // Compile-time validation of buffer size bounds


### PR DESCRIPTION
## Summary

Fixes #24.

This patch closes two related queue/accounting failure modes:

- Treats `stream: true` as a streaming response only for text-generation endpoints. Embedding and rerank requests now use non-streaming cleanup semantics and strip the unsupported `stream` flag before forwarding.
- Prunes abandoned queue waiters and wakes queued requests when a ready instance has available capacity before rejecting a fresh request as `queue_full`.
- Bumps the crate version to `1.3.2` and records the fix in the changelog.

## Root Cause

The router previously let a request-body `stream` flag choose the response cleanup mode for every endpoint. Non-text endpoints could therefore defer cleanup/accounting to downstream body consumption even though embeddings and rerank responses are not streaming API shapes. Separately, the fairness queue checked queued/pending waiters before pruning stale queue entries or waking waiters for an already-ready instance, so a full queue could reject new work before available capacity was re-evaluated.

## Validation

- `cargo +1.88.0 fmt --check`
- `cargo +1.88.0 test`
- `cargo +1.88.0 clippy --all-targets -- -D warnings`
- `cargo +1.88.0 build --release`
- Deployed PR head `f3b0e0e` to a two-node live mesh; both nodes reported `/version` `1.3.2` and `/healthz` `ok`.
- Embedding probe using `Qwen3-Embedding-8B` with `stream: true` returned HTTP 200 on both routing paths: peer-forwarded path `0.414339s`, direct-host path `0.146683s`; both returned one 4096-dimensional embedding and `usage.total_tokens = 4`.
- Post-probe state showed `Qwen3-Embedding-8B` no longer loaded after idle timeout and no remaining embedding backend process.
- Post-deploy logs contained `0` `queue_drop` / `queue_full` events for `Qwen3-Embedding-8B` on both nodes.
