### PR TITLE
fix: detect client disconnect to prevent CLOSE-WAIT socket leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.6] - 2026-05-04
+
+### Fixed
+
+- Prevent CLOSE-WAIT socket leak that exhausts file descriptors. Request
+  handlers waiting for cluster capacity (`capacity_notify`) now detect client
+  disconnect by polling the TCP socket state via `getsockopt(TCP_INFO)` every
+  5 seconds. When the socket enters CLOSE-WAIT (client sent FIN), the handler
+  exits and all resources are released through existing Drop guards. Also
+  unconditionally set hyper's timer and `header_read_timeout` on HTTP
+  connections. No timeouts are imposed — requests still wait indefinitely when
+  `max_request_duration_ms=0`, as long as the client remains connected.
+
 ## [1.3.5] - 2026-05-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.3.5"
+version = "1.3.6"
 dependencies = [
  "anyhow",
  "axum",
@@ -1556,6 +1556,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "libc",
  "logroller",
  "mdns-sd",
  "mockall",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.3.5"
+version = "1.3.6"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"
@@ -55,6 +55,7 @@ sha2 = "0.10"
 getrandom = "0.2"
 hostname = "0.4"
 http-body-util = "0.1"
+libc = "0.2"
 
 # mDNS discovery
 mdns-sd = "0.11"

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,5 +1,6 @@
 use crate::cluster;
 use crate::config::NodeConfig;
+use crate::connection::ConnectionHandle;
 use crate::health;
 use crate::metrics;
 use crate::node_state::{NodeState, PeerState};
@@ -14,12 +15,13 @@ use axum::{
     http::{HeaderMap, StatusCode},
     response::IntoResponse,
     routing::{get, post},
-    Json, Router,
+    Extension, Json, Router,
 };
 use http_body_util::BodyExt;
 use hyper_util::rt::TokioTimer;
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::os::unix::io::AsRawFd;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -455,6 +457,9 @@ async fn handle_tls_connection(
     app: Router<()>,
     http_config: crate::config::HttpConfig,
 ) {
+    // Grab raw fd before TLS consumes the stream (fd survives the TLS wrapper)
+    let conn_handle = ConnectionHandle::new(tcp_stream.as_raw_fd());
+
     let tls_stream = match acceptor.accept(tcp_stream).await {
         Ok(s) => s,
         Err(e) => {
@@ -477,6 +482,8 @@ async fn handle_tls_connection(
         remote_addr,
     };
 
+    let app = app.layer(Extension(conn_handle));
+
     let mut make_service = app.into_make_service_with_connect_info::<PeerIdentity>();
     let service = match make_service.call(&wrapper).await {
         Ok(s) => s,
@@ -496,6 +503,9 @@ async fn handle_http_connection(
     app: Router<()>,
     http_config: crate::config::HttpConfig,
 ) {
+    let conn_handle = ConnectionHandle::new(tcp_stream.as_raw_fd());
+    let app = app.layer(Extension(conn_handle));
+
     let mut make_service = app.into_make_service_with_connect_info::<SocketAddr>();
     let service = match make_service.call(remote_addr).await {
         Ok(s) => s,
@@ -537,10 +547,9 @@ where
         });
 
     let mut builder = hyper::server::conn::http1::Builder::new();
-    if http_config.idle_timeout_seconds > 0 {
-        builder.timer(TokioTimer::new());
-        builder.header_read_timeout(Duration::from_secs(http_config.idle_timeout_seconds));
-    }
+    builder.timer(TokioTimer::new());
+    let idle_secs = http_config.idle_timeout_seconds.max(30);
+    builder.header_read_timeout(Duration::from_secs(idle_secs));
 
     if let Err(err) = builder.serve_connection(io, hyper_service).await {
         tracing::debug!("Connection error: {}", err);
@@ -736,7 +745,7 @@ async fn handle_noise_http_request(
         }
     };
 
-    match router::route_request(State(state), req).await {
+    match router::route_request(State(state), None, req).await {
         Ok(resp) => resp.into_response(),
         Err(err) => err.into_response(),
     }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,0 +1,159 @@
+use std::os::unix::io::RawFd;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+// Linux TCP states from include/net/tcp_states.h
+const TCP_CLOSE_WAIT: u8 = 8;
+const TCP_LAST_ACK: u8 = 9;
+const TCP_CLOSE: u8 = 7;
+const TCP_CLOSING: u8 = 11;
+
+/// Per-connection handle that can detect client disconnect by inspecting the
+/// TCP socket state via `getsockopt(TCP_INFO)`.
+///
+/// The raw fd is valid for the lifetime of the hyper connection task that owns
+/// the underlying `TcpStream`. Handlers running inside that task can safely
+/// check this handle.
+#[derive(Debug, Clone)]
+pub struct ConnectionHandle {
+    raw_fd: RawFd,
+    disconnected: std::sync::Arc<AtomicBool>,
+}
+
+impl ConnectionHandle {
+    pub fn new(raw_fd: RawFd) -> Self {
+        Self {
+            raw_fd,
+            disconnected: std::sync::Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Returns true if the client has disconnected (TCP state is CLOSE-WAIT or
+    /// similar terminal state). Uses a cached flag so repeated calls after the
+    /// first detection are free.
+    pub fn is_client_gone(&self) -> bool {
+        if self.disconnected.load(Ordering::Relaxed) {
+            return true;
+        }
+        if tcp_state_is_closed(self.raw_fd) {
+            self.disconnected.store(true, Ordering::Relaxed);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Async future that resolves when the client disconnects. Polls the TCP socket
+/// state every `interval`. Intended for use in `tokio::select!` alongside
+/// blocking waits like `capacity_notify.notified()`.
+pub async fn poll_client_disconnect(handle: &ConnectionHandle, interval: Duration) {
+    loop {
+        tokio::time::sleep(interval).await;
+        if handle.is_client_gone() {
+            return;
+        }
+    }
+}
+
+fn tcp_state_is_closed(fd: RawFd) -> bool {
+    unsafe {
+        let mut info: libc::tcp_info = std::mem::zeroed();
+        let mut len = std::mem::size_of::<libc::tcp_info>() as libc::socklen_t;
+        let ret = libc::getsockopt(
+            fd,
+            libc::IPPROTO_TCP,
+            libc::TCP_INFO,
+            &mut info as *mut _ as *mut libc::c_void,
+            &mut len,
+        );
+        if ret != 0 {
+            return true;
+        }
+        matches!(
+            info.tcpi_state,
+            TCP_CLOSE_WAIT | TCP_LAST_ACK | TCP_CLOSE | TCP_CLOSING
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::io::AsRawFd;
+
+    #[tokio::test]
+    async fn test_connected_socket_not_reported_as_gone() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let client = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (server, _) = listener.accept().await.unwrap();
+
+        let handle = ConnectionHandle::new(server.as_raw_fd());
+        assert!(!handle.is_client_gone());
+
+        drop(client);
+        drop(server);
+    }
+
+    #[tokio::test]
+    async fn test_disconnected_socket_detected() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let client = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (server, _) = listener.accept().await.unwrap();
+
+        let handle = ConnectionHandle::new(server.as_raw_fd());
+
+        // Client disconnects
+        drop(client);
+
+        // Give the kernel a moment to process the FIN
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        assert!(handle.is_client_gone());
+    }
+
+    #[tokio::test]
+    async fn test_poll_client_disconnect_resolves_on_close() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let client = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (server, _) = listener.accept().await.unwrap();
+
+        let handle = ConnectionHandle::new(server.as_raw_fd());
+
+        // Drop client after a short delay
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            drop(client);
+        });
+
+        // poll_client_disconnect should resolve within interval + detection time
+        let result = tokio::time::timeout(
+            Duration::from_secs(2),
+            poll_client_disconnect(&handle, Duration::from_millis(100)),
+        )
+        .await;
+
+        assert!(result.is_ok(), "poll_client_disconnect should have resolved");
+    }
+
+    #[test]
+    fn test_invalid_fd_reports_gone() {
+        let handle = ConnectionHandle::new(-1);
+        assert!(handle.is_client_gone());
+    }
+
+    #[tokio::test]
+    async fn test_cached_flag_avoids_repeated_syscalls() {
+        let handle = ConnectionHandle::new(-1);
+        assert!(handle.is_client_gone());
+        // Second call uses cached flag
+        assert!(handle.is_client_gone());
+        assert!(handle.disconnected.load(Ordering::Relaxed));
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -100,6 +100,14 @@ impl AppError {
     pub fn request_timeout(message: impl Into<String>) -> Self {
         Self::new(StatusCode::REQUEST_TIMEOUT, message, "request_timeout")
     }
+
+    pub fn client_disconnected() -> Self {
+        Self::new(
+            StatusCode::from_u16(499).unwrap_or(StatusCode::BAD_REQUEST),
+            "Client closed connection",
+            "client_disconnected",
+        )
+    }
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod build_manager;
 mod circuit_breaker;
 mod cluster;
 mod config;
+mod connection;
 #[allow(clippy::items_after_test_module)]
 mod discovery;
 mod errors;

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,4 +1,5 @@
 use crate::config::Profile;
+use crate::connection::ConnectionHandle;
 use crate::errors::AppError;
 use crate::instance::Instance;
 use crate::node_state::{NodeError, NodeState};
@@ -8,6 +9,7 @@ use axum::{
     http::{header::RETRY_AFTER, HeaderMap, HeaderValue, Method, Request, Response, StatusCode},
     response::IntoResponse,
     response::Json,
+    Extension,
 };
 use bytes::Bytes;
 use futures::{future::BoxFuture, Stream, StreamExt, TryStreamExt};
@@ -23,6 +25,31 @@ use std::{
 use tokio::sync::RwLock;
 use tokio::time::timeout;
 use tracing::{error, info, warn, Instrument};
+
+const DISCONNECT_POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Wait for a capacity notification, but bail early if the client has
+/// disconnected. Returns `Err` if the client is gone.
+async fn wait_for_capacity_or_disconnect(
+    notify: &tokio::sync::Notify,
+    conn: &Option<ConnectionHandle>,
+) -> Result<(), AppError> {
+    match conn {
+        Some(handle) => {
+            tokio::select! {
+                _ = notify.notified() => Ok(()),
+                _ = crate::connection::poll_client_disconnect(handle, DISCONNECT_POLL_INTERVAL) => {
+                    info!(event = "client_disconnected", "Client disconnected during capacity wait");
+                    Err(AppError::client_disconnected())
+                }
+            }
+        }
+        None => {
+            notify.notified().await;
+            Ok(())
+        }
+    }
+}
 
 struct RequestGuard {
     state: Arc<NodeState>,
@@ -482,8 +509,10 @@ pub async fn list_models(
 
 pub async fn route_request(
     State(state): State<Arc<NodeState>>,
+    conn_handle: Option<Extension<ConnectionHandle>>,
     req: Request<Body>,
 ) -> Result<impl IntoResponse, AppError> {
+    let conn_handle = conn_handle.map(|Extension(h)| h);
     let (parts, body) = req.into_parts();
     let path_only = parts.uri.path().to_string();
     let path_and_query = parts
@@ -626,7 +655,7 @@ pub async fn route_request(
                         model = %model_to_use,
                         "All peers advertising model are currently unavailable, waiting for cluster capacity"
                     );
-                    state.capacity_notify.notified().await;
+                    wait_for_capacity_or_disconnect(&state.capacity_notify, &conn_handle).await?;
                     continue;
                 };
 
@@ -711,7 +740,7 @@ pub async fn route_request(
                             "Peer reported saturation, waiting for cluster capacity"
                         );
                         drop(peer_forward_guard);
-                        state.capacity_notify.notified().await;
+                        wait_for_capacity_or_disconnect(&state.capacity_notify, &conn_handle).await?;
                         continue;
                     }
                     ForwardOutcome::Transport(e) => {
@@ -728,7 +757,7 @@ pub async fn route_request(
                             "Peer transport failure, waiting for cluster capacity to retry"
                         );
                         drop(peer_forward_guard);
-                        state.capacity_notify.notified().await;
+                        wait_for_capacity_or_disconnect(&state.capacity_notify, &conn_handle).await?;
                         continue;
                     }
                 }
@@ -803,16 +832,31 @@ pub async fn route_request(
                 profile = %profile.id,
                 "No node available, waiting for cluster capacity"
             );
-            state.capacity_notify.notified().await;
+            wait_for_capacity_or_disconnect(&state.capacity_notify, &conn_handle).await?;
             // Loop back to retry select_best_node
         };
 
         if best_node.node_id == state.config.node_id {
-            // Local routing
-            match state
-                .get_instance_for_model(&model_name, &profile, true)
-                .await
-            {
+            // Local routing — wrap in disconnect check so we don't block
+            // forever inside get_instance_for_model's internal capacity waits
+            // if the client has already gone.
+            let instance_result = match &conn_handle {
+                Some(handle) => {
+                    tokio::select! {
+                        res = state.get_instance_for_model(&model_name, &profile, true) => res,
+                        _ = crate::connection::poll_client_disconnect(handle, DISCONNECT_POLL_INTERVAL) => {
+                            info!(event = "client_disconnected", "Client disconnected during instance acquisition");
+                            return Err(AppError::client_disconnected());
+                        }
+                    }
+                }
+                None => {
+                    state
+                        .get_instance_for_model(&model_name, &profile, true)
+                        .await
+                }
+            };
+            match instance_result {
                 Ok(instance_lock) => {
                     guard.set_instance(instance_lock.clone());
 
@@ -1237,7 +1281,7 @@ pub async fn route_request(
 
                 // Wait for cluster state to change (capacity freed, peer
                 // recovered, gossip update, drain finished) before retrying.
-                state.capacity_notify.notified().await;
+                wait_for_capacity_or_disconnect(&state.capacity_notify, &conn_handle).await?;
 
                 if state.draining.load(Ordering::Relaxed) {
                     state.metrics.inc_errors();
@@ -1268,7 +1312,7 @@ pub async fn route_request(
                         model = %model_name,
                         "No node available during retry, waiting for cluster capacity"
                     );
-                    state.capacity_notify.notified().await;
+                    wait_for_capacity_or_disconnect(&state.capacity_notify, &conn_handle).await?;
                 };
             }
         }


### PR DESCRIPTION
## Summary

- Add `ConnectionHandle` type that checks TCP socket state via `getsockopt(TCP_INFO)` to detect client disconnect (CLOSE-WAIT)
- All `capacity_notify` waits and `get_instance_for_model` in `route_request` now bail early when the client is gone
- Always set hyper timer and `header_read_timeout` on HTTP connections

Fixes #35

## Test plan

- [ ] All 318 existing tests pass (including 5 new connection module tests)
- [ ] Release binary builds clean
- [ ] Deploy to test node, confirm CLOSE-WAIT sockets clear within ~5s of client disconnect
- [ ] Verify long-running streaming requests with connected clients are unaffected