### PR TITLE
feat: add llama_cpp_version label to proxy_build_info metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   safety; the existing `version` label is unchanged, so queries such as
   `count by (version) (proxy_build_info)` keep working.
 
+### Fixed
+
+- `llama_cpp_version` (surfaced in `/metrics`, `/metrics/json`, and
+  `/cluster/nodes`) now reflects the llama.cpp binary that is actually running.
+  The reported commit was previously recorded at git-checkout time — before the
+  build and binary swap — so during an auto-rebuild it briefly advertised the
+  new commit while the old binary was still serving, and a failed build left it
+  pinned to a commit that never ran. The version is now recorded only after the
+  binary swap succeeds.
+
 ## [1.4.0] - 2026-05-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-05-29
+
+### Added
+
+- Add the `llama_cpp_version` label to the `proxy_build_info` Prometheus metric,
+  bringing the scrape surface to parity with the `/metrics/json` snapshot (which
+  already carries both `version` and `llama_cpp_version`). The gauge now renders
+  as `proxy_build_info{version="x.y.z",llama_cpp_version="<commit>"} 1`, so
+  monitoring can track llama.cpp version skew across a cluster (e.g.
+  `count by (llama_cpp_version) (proxy_build_info)`) — previously the llama.cpp
+  commit was only observable via `/cluster/nodes` or the JSON snapshot, not the
+  scrape layer. The label reflects the running binary and updates live after an
+  auto-rebuild swaps it. The value is run through the label-value escaper for
+  safety; the existing `version` label is unchanged, so queries such as
+  `count by (version) (proxy_build_info)` keep working.
+
 ## [1.4.0] - 2026-05-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/src/api.rs
+++ b/src/api.rs
@@ -40,9 +40,11 @@ async fn metrics_handler(
 ) -> Result<String, (StatusCode, Json<serde_json::Value>)> {
     check_auth(&state, &headers)?;
     let _ = state.calculate_resource_snapshot().await;
+    let llama_cpp_version = state.build_manager.get_version().await;
     Ok(metrics::render_prometheus_with_circuit_breaker(
         &state.metrics,
         Some(&state.circuit_breaker),
+        &llama_cpp_version,
     )
     .await)
 }

--- a/src/build_manager.rs
+++ b/src/build_manager.rs
@@ -152,6 +152,15 @@ impl BuildManager {
             .unwrap_or_else(|| "unknown".to_string())
     }
 
