### PR TITLE
fix: prevent request accounting leaks after cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.3] - 2026-04-28
+
+### Fixed
+
+- Queue priority tokens are now owned by cancellation-safe permits after a
+  waiter is dequeued. If the waiting request is cancelled before it acquires
+  capacity or requeues, the pending token is removed automatically so stale
+  fairness state cannot permanently block fresh dispatch.
+- Local response cleanup now releases request and instance accounting before
+  awaiting drain or queue state. This preserves graceful drain scheduling while
+  avoiding a lock-order inversion that could leave an idle backend appearing
+  full after cancelled or completed non-streaming work.
+- Non-streaming Noise peer responses now install cleanup before buffering the
+  peer body, so client cancellation after peer headers arrive cannot leak node
+  request accounting or peer-forward slots.
+- Drain cancellation checks no longer hold individual instance locks while
+  awaiting queue state.
+
 ## [1.3.2] - 2026-04-27
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.3.2"
+version = "1.3.3"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -143,7 +143,95 @@ use crate::security;
 
 pub struct QueueEntry {
     token: u64,
-    tx: oneshot::Sender<u64>,
+    tx: oneshot::Sender<PendingQueuePermit>,
+}
+
+/// Owns a promoted queue token until the request either acquires capacity,
+/// requeues, errors, or is cancelled.
+pub struct PendingQueuePermit {
+    key: String,
+    token: u64,
+    pending_tokens: Arc<RwLock<HashMap<String, HashSet<u64>>>>,
+    metrics: Arc<Metrics>,
+    released: bool,
+}
+
+impl PendingQueuePermit {
+    fn new(
+        key: String,
+        token: u64,
+        pending_tokens: Arc<RwLock<HashMap<String, HashSet<u64>>>>,
+        metrics: Arc<Metrics>,
+    ) -> Self {
+        Self {
+            key,
+            token,
+            pending_tokens,
+            metrics,
+            released: false,
+        }
+    }
+
+    async fn release(&mut self) {
+        if self.released {
+            return;
+        }
+        remove_pending_token_from(
+            self.pending_tokens.clone(),
+            self.metrics.clone(),
+            self.key.clone(),
+            self.token,
+        )
+        .await;
+        self.released = true;
+    }
+}
+
+impl Drop for PendingQueuePermit {
+    fn drop(&mut self) {
+        if self.released {
+            return;
+        }
+
+        let pending_tokens = self.pending_tokens.clone();
+        let metrics = self.metrics.clone();
+        let key = self.key.clone();
+        let token = self.token;
+
+        match tokio::runtime::Handle::try_current() {
+            Ok(handle) => {
+                handle.spawn(async move {
+                    remove_pending_token_from(pending_tokens, metrics, key, token).await;
+                });
+            }
+            Err(_) => {
+                warn!(
+                    token = token,
+                    model_key = %key,
+                    "Pending queue token cleanup skipped: tokio runtime unavailable during drop"
+                );
+            }
+        }
+    }
+}
+
+async fn remove_pending_token_from(
+    pending_tokens: Arc<RwLock<HashMap<String, HashSet<u64>>>>,
+    metrics: Arc<Metrics>,
+    key: String,
+    token: u64,
+) {
+    let mut pending = pending_tokens.write().await;
+    let mut remove_empty = false;
+    if let Some(set) = pending.get_mut(&key) {
+        if set.remove(&token) {
+            metrics.dec_pending_tokens();
+        }
+        remove_empty = set.is_empty();
+    }
+    if remove_empty {
+        pending.remove(&key);
+    }
 }
 
 /// Drop-guard that decrements a per-peer pending-forward counter. Ensures the
