### PR TITLE
feat: surface llama_cpp_version in /cluster/nodes and gossip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-05-29
+
+### Added
+
+- The cluster view (`GET /cluster/nodes`) now reports each node's
+  `llama_cpp_version` — the llama.cpp commit of the binary currently serving on
+  that node, or `"unknown"` if no build has been recorded. The value rides the
+  existing gossip channel, so any single node's `/cluster/nodes` response carries
+  the llama.cpp commit for every reachable peer. This makes llama.cpp version
+  skew observable cluster-wide from one endpoint, without scraping each node's
+  `/metrics` individually. The field mirrors the commit already exposed by the
+  `proxy_build_info` metric and the `/metrics/json` snapshot, and it reflects the
+  running binary live after an auto-rebuild swaps it. The gossip field is
+  additive and deserializes with a default, so a rolling upgrade interoperates:
+  peers that predate the field are recorded as `"unknown"`, and older nodes
+  ignore the field sent by upgraded peers.
+
+### Fixed
+
+- `/cluster/nodes` now actually surfaces `llama_cpp_version`. The 1.5.0 changelog
+  described the llama.cpp commit as "surfaced in ... `/cluster/nodes`", but the
+  field was never present on the cluster/gossip node representation — the view
+  exposed only the proxy `version`. Every node entry now includes the commit.
+
 ## [1.5.0] - 2026-05-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/SPEC.md
+++ b/SPEC.md
@@ -1100,7 +1100,7 @@ First gossip tick fires immediately on startup (no initial delay).
 
 Every `gossip_interval_seconds`, nodes exchange metadata including:
 
