### PR TITLE
feat: expose proxy version via build_info metric and JSON snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-05-29
+
+### Added
+
+- Expose the llamesh proxy version through the metrics surface. The Prometheus
+  endpoint now renders a `proxy_build_info{version="x.y.z"} 1` constant gauge
+  (the conventional `*_build_info` pattern), and the JSON metrics snapshot
+  (`/metrics/json`) gains a top-level `version` field alongside the existing
+  `llama_cpp_version`. This lets monitoring track proxy version rollout and skew
+  across a cluster (e.g. `count by (version) (proxy_build_info)`) — previously a
+  node could report its peers' versions via `/cluster/nodes` but not surface its
+  own to the scrape layer. The new snapshot field is `#[serde(default)]`, so
+  metrics files written by older versions still load.
+
 ## [1.3.6] - 2026-05-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.3.6"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.3.6"
+version = "1.4.0"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/SPEC.md
+++ b/SPEC.md
@@ -421,6 +421,7 @@ Per node, metrics snapshots are stored as JSON files at the path specified by `m
 ```json
 {
   "node_id": "node-a",
+  "version": "1.4.0",
   "llama_cpp_version": "7099-d23355afc",
   "requests_total": 1234,
   "errors_total": 12,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -105,6 +105,10 @@ pub struct Metrics {
 #[derive(Serialize, Deserialize)]
 pub struct MetricsSnapshot {
     pub node_id: String,
+    /// Version of the llamesh proxy itself (from `CARGO_PKG_VERSION`).
+    /// `#[serde(default)]` keeps snapshots written by older versions loadable.
+    #[serde(default)]
+    pub version: String,
     pub llama_cpp_version: String,
     pub requests_total: u64,
     pub errors_total: u64,
@@ -375,6 +379,7 @@ impl Metrics {
 
         MetricsSnapshot {
             node_id,
+            version: env!("CARGO_PKG_VERSION").to_string(),
             llama_cpp_version: version,
             requests_total: self.requests_total.load(Ordering::Relaxed),
             errors_total: self.errors_total.load(Ordering::Relaxed),
@@ -410,6 +415,21 @@ pub async fn render_prometheus_with_circuit_breaker(
     circuit_breaker: Option<&CircuitBreaker>,
 ) -> String {
     let mut out = String::new();
+
+    // Build info as a constant gauge with the proxy version in a label. This is
+    // the conventional Prometheus pattern for exposing version (cf.
+    // `*_build_info`): the value is always 1 and rollout/skew is tracked via the
+    // label, e.g. `count by (version) (proxy_build_info)`. The version comes from
+    // `CARGO_PKG_VERSION`, a compile-time constant that is always a valid semver,
+    // so it needs no label-value escaping.
+    out.push_str(
+        "# HELP proxy_build_info Build information for the llamesh proxy; value is always 1.\n",
+    );
+    out.push_str("# TYPE proxy_build_info gauge\n");
+    out.push_str(&format!(
+        "proxy_build_info{{version=\"{}\"}} 1\n",
+        env!("CARGO_PKG_VERSION")
+    ));
 
     // Global metrics with TYPE/HELP headers for Prometheus spec compliance
     out.push_str("# HELP proxy_requests_total Total number of requests received.\n");
@@ -735,6 +755,52 @@ mod tests {
         assert!(output.contains("proxy_node_gpu_telemetry_available 1"));
         assert!(output.contains("proxy_hash_requests_total{hash=\"abc123\""));
         assert!(output.contains("names=\"gpt\\\"cool\\\"\""));
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_build_info() {
+        let metrics = Metrics::new();
+        let output = render_prometheus_with_circuit_breaker(&metrics, None).await;
+
+        // build_info is rendered as a constant gauge carrying the proxy version
+        // in a label, matching the crate version at compile time.
+        assert!(output.contains("# TYPE proxy_build_info gauge"));
+        assert!(output.contains(&format!(
+            "proxy_build_info{{version=\"{}\"}} 1",
+            env!("CARGO_PKG_VERSION")
+        )));
+    }
+
+    #[tokio::test]
+    async fn test_snapshot_includes_proxy_version() {
+        let metrics = Metrics::new();
+        let snapshot = metrics
+            .snapshot("node-a".to_string(), "llama-cpp-1234".to_string(), None)
+            .await;
+
+        // The proxy version is the crate version and is distinct from the
+        // llama.cpp binary version carried in `llama_cpp_version`.
+        assert_eq!(snapshot.version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(snapshot.llama_cpp_version, "llama-cpp-1234");
+    }
+
+    #[test]
+    fn test_snapshot_deserializes_without_version_field() {
+        // Snapshots persisted by versions predating the `version` field must
+        // still load (the field is `#[serde(default)]`).
+        let legacy = r#"{
+            "node_id": "node-a",
+            "llama_cpp_version": "old",
+            "requests_total": 7,
+            "errors_total": 1,
+            "current_requests": 0,
+            "hashes": {},
+            "updated_at": "2025-01-01T00:00:00Z"
+        }"#;
+        let snapshot: MetricsSnapshot =
+            serde_json::from_str(legacy).expect("legacy snapshot should deserialize");
+        assert_eq!(snapshot.version, "");
+        assert_eq!(snapshot.requests_total, 7);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Adds a `proxy_build_info{version="x.y.z"} 1` constant gauge to the Prometheus output (the conventional `*_build_info` pattern) so proxy version rollout and skew are trackable from the monitoring stack, e.g. `count by (version) (proxy_build_info)`.
- Adds a top-level `version` field to the `/metrics/json` snapshot, alongside the existing `llama_cpp_version`.
- Previously a node could report its peers' versions via `/cluster/nodes` but couldn't surface its own version to the scrape layer.

The version is read from `CARGO_PKG_VERSION` (a compile-time constant), so the Prometheus renderer takes no new arguments and the label needs no escaping. The new snapshot field is `#[serde(default)]`, so metrics files written by older versions still deserialize and persisted counters survive the upgrade.

## Changes

- `src/metrics.rs`: render `proxy_build_info`; add `version` to `MetricsSnapshot`; 3 new tests.
- `SPEC.md`: document `version` in the JSON snapshot example.
- `Cargo.toml` / `Cargo.lock`: 1.3.6 → 1.4.0 (minor, backward-compatible feature).
- `CHANGELOG.md`: 1.4.0 release section.

## Test plan

- `cargo test` — full suite passes (304 unit + integration), including 3 new tests:
  - `test_prometheus_build_info` — gauge rendered with the crate-version label.
  - `test_snapshot_includes_proxy_version` — snapshot carries the crate version, distinct from `llama_cpp_version`.
  - `test_snapshot_deserializes_without_version_field` — legacy snapshots (no `version` field) still load.
- Live-validated on a node: `/version`, `/metrics` (`proxy_build_info{version="1.4.0"} 1`), and `/metrics/json` (`version: 1.4.0`) all correct; a pre-existing on-disk snapshot without the `version` field loaded without error and persisted counters were preserved; an end-to-end embeddings request succeeded.

Closes #37
