### PR TITLE
fix: prevent instance slot leak when get_instance_for_model is cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.5] - 2026-05-01
+
+### Fixed
+
+- Plug a slot leak in `get_instance_for_model` that could prevent an instance
+  from ever completing its drain. `try_get_or_spawn` increments
+  `in_flight_requests` synchronously when it returns Ok, but the caller then
+  awaits readiness on the instance through several `.await` points (token
+  release, status reads, `ready_signal.notified()`). A future cancelled at
+  any of those awaits would leak the slot, leaving `in_flight_requests > 0`
+  with no request actively running. Drain blocks on `in_flight_requests == 0`,
+  so a leaked slot would pin the instance's VRAM forever. Fix: wrap the slot
+  in a new `SlotReleaseGuard` RAII type. Drop spawns the decrement and queue
+  notifications; the existing happy-path `Ok(inst)` returns now go through
+  `slot_guard.detach()` to transfer responsibility to the router's
+  `RequestGuard` / `cleanup_fut` chain. Removes the manual decrements that
+  previously only handled the explicit `Failed` paths.
+
 ## [1.3.4] - 2026-04-29
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.3.4"
+version = "1.3.5"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -296,6 +296,70 @@ impl Drop for PeerForwardGuard {
     }
 }
 
+/// RAII guard for an `in_flight_requests` slot reservation on an instance.
+///
+/// `try_get_or_spawn` increments `in_flight_requests` synchronously when it
+/// returns Ok. The caller (`get_instance_for_model`) then awaits readiness on
+/// the instance, which exposes the slot to cancellation if the calling
+/// future is dropped between the increment and the responsibility transfer
+/// to the router's `RequestGuard`. This guard closes that gap: it owns the
+/// release until the caller explicitly detaches it on a successful return.
+///
+/// On Drop without prior detach, decrements `in_flight_requests` via a
+/// spawned task (Drop is sync; the lock is async) and notifies waiters /
+/// drains so the instance can become idle and be evicted.
+pub struct SlotReleaseGuard {
+    state: Arc<NodeState>,
+    instance: Arc<RwLock<Instance>>,
+    released: bool,
+}
+
+impl SlotReleaseGuard {
+    pub fn new(state: Arc<NodeState>, instance: Arc<RwLock<Instance>>) -> Self {
+        Self {
+            state,
+            instance,
+            released: false,
+        }
+    }
+
+    /// Caller has taken responsibility for the slot release (e.g. by handing
+    /// the instance to a `RequestGuard` whose Drop or whose paired
+    /// `cleanup_fut` will perform the decrement). Subsequent Drop becomes a
+    /// no-op. Returns the inner instance Arc for convenience.
+    pub fn detach(mut self) -> Arc<RwLock<Instance>> {
+        self.released = true;
+        self.instance.clone()
+    }
+}
+
+impl Drop for SlotReleaseGuard {
+    fn drop(&mut self) {
+        if self.released {
+            return;
+        }
+        let inst = self.instance.clone();
+        let state = self.state.clone();
+        tokio::spawn(async move {
+            let (model, profile, became_idle) = {
+                let mut i = inst.write().await;
+                i.in_flight_requests = i.in_flight_requests.saturating_sub(1);
+                (
+                    i.model_name.clone(),
+                    i.profile_id.clone(),
+                    i.in_flight_requests == 0,
+                )
+            };
+            if became_idle {
+                state.maybe_cancel_drains().await;
+                state.notify_all_queues().await;
+            } else {
+                state.notify_queue(&model, &profile).await;
+            }
+        });
+    }
+}
+
 impl NodeState {
     pub async fn new(
         config: NodeConfig,
@@ -1121,7 +1185,7 @@ impl NodeState {
     }
 
     pub async fn get_instance_for_model(
-        &self,
+        self: &Arc<Self>,
         model_name: &str,
         profile: &Profile,
         reserve_slot: bool,
@@ -1306,6 +1370,15 @@ impl NodeState {
                 .await
             {
                 Ok(inst) => {
+                    // try_get_or_spawn incremented in_flight_requests
+                    // synchronously and returned Ok. The awaits below (token
+                    // release, ready_signal, status re-read) are cancellation
+                    // points; without an RAII guard, a cancelled caller would
+                    // leak the slot and block the instance's drain forever.
+                    // SlotReleaseGuard transfers responsibility to the caller
+                    // only on the explicit detach() at the Ready returns.
+                    let slot_guard = SlotReleaseGuard::new(self.clone(), inst.clone());
+
                     // Successfully acquired slot - clean up pending token and record metrics
                     if let Some(mut token) = my_token.take() {
                         token.release().await;
@@ -1320,17 +1393,14 @@ impl NodeState {
                         let r = inst.read().await;
                         let s = r.status.lock().clone();
                         if s == InstanceStatus::Ready {
-                            return Ok(inst.clone());
+                            return Ok(slot_guard.detach());
                         }
                         if s == InstanceStatus::Failed {
                             // Instance failed immediately - check for cold-start OOM recovery
                             let is_cold = r.is_cold_start;
                             drop(r);
-                            let mut w = inst.write().await;
-                            if w.in_flight_requests > 0 {
-                                w.in_flight_requests -= 1;
-                            }
-                            drop(w);
+                            // SlotReleaseGuard's Drop will decrement and notify.
+                            drop(slot_guard);
 
                             consecutive_spawn_failures += 1;
 
@@ -1388,16 +1458,13 @@ impl NodeState {
                     let r = inst.read().await;
                     let s = r.status.lock().clone();
                     if s == InstanceStatus::Ready {
-                        return Ok(inst.clone());
+                        return Ok(slot_guard.detach());
                     } else {
                         // Instance failed after startup - check for cold-start OOM recovery
                         let is_cold = is_cold_start;
                         drop(r);
-                        let mut w = inst.write().await;
-                        if w.in_flight_requests > 0 {
-                            w.in_flight_requests -= 1;
-                        }
-                        drop(w);
+                        // SlotReleaseGuard's Drop will decrement and notify.
+                        drop(slot_guard);
 
                         consecutive_spawn_failures += 1;
 
@@ -3579,9 +3646,11 @@ mod tests {
         config.model_defaults.max_concurrent_requests_per_instance = 1;
         config.model_defaults.max_queue_size_per_model = 1;
         let build_manager = BuildManager::new(config.llama_cpp.clone());
-        let state = NodeState::new(config, Cookbook { models: vec![] }, build_manager)
-            .await
-            .unwrap();
+        let state = Arc::new(
+            NodeState::new(config, Cookbook { models: vec![] }, build_manager)
+                .await
+                .unwrap(),
+        );
 
         let profile = sample_profile();
         let inst = Instance::new(
@@ -3618,6 +3687,94 @@ mod tests {
         assert_eq!(instance.read().await.in_flight_requests, 1);
         let queues = state.queues.read().await;
         assert!(queues.get(&key).is_none_or(|queue| queue.is_empty()));
+    }
+
+    #[tokio::test]
+    async fn slot_release_guard_decrements_on_drop() {
+        // Regression test for the cancel-safety hole in get_instance_for_model:
+        // when the caller's future is cancelled between try_get_or_spawn
+        // returning Ok (which already incremented in_flight_requests) and the
+        // Ready return that hands the instance to the router, the slot would
+        // leak forever, blocking the instance's drain. SlotReleaseGuard's
+        // Drop is responsible for closing that gap.
+        let mut config = minimal_node_config();
+        config.cluster.enabled = false;
+        let build_manager = BuildManager::new(config.llama_cpp.clone());
+        let state = Arc::new(
+            NodeState::new(config, Cookbook { models: vec![] }, build_manager)
+                .await
+                .unwrap(),
+        );
+
+        let inst = Instance::new(
+            "inst-x".into(),
+            "test".into(),
+            "default".into(),
+            "127.0.0.1".into(),
+            8000,
+            "hash".into(),
+            false,
+        );
+        let inst_arc = Arc::new(RwLock::new(inst));
+        // Simulate try_get_or_spawn's increment.
+        inst_arc.write().await.in_flight_requests = 1;
+
+        // Drop the guard without detaching — the cancellation case.
+        let guard = SlotReleaseGuard::new(state.clone(), inst_arc.clone());
+        drop(guard);
+
+        // Drop is sync but spawns the decrement task; wait for it.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            let in_flight = inst_arc.read().await.in_flight_requests;
+            if in_flight == 0 {
+                break;
+            }
+            if std::time::Instant::now() > deadline {
+                panic!(
+                    "in_flight_requests did not drain after SlotReleaseGuard drop; got {in_flight}"
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn slot_release_guard_no_op_after_detach() {
+        // On the success path, get_instance_for_model calls .detach() to
+        // transfer the slot release to the caller's RequestGuard /
+        // cleanup_fut. The guard's own Drop must NOT then double-decrement.
+        let mut config = minimal_node_config();
+        config.cluster.enabled = false;
+        let build_manager = BuildManager::new(config.llama_cpp.clone());
+        let state = Arc::new(
+            NodeState::new(config, Cookbook { models: vec![] }, build_manager)
+                .await
+                .unwrap(),
+        );
+
+        let inst = Instance::new(
+            "inst-y".into(),
+            "test".into(),
+            "default".into(),
+            "127.0.0.1".into(),
+            8000,
+            "hash".into(),
+            false,
+        );
+        let inst_arc = Arc::new(RwLock::new(inst));
+        inst_arc.write().await.in_flight_requests = 1;
+
+        let guard = SlotReleaseGuard::new(state.clone(), inst_arc.clone());
+        let returned = guard.detach();
+        // detach returns the same Arc so the caller can dispatch.
+        assert!(Arc::ptr_eq(&returned, &inst_arc));
+
+        // Give any (incorrectly spawned) decrement task a chance to run.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // The slot must still be reserved: caller now owns the release.
+        assert_eq!(inst_arc.read().await.in_flight_requests, 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes a `in_flight_requests` slot leak that can wedge an instance's drain forever, preventing the instance from being terminated and pinning its VRAM. Manifests as: an instance is marked `draining` early in its lifetime (e.g. tenure-expired with a competitor queued), then never finishes draining despite no apparent work, and the cluster degrades over time.

## Root cause

`try_get_or_spawn` (in `src/node_state/mod.rs`) increments `in_flight_requests` synchronously when it returns Ok. The caller, `get_instance_for_model`, then awaits readiness on the instance through several `.await` points (pending-token release, inner `inst.read().await`, `ready_signal.notified()`, post-wait status re-read). If the calling future is cancelled at any of those awaits, the increment is leaked: no code path decrements it.

The Failed-status branches inside `get_instance_for_model` already had explicit decrements, but cancellation has no branch — Rust async futures drop their stack with no opportunity to run code unless a Drop guard is installed.

## Fix

New RAII type `SlotReleaseGuard`:

- Owns the slot release from acquisition.
- `Drop`: spawns a task to decrement `in_flight_requests`, then fires `notify_all_queues` (or `notify_queue`) and `maybe_cancel_drains` as appropriate.
- `detach()`: consumes the guard without releasing — used on the Ready return paths to hand responsibility to the router's existing `RequestGuard` / `cleanup_fut` chain.

`get_instance_for_model` is updated to construct a `SlotReleaseGuard` immediately after `try_get_or_spawn` returns Ok and hold it across all subsequent awaits. The Failed-status branches drop the guard explicitly (replaces the manual `inst.in_flight_requests -= 1` lock-acquire-and-decrement). Signature changes from `&self` to `self: &Arc<Self>` so the guard can hold an `Arc<NodeState>` for its spawned decrement task; all existing call sites already pass `Arc<NodeState>`.

## Verification

- `cargo test --release -- --test-threads=1` — 313 tests pass (296 unit + 17 integration), including two new unit tests:
  - `slot_release_guard_decrements_on_drop` — Drop releases the slot.
  - `slot_release_guard_no_op_after_detach` — detach prevents Drop from releasing.
- Live cluster verification: deployed v1.3.5 to both nodes; ran 10 concurrent embedding requests with 1-second client-cancellation; cluster's `current_requests` returned to 0 within 5 seconds; idle eviction successfully terminated the instance afterward (visible `instance_terminate reason=idle` in the log).

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --release -- --test-threads=1` — 313 passed
- [x] New tests cover both Drop-releases and detach-no-op cases
- [x] Existing `integration_test_peer_forward_cancellation` (the related cancel-safety regression test) still passes
- [x] Live verification: 10-way concurrent client-cancellation does not leak slots; idle eviction subsequently terminates the instance

Closes #33.