-* `node_id`, `version`, supported models.
+* `node_id`, `version` (proxy version), `llama_cpp_version` (llama.cpp commit of the binary currently serving, or `unknown` if none recorded yet), supported models.
 * `loaded_models`: Which models are currently loaded and running.
 * `model_stats`: Per-model metrics including tokens per second, queue length, and learned VRAM/sysmem usage.
 * `ready` flag: Whether the node is ready to serve (false when draining or binary is unavailable).

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -475,6 +475,8 @@ pub async fn process_gossip_message(
                     node_id: info.node_id,
                     address: info.address,
                     version: "unknown".to_string(),
+                    // Not yet heard from directly; filled in on first gossip.
+                    llama_cpp_version: "unknown".to_string(),
                     last_seen: now_secs,
                     supported_models: vec![],
                     active_instances: 0,
@@ -585,6 +587,7 @@ mod tests {
             node_id: "node-origin".into(),
             address: "http://node-origin".into(),
             version: "0.1.0".into(),
+            llama_cpp_version: "origincpp1".into(),
             last_seen: 1000,
             supported_models: vec![],
             active_instances: 0,
@@ -620,14 +623,19 @@ mod tests {
 
         let peers = state.peers.read().await;
 
-        // Should have origin peer
+        // Should have origin peer, including the llama.cpp version it gossiped
+        // (so /cluster/nodes can surface per-node llama.cpp version skew).
         assert!(peers.contains_key("node-origin"));
+        let origin = peers.get("node-origin").unwrap();
+        assert_eq!(origin.llama_cpp_version, "origincpp1");
 
-        // Should have discovered peer
+        // Should have discovered peer. Transitively-discovered peers have no
+        // direct gossip yet, so their llama.cpp version is "unknown" until heard.
         assert!(peers.contains_key("node-new"));
         let new_peer = peers.get("node-new").unwrap();
         assert_eq!(new_peer.address, "http://node-new");
         assert_eq!(new_peer.version, "unknown");
+        assert_eq!(new_peer.llama_cpp_version, "unknown");
     }
 
     #[test]
@@ -667,6 +675,7 @@ mod tests {
                     node_id: "remote-peer".into(),
                     address: "http://node-b:8080".into(), // Real hostname
                     version: "0.1.0".into(),
+                    llama_cpp_version: "unknown".into(),
                     last_seen: 1000,
                     supported_models: vec!["model:default".into()],
                     active_instances: 0,
@@ -695,6 +704,7 @@ mod tests {
             node_id: "remote-peer".into(),
             address: "http://127.0.0.1:8080".into(), // Loopback - should be ignored
             version: "0.1.0".into(),
+            llama_cpp_version: "unknown".into(),
             last_seen: 2000,
             supported_models: vec!["model:default".into(), "new-model:default".into()],
             active_instances: 1,

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -2337,10 +2337,17 @@ impl NodeState {
                 .collect()
         };
 
+        // Reflect the llama.cpp commit of the binary currently serving, so the
+        // cluster view (`/cluster/nodes`) and gossip carry per-node llama.cpp
+        // version for skew detection. Matches the value surfaced via `/metrics`
+        // (`proxy_build_info`) and `/metrics/json`.
+        let llama_cpp_version = self.build_manager.get_version().await;
+
         PeerState {
             node_id: self.config.node_id.clone(),
             address,
             version: env!("CARGO_PKG_VERSION").to_string(),
+            llama_cpp_version,
             last_seen: std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_secs())
@@ -3254,6 +3261,7 @@ mod tests {
             node_id: "peer-a".into(),
             address: "http://peer-a".into(),
             version: "0.1.0".into(),
+            llama_cpp_version: "unknown".into(),
             last_seen: 0,
             supported_models: supported.into_iter().map(|s| s.to_string()).collect(),
             active_instances: 0,
@@ -3478,6 +3486,7 @@ mod tests {
             node_id: "remote-peer".into(),
             address: "http://remote-peer".into(),
             version: "0.1.0".into(),
+            llama_cpp_version: "unknown".into(),
             last_seen: now,                                        // Recent
             supported_models: vec!["remote-model:default".into()], // Supports our model
             active_instances: 0,
@@ -3847,6 +3856,11 @@ mod tests {
         assert!(!self_peer
             .supported_models
             .contains(&"local-model:zero-capacity".into()));
+
+        // The self peer reports its llama.cpp version from the build manager.
+        // With no build recorded, get_version() yields the "unknown" sentinel,
+        // which is what gossip and /cluster/nodes will carry for this node.
+        assert_eq!(self_peer.llama_cpp_version, "unknown");
     }
 
     #[tokio::test]
@@ -4368,6 +4382,7 @@ mod tests {
             node_id: "test".into(),
             address: "http://test".into(),
             version: "0.1.0".into(),
+            llama_cpp_version: "unknown".into(),
             last_seen: 0,
             supported_models: vec![],
             active_instances: 2,
@@ -4403,6 +4418,7 @@ mod tests {
             node_id: "test".into(),
             address: "http://test".into(),
             version: "0.1.0".into(),
+            llama_cpp_version: "unknown".into(),
             last_seen: 0,
             supported_models: vec![],
             active_instances: 0,
@@ -4438,6 +4454,7 @@ mod tests {
             node_id: "test".into(),
             address: "http://test".into(),
             version: "0.1.0".into(),
+            llama_cpp_version: "unknown".into(),
             last_seen: 0,
             supported_models: vec![],
             active_instances: 2,
@@ -4475,6 +4492,7 @@ mod tests {
             node_id: "test".into(),
             address: "http://test".into(),
             version: "0.1.0".into(),
+            llama_cpp_version: "unknown".into(),
             last_seen: 0,
             supported_models: vec![],
             active_instances: 2,
@@ -4513,6 +4531,7 @@ mod tests {
             node_id: "loaded".into(),
             address: "http://loaded".into(),
             version: "0.1.0".into(),
+            llama_cpp_version: "unknown".into(),
             last_seen: 0,
             supported_models: vec!["gpt:fast".into()],
             active_instances: 1,
@@ -4549,6 +4568,7 @@ mod tests {
             node_id: "unloaded".into(),
             address: "http://unloaded".into(),
             version: "0.1.0".into(),
+            llama_cpp_version: "unknown".into(),
             last_seen: 0,
             supported_models: vec!["gpt:fast".into()],
             active_instances: 0,
@@ -4600,6 +4620,7 @@ mod tests {
             node_id: "loaded".into(),
             address: "http://loaded".into(),
             version: "0.1.0".into(),
+            llama_cpp_version: "unknown".into(),
             last_seen: 0,
             supported_models: vec!["gpt:fast".into()],
             active_instances: 1,
@@ -4636,6 +4657,7 @@ mod tests {
             node_id: "unloaded".into(),
             address: "http://unloaded".into(),
             version: "0.1.0".into(),
+            llama_cpp_version: "unknown".into(),
             last_seen: 0,
             supported_models: vec!["gpt:fast".into()],
             active_instances: 0,
@@ -4689,6 +4711,7 @@ mod tests {
             node_id: "idle".into(),
             address: "http://idle".into(),
             version: "0.1.0".into(),
+            llama_cpp_version: "unknown".into(),
             last_seen: 0,
             supported_models: vec!["gpt:fast".into()],
             active_instances: 1,
@@ -4715,6 +4738,7 @@ mod tests {
             node_id: "busy".into(),
             address: "http://busy".into(),
             version: "0.1.0".into(),
+            llama_cpp_version: "unknown".into(),
             last_seen: 0,
             supported_models: vec!["gpt:fast".into()],
             active_instances: 1,
@@ -4758,6 +4782,7 @@ mod tests {
             node_id: "slow".into(),
             address: "http://slow".into(),
             version: "0.1.0".into(),
+            llama_cpp_version: "unknown".into(),
             last_seen: 0,
             supported_models: vec!["gpt:fast".into()],
             active_instances: 1,
@@ -4827,6 +4852,7 @@ mod tests {
             node_id: "peer".into(),
             address: "http://peer".into(),
             version: "0.1.0".into(),
+            llama_cpp_version: "unknown".into(),
             last_seen: 0,
             supported_models: vec!["gpt:fast".into()],
             active_instances: 1,

--- a/src/node_state/peer_state.rs
+++ b/src/node_state/peer_state.rs
@@ -25,6 +25,13 @@ pub struct PeerState {
     pub node_id: String,
     pub address: String,
     pub version: String,
+    /// llama.cpp commit of the binary currently serving on this node, or
+    /// `"unknown"` if no build has been recorded yet. Mirrors the value the node
+    /// reports via `/metrics` (`proxy_build_info`) and `/metrics/json`, letting
+    /// the cluster view (`/cluster/nodes`) surface llama.cpp version skew across
+    /// nodes from any single node.
+    #[serde(default = "default_llama_cpp_version")]
+    pub llama_cpp_version: String,
     pub last_seen: u64,
     pub supported_models: Vec<String>,
     #[serde(default)]
@@ -71,6 +78,13 @@ fn default_ready() -> bool {
     true // For backwards compatibility with older nodes that don't send this field
 }
 
+fn default_llama_cpp_version() -> String {
+    // Pre-1.6.0 peers don't gossip this field; treat them as "version not yet
+    // known", matching the sentinel `BuildManager::get_version` returns before a
+    // build is recorded.
+    "unknown".to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -109,6 +123,7 @@ mod tests {
             node_id: "node-1".into(),
             address: "http://localhost:8080".into(),
             version: "1.0.0".into(),
+            llama_cpp_version: "b2c3d4e5f".into(),
             last_seen: 12345,
             supported_models: vec!["model:fast".into()],
             model_stats: HashMap::new(),
@@ -133,6 +148,8 @@ mod tests {
         let parsed: PeerState = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.node_id, "node-1");
         assert_eq!(parsed.address, "http://localhost:8080");
+        assert_eq!(parsed.version, "1.0.0");
+        assert_eq!(parsed.llama_cpp_version, "b2c3d4e5f");
         assert_eq!(parsed.active_instances, 2);
         assert_eq!(parsed.external_vram_mb, 500);
         assert!(parsed.gpu_telemetry_available);
@@ -144,7 +161,8 @@ mod tests {
 
     #[test]
     fn test_peer_state_default_ready() {
-        // Test backwards compatibility - missing "ready" field defaults to true
+        // Test backwards compatibility - a pre-1.6.0 node's gossip omits both the
+        // "ready" and "llama_cpp_version" fields, which must fall back to defaults.
         let json = r#"{
             "node_id": "node-old",
             "address": "http://old:8080",
@@ -160,6 +178,10 @@ mod tests {
         }"#;
         let parsed: PeerState = serde_json::from_str(json).unwrap();
         assert!(parsed.ready); // Should default to true
+
+        // Missing "llama_cpp_version" (older peer) defaults to "unknown" rather
+        // than failing the gossip deserialize.
+        assert_eq!(parsed.llama_cpp_version, "unknown");
         assert_eq!(parsed.external_vram_mb, 0);
         assert_eq!(parsed.device_vram_used_mb, 0);
         assert!(!parsed.gpu_telemetry_available);
@@ -168,5 +190,10 @@ mod tests {
     #[test]
     fn test_default_ready_returns_true() {
         assert!(default_ready());
+    }
+
+    #[test]
+    fn test_default_llama_cpp_version_returns_unknown() {
+        assert_eq!(default_llama_cpp_version(), "unknown");
     }
 }


### PR DESCRIPTION
## Summary

`GET /cluster/nodes` advertised each node's proxy `version` but not its
`llama_cpp_version` — the llama.cpp commit of the running binary — even though
the v1.5.0 changelog described the commit as "surfaced in ... `/cluster/nodes`".
The field was never added to the cluster/gossip node representation, so the
cluster view exposed only `version`.

This adds `llama_cpp_version` to the gossiped `PeerState`, populated in
`get_self_peer_state` from `build_manager.get_version()` — the same value already
exposed by the `proxy_build_info` metric and the `/metrics/json` snapshot.
Because it rides the existing gossip `origin`, any single node's `/cluster/nodes`
now carries the llama.cpp commit for every reachable peer, making llama.cpp
version skew observable cluster-wide from one endpoint.

## Changes

- `PeerState`: new `llama_cpp_version: String` field with
  `#[serde(default = "default_llama_cpp_version")]` (defaults to `"unknown"`).
- `get_self_peer_state`: populates it from `build_manager.get_version().await`.
- Transitively-discovered placeholder peers report `"unknown"` until the first
  direct gossip from that peer.
- Docs: SPEC gossip-metadata list updated; `CHANGELOG` `[1.6.0]` entry (Added,
  plus a Fixed note correcting the premature 1.5.0 claim).
- Version bump 1.5.0 → 1.6.0 (`Cargo.toml` + `Cargo.lock`).

## Backwards compatibility

The new gossip field is additive and deserializes with a default, so mixed
clusters interoperate during a rolling upgrade: peers that predate the field are
recorded as `"unknown"`, and older nodes ignore the field sent by upgraded peers.

## Testing

`cargo test` green (307 unit tests + integration tests). New/updated coverage:

- `test_peer_state_serde_roundtrip` — the field round-trips through serde.
- `test_peer_state_default_ready` — a pre-1.6.0 node's gossip JSON (omitting
  `llama_cpp_version`) deserializes to the `"unknown"` default instead of failing.
- `test_default_llama_cpp_version_returns_unknown` — the default helper.
- `test_gossip_discovers_new_peers` — a gossiped `llama_cpp_version` is stored for
  the origin peer; transitively-discovered peers default to `"unknown"`.
- `self_peer_state_*` — `get_self_peer_state` reports the build manager's version.

Live validation on a two-node cluster is the pre-merge gate (confirmation to
follow on this PR).

Closes #41