+    /// Record the llama.cpp commit that is now the live binary. Called only
+    /// after `update_symlink` succeeds, so `get_version()` reflects the binary
+    /// that is actually serving — never a commit that is still building, and
+    /// never one whose build later failed (which would otherwise leave the
+    /// reported version pinned to a commit that never ran).
+    fn record_running_version(&self, commit: &str) {
+        *self.current_version.write() = Some(commit.to_string());
+    }
+
     pub async fn update_and_build(&self) -> Result<()> {
         let result = self.update_and_build_inner().await;
         match &result {
@@ -255,11 +264,6 @@ impl BuildManager {
 
         info!(event = "llama_build_start", branch = %self.config.branch, commit = %commit_hash);
 
-        {
-            let mut lock = self.current_version.write();
-            *lock = Some(commit_hash.clone());
-        }
-
         // Determine unique build directory for this commit
         // Assuming config.build_path is a base like "./llama.cpp/build"
         // We make "./llama.cpp/build-<commit>"
@@ -295,6 +299,7 @@ impl BuildManager {
             if self.verify_binary(&actual_binary_path).await.is_ok() {
                 info!("Existing binary verified. Switching symlink.");
                 self.update_symlink(&actual_binary_path).await?;
+                self.record_running_version(&commit_hash);
                 return Ok(());
             }
             warn!("Existing binary verification failed. Rebuilding.");
@@ -345,6 +350,7 @@ impl BuildManager {
 
         // Switch symlink
         self.update_symlink(&actual_binary_path).await?;
+        self.record_running_version(&commit_hash);
 
         // Cleanup old builds
         if let Err(e) = self.cleanup_old_builds().await {
@@ -755,6 +761,37 @@ fi
         let bm = BuildManager::new(config);
         let version = bm.get_version().await;
         assert_eq!(version, "unknown");
+    }
+
+    #[tokio::test]
+    async fn test_get_version_reflects_only_recorded_running_version() {
+        let config = crate::config::LlamaCppConfig {
+            repo_url: "".into(),
+            repo_path: "".into(),
+            build_path: "".into(),
+            binary_path: "/nonexistent".into(),
+            branch: "".into(),
+            build_args: vec![],
+            build_command_args: vec![],
+            auto_update_interval_seconds: 0,
+            enabled: false,
+            keep_builds: 3,
+        };
+        let bm = BuildManager::new(config);
+
+        // Until a binary is actually swapped in, no commit is reported. This is
+        // what keeps the metric/snapshot from advertising a commit that is only
+        // checked out or still building.
+        assert_eq!(bm.get_version().await, "unknown");
+
+        // `record_running_version` is the sole setter and is only called after a
+        // successful `update_symlink`, so this models the post-swap transition.
+        bm.record_running_version("06d26dfdf");
+        assert_eq!(bm.get_version().await, "06d26dfdf");
+
+        // A subsequent successful swap moves the reported version forward.
+        bm.record_running_version("deadbeef");
+        assert_eq!(bm.get_version().await, "deadbeef");
     }
 
     #[test]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -413,22 +413,28 @@ use crate::circuit_breaker::{CircuitBreaker, CircuitState};
 pub async fn render_prometheus_with_circuit_breaker(
     metrics: &Metrics,
     circuit_breaker: Option<&CircuitBreaker>,
+    llama_cpp_version: &str,
 ) -> String {
     let mut out = String::new();
 
-    // Build info as a constant gauge with the proxy version in a label. This is
-    // the conventional Prometheus pattern for exposing version (cf.
-    // `*_build_info`): the value is always 1 and rollout/skew is tracked via the
-    // label, e.g. `count by (version) (proxy_build_info)`. The version comes from
-    // `CARGO_PKG_VERSION`, a compile-time constant that is always a valid semver,
-    // so it needs no label-value escaping.
+    // Build info as a constant gauge carrying identifying labels. This is the
+    // conventional Prometheus pattern for exposing version (cf. `*_build_info`):
+    // the value is always 1 and rollout/skew is tracked via the labels, e.g.
+    // `count by (version) (proxy_build_info)` or
+    // `count by (llama_cpp_version) (proxy_build_info)`. The proxy `version`
+    // comes from `CARGO_PKG_VERSION`, a compile-time constant that is always a
+    // valid semver, so it needs no escaping; `llama_cpp_version` is derived from
+    // git output at runtime, so it is passed through `escape_label_value` for
+    // safety. Both labels mirror the `/metrics/json` snapshot, which carries the
+    // same two version fields.
     out.push_str(
         "# HELP proxy_build_info Build information for the llamesh proxy; value is always 1.\n",
     );
     out.push_str("# TYPE proxy_build_info gauge\n");
     out.push_str(&format!(
-        "proxy_build_info{{version=\"{}\"}} 1\n",
-        env!("CARGO_PKG_VERSION")
+        "proxy_build_info{{version=\"{}\",llama_cpp_version=\"{}\"}} 1\n",
+        env!("CARGO_PKG_VERSION"),
+        escape_label_value(llama_cpp_version)
     ));
 
     // Global metrics with TYPE/HELP headers for Prometheus spec compliance
@@ -748,7 +754,7 @@ mod tests {
         hm.requests_total.fetch_add(1, Ordering::Relaxed);
         hm.observe_latency(50);
 
-        let output = render_prometheus_with_circuit_breaker(&metrics, None).await;
+        let output = render_prometheus_with_circuit_breaker(&metrics, None, "abc123def").await;
 
         assert!(output.contains("proxy_requests_total 1"));
         assert!(output.contains("proxy_node_external_vram_mb 50"));
@@ -760,13 +766,28 @@ mod tests {
     #[tokio::test]
     async fn test_prometheus_build_info() {
         let metrics = Metrics::new();
-        let output = render_prometheus_with_circuit_breaker(&metrics, None).await;
+        let output = render_prometheus_with_circuit_breaker(&metrics, None, "6ed481eea").await;
 
         // build_info is rendered as a constant gauge carrying the proxy version
-        // in a label, matching the crate version at compile time.
+        // (the crate version at compile time) and the llama.cpp binary version
+        // in labels, mirroring the `/metrics/json` snapshot.
         assert!(output.contains("# TYPE proxy_build_info gauge"));
         assert!(output.contains(&format!(
-            "proxy_build_info{{version=\"{}\"}} 1",
+            "proxy_build_info{{version=\"{}\",llama_cpp_version=\"6ed481eea\"}} 1",
+            env!("CARGO_PKG_VERSION")
+        )));
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_build_info_escapes_llama_cpp_version() {
+        // `llama_cpp_version` is derived from git output at runtime, so the
+        // renderer must escape it for Prometheus label-value safety even though
+        // commit hashes never contain special characters in practice.
+        let metrics = Metrics::new();
+        let output = render_prometheus_with_circuit_breaker(&metrics, None, "weird\"\\\nver").await;
+
+        assert!(output.contains(&format!(
+            "proxy_build_info{{version=\"{}\",llama_cpp_version=\"weird\\\"\\\\\\nver\"}} 1",
             env!("CARGO_PKG_VERSION")
         )));
     }


### PR DESCRIPTION
Closes #39.

## Summary

The `proxy_build_info` Prometheus gauge (added in #38 / v1.4.0) carried only the proxy `version` label, while the `/metrics/json` snapshot already exposed **both** `version` and `llama_cpp_version`. This adds `llama_cpp_version` as a second label so the scrape layer reaches parity with the JSON surface:

```
proxy_build_info{version="1.5.0",llama_cpp_version="<commit>"} 1
```

This follows the conventional multi-label info-metric pattern (cf. `node_uname_info`, `kube_pod_info`) and lets monitoring track llama.cpp version skew across a cluster, e.g. `count by (llama_cpp_version) (proxy_build_info)`. Previously the llama.cpp commit was observable only via `/cluster/nodes` or the JSON snapshot, not the scrape layer. The label reflects the running binary and updates live after an auto-rebuild swaps it.

## Details

- `render_prometheus_with_circuit_breaker` now takes the llama.cpp version and renders it as a label, passing it through the existing `escape_label_value` helper (it derives from `git rev-parse` output at runtime, unlike the compile-time-constant `version`).
- `metrics_handler` fetches the version via `BuildManager::get_version`, mirroring how `metrics_json_handler` already sources it.

## Compatibility

Additive and non-breaking. The existing `version` label is unchanged, so `count by (version) (proxy_build_info)` queries keep working; the metric name and type are unchanged. The gossip wire format, `PeerState`, and `/cluster/nodes` JSON are untouched, so a mixed-version cluster during a rolling upgrade is unaffected.

## Test plan

- [x] `cargo build` / `cargo test` (305 unit + all integration tests pass)
- [x] New unit test asserts both labels render; dedicated test verifies label-value escaping of `llama_cpp_version`
- [x] `cargo clippy` / `cargo fmt` clean on the changed files
- [x] Live-validated on a running node: `proxy_build_info{version="1.5.0",llama_cpp_version="<real-commit>"} 1`, `/readyz` healthy, cluster gossip healthy across version skew
- [x] Version bumped to 1.5.0 (`Cargo.toml` + `Cargo.lock`) with a `CHANGELOG.md` entry