@@ -1043,8 +1131,9 @@ impl NodeState {
         // (e.g., missing shared libraries, bad binary path).
         let mut consecutive_spawn_failures = 0u32;
 
-        // Token for this request - None = fresh request, Some = notified waiter with priority
-        let mut my_token: Option<u64> = None;
+        // Token for this request - None = fresh request, Some = notified waiter with priority.
+        // The permit owns pending-token cleanup if this future is cancelled.
+        let mut my_token: Option<PendingQueuePermit> = None;
         // Track when we first started waiting in queue (for metrics)
         let mut queue_start: Option<std::time::Instant> = None;
 
@@ -1055,9 +1144,8 @@ impl NodeState {
             // one more try — if it still fails, the binary is likely broken.
             const MAX_LOCAL_SPAWN_FAILURES: u32 = 3;
             if consecutive_spawn_failures >= MAX_LOCAL_SPAWN_FAILURES {
-                if let Some(token) = my_token {
-                    self.remove_pending_token(model_name, &profile.id, token)
-                        .await;
+                if let Some(mut token) = my_token.take() {
+                    token.release().await;
                 }
                 warn!(
                     event = "spawn_failures_exhausted",
@@ -1070,9 +1158,8 @@ impl NodeState {
             }
             // If node is draining, stop waiting and let the request fail fast
             if self.draining.load(Ordering::Relaxed) {
-                if let Some(token) = my_token {
-                    self.remove_pending_token(model_name, &profile.id, token)
-                        .await;
+                if let Some(mut token) = my_token.take() {
+                    token.release().await;
                 }
                 return Err(NodeError::Other(anyhow::anyhow!("Node is shutting down")));
             }
@@ -1080,9 +1167,8 @@ impl NodeState {
             if let Some(timeout) = queue_timeout {
                 if loop_start.elapsed() > timeout {
                     // Clean up pending token if we have one
-                    if let Some(token) = my_token {
-                        self.remove_pending_token(model_name, &profile.id, token)
-                            .await;
+                    if let Some(mut token) = my_token.take() {
+                        token.release().await;
                     }
                     return Err(NodeError::QueueTimeout);
                 }
@@ -1206,9 +1292,8 @@ impl NodeState {
             {
                 Ok(inst) => {
                     // Successfully acquired slot - clean up pending token and record metrics
-                    if let Some(token) = my_token.take() {
-                        self.remove_pending_token(model_name, &profile.id, token)
-                            .await;
+                    if let Some(mut token) = my_token.take() {
+                        token.release().await;
                     }
                     // Record queue wait time if we waited
                     if let Some(start) = queue_start {
@@ -1372,9 +1457,8 @@ impl NodeState {
                         );
 
                         // If we had a token but failed to acquire, clear it before re-queueing
-                        if let Some(token) = my_token.take() {
-                            self.remove_pending_token(model_name, &profile.id, token)
-                                .await;
+                        if let Some(mut token) = my_token.take() {
+                            token.release().await;
                         }
 
                         let key = format!("{}:{}", model_name, profile.id);
@@ -1480,9 +1564,8 @@ impl NodeState {
                         }
                     } else {
                         // Clean up token for non-retriable errors
-                        if let Some(token) = my_token {
-                            self.remove_pending_token(model_name, &profile.id, token)
-                                .await;
+                        if let Some(mut token) = my_token.take() {
+                            token.release().await;
                         }
                         return Err(e);
                     }
@@ -2491,12 +2574,13 @@ impl NodeState {
     /// Remove a pending token after waiter successfully acquires slot or times out.
     async fn remove_pending_token(&self, model_name: &str, profile_id: &str, token: u64) {
         let key = format!("{model_name}:{profile_id}");
-        let mut pending = self.pending_tokens.write().await;
-        if let Some(set) = pending.get_mut(&key) {
-            if set.remove(&token) {
-                self.metrics.dec_pending_tokens();
-            }
-        }
+        remove_pending_token_from(
+            self.pending_tokens.clone(),
+            self.metrics.clone(),
+            key,
+            token,
+        )
+        .await;
     }
 
     /// Remove a queued waiter by its preassigned token. This is used on timeout
@@ -2526,65 +2610,76 @@ impl NodeState {
     /// for the notified waiter.
     pub async fn notify_queue(&self, model_name: &str, profile_id: &str) -> bool {
         let key = format!("{model_name}:{profile_id}");
-        // LOCK_ORDER: queues (2) - will release before pending_tokens (3)
-        let mut queues = self.queues.write().await;
-        if let Some(queue) = queues.get_mut(&key) {
-            while let Some(entry) = queue.pop_front() {
-                let token = entry.token;
-
-                if entry.tx.send(token).is_ok() {
-                    // Successfully sent - add token to pending set
-                    // LOCK_ORDER: Must drop queues (2) before acquiring pending_tokens (3)
-                    drop(queues);
-                    let mut pending = self.pending_tokens.write().await;
-                    pending.entry(key).or_default().insert(token);
-                    self.metrics.inc_pending_tokens();
-                    info!(event = "queue_dequeue", model = %model_name, token = token);
-                    return true;
-                }
-                // Receiver dropped, try next waiter (token not added to pending)
-            }
-        }
-        false
+        self.notify_queue_by_key(&key).await
     }
 
     /// Notify one waiter per model that capacity is available.
     /// Called when overall node capacity frees up (e.g., instance crash, eviction).
     pub async fn notify_all_queues(&self) {
-        // LOCK_ORDER: queues (2) - will release before pending_tokens (3)
-        let mut queues = self.queues.write().await;
-        let mut tokens_to_add: Vec<(String, u64)> = Vec::new();
+        let keys: Vec<String> = {
+            let queues = self.queues.read().await;
+            queues.keys().cloned().collect()
+        };
 
-        for (key, queue) in queues.iter_mut() {
-            while let Some(entry) = queue.pop_front() {
-                let token = entry.token;
-                if entry.tx.send(token).is_ok() {
-                    tokens_to_add.push((key.clone(), token));
-                    info!(event = "queue_dequeue", model_key = %key, token = token);
-                    break; // Wake one waiter per model
-                }
-                // Receiver dropped, try next waiter
-            }
-        }
-        // LOCK_ORDER: Must drop queues (2) before acquiring pending_tokens (3)
-        drop(queues);
-
-        // Add all pending tokens in one lock acquisition
-        if !tokens_to_add.is_empty() {
-            let count = tokens_to_add.len();
-            // LOCK_ORDER: pending_tokens (3) - safe, queues already released
-            let mut pending = self.pending_tokens.write().await;
-            for (key, token) in tokens_to_add {
-                pending.entry(key).or_default().insert(token);
-            }
-            // Increment metrics for each token added
-            for _ in 0..count {
-                self.metrics.inc_pending_tokens();
-            }
+        for key in keys {
+            self.notify_queue_by_key(&key).await;
         }
 
         // Wake any cluster-aware waiters (route_or_wait callers)
         self.capacity_notify.notify_waiters();
+    }
+
+    async fn notify_queue_by_key(&self, key: &str) -> bool {
+        loop {
+            let entry = {
+                // LOCK_ORDER: queues (2) - released before pending_tokens (3)
+                let mut queues = self.queues.write().await;
+                let Some(queue) = queues.get_mut(key) else {
+                    return false;
+                };
+                let entry = queue.pop_front();
+                if queue.is_empty() {
+                    queues.remove(key);
+                }
+                entry
+            };
+
+            let Some(entry) = entry else {
+                return false;
+            };
+
+            let permit = self
+                .promote_pending_token(key.to_string(), entry.token)
+                .await;
+            match entry.tx.send(permit) {
+                Ok(()) => {
+                    info!(event = "queue_dequeue", model_key = %key, token = entry.token);
+                    return true;
+                }
+                Err(mut returned) => {
+                    returned.release().await;
+                    // Receiver dropped; try the next queued waiter for this model.
+                }
+            }
+        }
+    }
+
+    async fn promote_pending_token(&self, key: String, token: u64) -> PendingQueuePermit {
+        {
+            // LOCK_ORDER: pending_tokens (3) - queues already released
+            let mut pending = self.pending_tokens.write().await;
+            let inserted = pending.entry(key.clone()).or_default().insert(token);
+            if inserted {
+                self.metrics.inc_pending_tokens();
+            }
+        }
+
+        PendingQueuePermit::new(
+            key,
+            token,
+            self.pending_tokens.clone(),
+            self.metrics.clone(),
+        )
     }
 
     // ── Drain Scheduling ─────────────────────────────────────────────────
@@ -2621,34 +2716,51 @@ impl NodeState {
     /// peers or timed out). Notifies the drained model's queue so its
     /// pending requests can resume being dispatched.
     pub async fn maybe_cancel_drains(&self) {
-        let instances = self.instances.read().await;
-        for inst_lock in instances.values() {
-            let inst = inst_lock.read().await;
-            if !inst.draining.load(std::sync::atomic::Ordering::Relaxed) {
-                continue;
+        let candidates: Vec<(Arc<RwLock<Instance>>, String, String, String)> = {
+            let instances = self.instances.read().await;
+            let mut candidates = Vec::new();
+            for inst_lock in instances.values() {
+                let inst = inst_lock.read().await;
+                if inst.draining.load(std::sync::atomic::Ordering::Relaxed) {
+                    candidates.push((
+                        inst_lock.clone(),
+                        inst.model_name.clone(),
+                        inst.profile_id.clone(),
+                        inst.id.clone(),
+                    ));
+                }
             }
+            candidates
+        };
+
+        for (inst_lock, model_name, profile_id, instance_id) in candidates {
             if self
-                .has_queued_competitors_needing_eviction(&inst.model_name)
+                .has_queued_competitors_needing_eviction(&model_name)
                 .await
             {
                 continue;
             }
 
+            let inst = inst_lock.write().await;
+            if inst.id != instance_id
+                || inst.model_name != model_name
+                || inst.profile_id != profile_id
+                || !inst.draining.load(std::sync::atomic::Ordering::Relaxed)
+            {
+                continue;
+            }
             inst.draining
                 .store(false, std::sync::atomic::Ordering::Relaxed);
-            let model_name = inst.model_name.clone();
-            let profile_id = inst.profile_id.clone();
             info!(
                 event = "drain_cancelled",
                 model = %model_name,
                 profile = %profile_id,
-                instance_id = %inst.id,
+                instance_id = %instance_id,
                 "Drain cancelled — no more competitors needing eviction"
             );
             drop(inst);
-            drop(instances);
             self.notify_queue(&model_name, &profile_id).await;
-            return; // Released instances lock, must restart iteration
+            return;
         }
     }
 
@@ -3338,13 +3450,58 @@ mod tests {
 
         state.notify_queue("test", "default").await;
 
-        assert_eq!(rx.await.unwrap(), token);
+        let mut permit = rx.await.unwrap();
+        assert_eq!(permit.token, token);
         let queues = state.queues.read().await;
-        assert!(queues.get(&key).is_some_and(|queue| queue.is_empty()));
+        assert!(queues.get(&key).is_none_or(|queue| queue.is_empty()));
         drop(queues);
 
         let pending = state.pending_tokens.read().await;
         assert!(pending.get(&key).is_some_and(|set| set.contains(&token)));
+        drop(pending);
+
+        permit.release().await;
+        let pending = state.pending_tokens.read().await;
+        assert!(!pending.get(&key).is_some_and(|set| set.contains(&token)));
+    }
+
+    #[tokio::test]
+    async fn notify_queue_drops_pending_token_when_receiver_is_cancelled() {
+        let mut config = minimal_node_config();
+        config.cluster.enabled = false;
+        let build_manager = BuildManager::new(config.llama_cpp.clone());
+        let state = NodeState::new(config, Cookbook { models: vec![] }, build_manager)
+            .await
+            .unwrap();
+
+        let key = "test:default".to_string();
+        let token = 43;
+        let (tx, rx) = oneshot::channel();
+        {
+            let mut queues = state.queues.write().await;
+            queues.insert(key.clone(), VecDeque::from([QueueEntry { token, tx }]));
+        }
+
+        assert!(state.notify_queue("test", "default").await);
+
+        {
+            let pending = state.pending_tokens.read().await;
+            assert!(pending.get(&key).is_some_and(|set| set.contains(&token)));
+        }
+        assert_eq!(
+            state.metrics.queue_pending_tokens.load(Ordering::Relaxed),
+            1
+        );
+
+        drop(rx);
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+        let pending = state.pending_tokens.read().await;
+        assert!(!pending.get(&key).is_some_and(|set| set.contains(&token)));
+        assert_eq!(
+            state.metrics.queue_pending_tokens.load(Ordering::Relaxed),
+            0
+        );
     }
 
     #[tokio::test]
@@ -3387,13 +3544,17 @@ mod tests {
             .await;
 
         assert_eq!(woken, 1);
-        assert_eq!(rx.await.unwrap(), token);
+        let mut permit = rx.await.unwrap();
+        assert_eq!(permit.token, token);
         let queues = state.queues.read().await;
-        assert!(queues.get(&key).is_some_and(|queue| queue.is_empty()));
+        assert!(queues.get(&key).is_none_or(|queue| queue.is_empty()));
         drop(queues);
 
         let pending = state.pending_tokens.read().await;
         assert!(pending.get(&key).is_some_and(|set| set.contains(&token)));
+        drop(pending);
+
+        permit.release().await;
     }
 
     #[tokio::test]

--- a/src/router.rs
+++ b/src/router.rs
@@ -643,56 +643,70 @@ pub async fn route_request(
                                 let hash_metrics = hash_metrics.clone();
 
                                 Box::pin(async move {
-                                    let (model_name, profile_id, became_idle) = {
+                                    let (
+                                        model_name,
+                                        profile_id,
+                                        instance_id,
+                                        became_idle,
+                                        was_draining,
+                                        tenure_expired,
+                                    ) = {
                                         let mut inst = instance_lock.write().await;
                                         inst.in_flight_requests =
                                             inst.in_flight_requests.saturating_sub(1);
                                         let idle = inst.in_flight_requests == 0;
+                                        let was_draining = inst.draining.load(Ordering::Relaxed);
+                                        let tenure_expired = inst
+                                            .evictable_after
+                                            .lock()
+                                            .map(|t| std::time::Instant::now() >= t)
+                                            .unwrap_or(false);
+                                        (
+                                            inst.model_name.clone(),
+                                            inst.profile_id.clone(),
+                                            inst.id.clone(),
+                                            idle,
+                                            was_draining,
+                                            tenure_expired,
+                                        )
+                                    };
+                                    state.metrics.dec_current_requests();
 
-                                        // ── Drain scheduling ────────────────────────────
-                                        // Check if this instance should be drained for a
-                                        // queued competitor that needs its VRAM.
-                                        if !inst.draining.load(Ordering::Relaxed) {
-                                            let dominated = state
-                                                .has_queued_competitors_needing_eviction(
-                                                    &inst.model_name,
-                                                )
-                                                .await;
-                                            if dominated {
-                                                let tenure_expired = inst
-                                                    .evictable_after
-                                                    .lock()
-                                                    .map(|t| std::time::Instant::now() >= t)
-                                                    .unwrap_or(false);
-                                                let own_queue_empty = idle
-                                                    && !state
-                                                        .has_pending_for_model(
-                                                            &inst.model_name,
-                                                            &inst.profile_id,
-                                                        )
-                                                        .await;
+                                    // ── Drain scheduling ────────────────────────────
+                                    // Do not hold the instance lock while checking queues:
+                                    // NodeState's lock order requires queues before
+                                    // individual instance locks.
+                                    if !was_draining {
+                                        let dominated = state
+                                            .has_queued_competitors_needing_eviction(&model_name)
+                                            .await;
+                                        if dominated {
+                                            let own_queue_empty = became_idle
+                                                && !state
+                                                    .has_pending_for_model(
+                                                        &model_name,
+                                                        &profile_id,
+                                                    )
+                                                    .await;
 
-                                                if tenure_expired || own_queue_empty {
+                                            if tenure_expired || own_queue_empty {
+                                                let inst = instance_lock.write().await;
+                                                if inst.id == instance_id
+                                                    && !inst.draining.load(Ordering::Relaxed)
+                                                {
                                                     inst.draining.store(true, Ordering::Relaxed);
                                                     info!(
                                                         event = "drain_triggered",
-                                                        model = %inst.model_name,
-                                                        profile = %inst.profile_id,
-                                                        instance_id = %inst.id,
+                                                        model = %model_name,
+                                                        profile = %profile_id,
+                                                        instance_id = %instance_id,
                                                         reason = if tenure_expired { "tenure_expired" } else { "queue_empty" },
                                                         "Instance marked draining for competing model"
                                                     );
                                                 }
                                             }
                                         }
-
-                                        (
-                                            inst.model_name.clone(),
-                                            inst.profile_id.clone(),
-                                            idle,
-                                        )
-                                    };
-                                    state.metrics.dec_current_requests();
+                                    }
 
                                     // Critical: If instance became idle, we must notify ALL queues.
                                     // Why? Because another model's queue might be blocked by MaxInstancesNode.
@@ -1023,7 +1037,15 @@ async fn handle_non_streaming_response(
         }
     };
 
-    // Parse for usage
+    build_non_streaming_body_response(status, headers, bytes, tokens_generated)
+}
+
+fn build_non_streaming_body_response(
+    status: StatusCode,
+    headers: HeaderMap,
+    bytes: Bytes,
+    tokens_generated: Arc<AtomicU64>,
+) -> Response<Body> {
     if let Ok(val) = serde_json::from_slice::<Value>(&bytes) {
         if let Some(usage) = val.get("usage") {
             if let Some(completion_tokens) = usage.get("completion_tokens").and_then(|v| v.as_u64())
@@ -1118,38 +1140,6 @@ where
     response
 }
 
-async fn handle_non_streaming_body(
-    status: StatusCode,
-    headers: HeaderMap,
-    bytes: Bytes,
-    cleanup: BoxFuture<'static, ()>,
-    tokens_generated: Arc<AtomicU64>,
-) -> Response<Body> {
-    let _cleanup_guard = AutoCleanup::new(cleanup);
-
-    if let Ok(val) = serde_json::from_slice::<Value>(&bytes) {
-        if let Some(usage) = val.get("usage") {
-            if let Some(completion_tokens) = usage.get("completion_tokens").and_then(|v| v.as_u64())
-            {
-                info!(
-                    "Counted {} tokens from non-streaming response",
-                    completion_tokens
-                );
-                tokens_generated.fetch_add(completion_tokens, Ordering::Relaxed);
-            }
-        } else {
-            info!("No usage field in response");
-        }
-    } else {
-        info!("Failed to parse response as JSON");
-    }
-
-    let mut response = Response::new(Body::from(bytes));
-    *response.status_mut() = status;
-    *response.headers_mut() = headers;
-    response
-}
-
 async fn peer_response_to_client(
     response: PeerResponse,
     stream_requested: bool,
@@ -1179,6 +1169,7 @@ async fn peer_response_to_client(
                     tokens_generated,
                 )
             } else {
+                let _cleanup_guard = AutoCleanup::new(cleanup);
                 match body
                     .map(|chunk| chunk.map_err(|e| std::io::Error::other(e.to_string())))
                     .try_fold(Vec::new(), |mut acc, chunk| async move {
@@ -1187,19 +1178,14 @@ async fn peer_response_to_client(
                     })
                     .await
                 {
-                    Ok(bytes) => {
-                        handle_non_streaming_body(
-                            status,
-                            headers,
-                            Bytes::from(bytes),
-                            cleanup,
-                            tokens_generated,
-                        )
-                        .await
-                    }
+                    Ok(bytes) => build_non_streaming_body_response(
+                        status,
+                        headers,
+                        Bytes::from(bytes),
+                        tokens_generated,
+                    ),
                     Err(e) => {
                         error!("Failed to read peer response body: {}", e);
-                        let _cleanup_guard = AutoCleanup::new(cleanup);
                         Response::builder()
                             .status(StatusCode::BAD_GATEWAY)
                             .body(Body::from("Failed to read peer response"))

--- a/tests/integration_test_peer_forward_cancellation.rs
+++ b/tests/integration_test_peer_forward_cancellation.rs
@@ -1,8 +1,11 @@
-//! Verifies that a cancelled request in the forward-to-peer path does not
-//! leak the node-level `current_requests` gauge. Regression coverage for the
-//! counter leak in the local-unknown-model forward handler, where a missing
-//! `RequestGuard` let the `inc_requests()` at the top of the path go
-//! unbalanced on cancellation.
+//! Verifies that cancelled requests in the forward-to-peer path do not leak
+//! the node-level `current_requests` gauge. Regression coverage for two peer
+//! forwarding cancellation sites:
+//!
+//! - forwarding before response headers arrive, where a missing `RequestGuard`
+//!   let the `inc_requests()` at the top of the path go unbalanced;
+//! - Noise peer response body buffering after response headers arrive, where
+//!   the cleanup future was not guarded before awaiting the body stream.
 //!
 //! Setup: two nodes A and B with gossip enabled. Node A owns `peer-model`,
 //! Node B does not. A client sends a request for `peer-model` to Node B with
@@ -14,7 +17,7 @@
 //! interval after the abort. Without the fix, it stays > 0 forever.
 
 use reqwest::StatusCode;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tokio::time::sleep;
 
@@ -28,6 +31,10 @@ const NODE_A_ADDR: &str = "127.0.0.1:9230";
 const NODE_B_ADDR: &str = "127.0.0.1:9231";
 const NODE_A_URL: &str = "http://127.0.0.1:9230";
 const NODE_B_URL: &str = "http://127.0.0.1:9231";
+const NODE_A_BODY_ADDR: &str = "127.0.0.1:9232";
+const NODE_B_BODY_ADDR: &str = "127.0.0.1:9233";
+const NODE_A_BODY_URL: &str = "http://127.0.0.1:9232";
+const NODE_B_BODY_URL: &str = "http://127.0.0.1:9233";
 
 fn config_node(
     node_id: &str,
@@ -100,6 +107,44 @@ models:
         max_instances: 1
         llama_server_args: ""
 "#;
+
+/// Mock-server wrapper that sends response headers promptly, then pauses
+/// halfway through the non-streaming body.
+async fn setup_slow_body_mock_script(root: &Path, suffix: &str, body_delay_ms: u64) -> PathBuf {
+    let mock_script = root.join(format!("tests/mock_server_{suffix}.sh"));
+    let mock_bin = std::env::var_os("CARGO_BIN_EXE_mock_llama_server")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            let debug_bin = root.join("target/debug/mock_llama_server");
+            if debug_bin.exists() {
+                debug_bin
+            } else {
+                root.join("target/release/mock_llama_server")
+            }
+        });
+    let script = format!(
+        r#"#!/bin/bash
+export MOCK_SLOW_BODY_MS={body_delay_ms}
+BIN="{}"
+"$BIN" "$@" &
+PID=$!
+trap "kill $PID" EXIT TERM INT
+wait $PID
+"#,
+        mock_bin.display()
+    );
+    tokio::fs::write(&mock_script, script).await.unwrap();
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = tokio::fs::metadata(&mock_script)
+        .await
+        .unwrap()
+        .permissions();
+    perms.set_mode(0o755);
+    tokio::fs::set_permissions(&mock_script, perms)
+        .await
+        .unwrap();
+    mock_script
+}
 
 async fn current_requests(client: &reqwest::Client, base_url: &str) -> u64 {
     let Ok(resp) = client.get(format!("{base_url}/metrics/json")).send().await else {
@@ -297,6 +342,161 @@ async fn cancelled_peer_forward_does_not_leak_current_requests() {
     graceful_stop(&mut proxy_b).await;
     cleanup_procs("mock_server_peer_fwd_cancel.sh").await;
     cleanup_by_port_range_pattern("1312[0-9]").await;
+    let _ = tokio::fs::remove_file(mock_script).await;
+    let _ = tokio::fs::remove_file(config_a_path).await;
+    let _ = tokio::fs::remove_file(cookbook_a_path).await;
+    let _ = tokio::fs::remove_file(config_b_path).await;
+    let _ = tokio::fs::remove_file(cookbook_b_path).await;
+}
+
+#[tokio::test]
+async fn cancelled_peer_forward_during_noise_body_buffer_does_not_leak_current_requests() {
+    cleanup_procs("mock_server_peer_fwd_body_cancel.sh").await;
+    cleanup_procs("config_peer_fwd_body_cancel").await;
+    cleanup_by_port_range_pattern("1313[0-9]").await;
+
+    let root = std::env::current_dir().unwrap();
+    let mock_script = setup_slow_body_mock_script(&root, "peer_fwd_body_cancel", 5000).await;
+
+    let config_a_path = root.join("tests/config_peer_fwd_body_cancel_a.yaml");
+    let cookbook_a_path = root.join("tests/cookbook_peer_fwd_body_cancel_a.yaml");
+    let config_b_path = root.join("tests/config_peer_fwd_body_cancel_b.yaml");
+    let cookbook_b_path = root.join("tests/cookbook_peer_fwd_body_cancel_b.yaml");
+
+    let proxy_bin = llamesh_binary(&root);
+
+    tokio::fs::write(
+        &config_a_path,
+        config_node(
+            "node-a-body-cancel",
+            NODE_A_BODY_ADDR,
+            NODE_B_BODY_URL,
+            13130,
+            13134,
+            &mock_script,
+        ),
+    )
+    .await
+    .unwrap();
+    tokio::fs::write(&cookbook_a_path, COOKBOOK_A)
+        .await
+        .unwrap();
+    tokio::fs::write(
+        &config_b_path,
+        config_node(
+            "node-b-body-cancel",
+            NODE_B_BODY_ADDR,
+            NODE_A_BODY_URL,
+            13135,
+            13139,
+            &mock_script,
+        ),
+    )
+    .await
+    .unwrap();
+    tokio::fs::write(&cookbook_b_path, COOKBOOK_B)
+        .await
+        .unwrap();
+
+    let mut proxy_a = tokio::process::Command::new(&proxy_bin)
+        .arg("--config")
+        .arg(&config_a_path)
+        .arg("--cookbook")
+        .arg(&cookbook_a_path)
+        .kill_on_drop(true)
+        .spawn()
+        .expect("failed to start proxy A");
+    let mut proxy_b = tokio::process::Command::new(&proxy_bin)
+        .arg("--config")
+        .arg(&config_b_path)
+        .arg("--cookbook")
+        .arg(&cookbook_b_path)
+        .kill_on_drop(true)
+        .spawn()
+        .expect("failed to start proxy B");
+
+    assert!(
+        wait_for_ready(NODE_A_BODY_URL).await,
+        "node A failed to ready"
+    );
+    assert!(
+        wait_for_ready(NODE_B_BODY_URL).await,
+        "node B failed to ready"
+    );
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .unwrap();
+
+    assert!(
+        wait_for_peer_discovery(
+            &client,
+            NODE_B_BODY_URL,
+            "node-a-body-cancel",
+            Duration::from_secs(15)
+        )
+        .await,
+        "node B should discover node A within 15s"
+    );
+
+    let body = serde_json::json!({
+        "model": "peer-model:default",
+        "messages": [{"role": "user", "content": "hi"}],
+    });
+
+    // Warm up the peer path and spawn A's instance so the cancellation below
+    // lands after peer response headers, inside B's Noise body buffering.
+    let warmup_resp = client
+        .post(format!("{NODE_B_BODY_URL}/v1/chat/completions"))
+        .json(&body)
+        .send()
+        .await
+        .expect("warmup forward should succeed");
+    assert_eq!(warmup_resp.status(), StatusCode::OK);
+    let _ = warmup_resp.bytes().await.expect("warmup body should read");
+
+    assert!(
+        wait_for_current_requests(&client, NODE_B_BODY_URL, 0, Duration::from_secs(10)).await,
+        "node B should have 0 in-flight requests after warmup"
+    );
+    assert!(
+        wait_for_current_requests(&client, NODE_A_BODY_URL, 0, Duration::from_secs(10)).await,
+        "node A should have 0 in-flight requests after warmup"
+    );
+
+    // The mock sends peer response headers promptly, then stalls the
+    // non-streaming body for 5s. A 1200ms client timeout cancels B while it is
+    // awaiting the peer Noise body stream.
+    let cancel_client = reqwest::Client::builder()
+        .timeout(Duration::from_millis(1200))
+        .build()
+        .unwrap();
+    let result = cancel_client
+        .post(format!("{NODE_B_BODY_URL}/v1/chat/completions"))
+        .json(&body)
+        .send()
+        .await;
+    assert!(
+        result.is_err(),
+        "short-timeout request should fail before B finishes buffering peer body"
+    );
+
+    assert!(
+        wait_for_current_requests(&client, NODE_B_BODY_URL, 0, Duration::from_secs(10)).await,
+        "node B's current_requests should return to 0 within 10s after body-buffer cancel; \
+         observed {}",
+        current_requests(&client, NODE_B_BODY_URL).await
+    );
+    assert!(
+        wait_for_current_requests(&client, NODE_A_BODY_URL, 0, Duration::from_secs(10)).await,
+        "node A should finish any peer work accepted before B's client cancelled"
+    );
+
+    graceful_stop(&mut proxy_a).await;
+    graceful_stop(&mut proxy_b).await;
+    cleanup_procs("mock_server_peer_fwd_body_cancel.sh").await;
+    cleanup_by_port_range_pattern("1313[0-9]").await;
     let _ = tokio::fs::remove_file(mock_script).await;
     let _ = tokio::fs::remove_file(config_a_path).await;
     let _ = tokio::fs::remove_file(cookbook_a_path).await;


### PR DESCRIPTION
Fixes #29

## Summary

Fixes cancellation-safety gaps in llamesh request accounting that could leave stale queue or in-flight state behind under load. The queue fix replaces raw pending-token handoff with an owned permit. The peer Noise non-streaming path now also owns cleanup before buffering the peer body, so cancellation after peer headers but before body completion cannot leak node request accounting.

## Root Cause

The previous queue implementation promoted raw token IDs into `pending_tokens` after dequeue. If the receiving request was cancelled during the promoted-token window, there was no owner responsible for removing that token.

Local response cleanup also had two related accounting hazards: local non-streaming cleanup could await queue/drain checks while holding an individual instance lock, and non-streaming Noise peer responses installed cleanup only after buffering the peer body. A client cancellation during that body-buffer await could drop the cleanup future unrun.

## Changes

- Replace raw dequeued token delivery with a cancellation-safe pending queue permit that removes its pending token on explicit release or drop.
- Preserve `notify_all_queues()` cross-model wake semantics while routing all promotion through the same permit path.
- Refactor local response cleanup to decrement `in_flight_requests` and `current_requests` before awaiting drain/queue checks.
- Refactor drain cancellation checks to avoid holding individual instance locks while awaiting queue state.
- Install cleanup before buffering non-streaming Noise peer response bodies.
- Add regression coverage for cancellation during peer Noise body buffering.
- Bump package version to `1.3.3` and update the changelog.

## Validation

- `cargo +1.88.0 fmt`
- `cargo +1.88.0 test cancelled_peer_forward_during_noise_body_buffer_does_not_leak_current_requests --test integration_test_peer_forward_cancellation`
- `cargo +1.88.0 test`
- `cargo +1.88.0 clippy --all-targets -- -D warnings`
- `cargo +1.88.0 build --release`

## Deployment Validation

- Deployed and validated this change set on the private production cluster.
- Restarted the user `llamesh.service` instances.
- All deployed services reported `/version` as `1.3.3` and active service state after restart.
- Canary embedding request returned HTTP 200 with one 4096-dimensional embedding in 442 ms.
- Five-sample metric watch after restart: `proxy_queue_pending_tokens` stayed 0, `proxy_queue_wait_count` stayed 0, `proxy_errors_total` stayed flat, and `proxy_current_requests` returned to 0 on all deployed services.
- Recent post-restart logs showed embeddings forwarded locally with backend `POST /v1/embeddings` responses returning 200. No post-restart matches for `queue_drop`, cleanup-skip warnings, peer-body read failures, panics, or errors.
