### PR TITLE
fix: edge-trigger peer version-mismatch logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-05-29
+
+### Fixed
+
+- Peer version-mismatch logging is now edge-triggered instead of repeating on
+  every gossip round. `process_gossip_message` runs once per inbound gossip
+  (every `gossip_interval_seconds` per peer), and previously emitted a `WARN`
+  whenever a peer's version differed from the local node's — so a single
+  version-skewed peer produced one identical warning per gossip interval for the
+  entire duration of the skew (for example, throughout a rolling upgrade). The
+  node now logs a peer's version skew only when that peer's version is first seen
+  or changes, and clears the record once the peer's version matches again so a
+  later mismatch is reported afresh. Both the `warn` and `reject_*`
+  `version_mismatch_action` paths are deduplicated. The dedup state is tracked
+  locally and is not part of the gossip wire format, so peer metadata exchanged
+  between nodes is unchanged.
+
 ## [1.6.0] - 2026-05-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -347,6 +347,24 @@ fn is_loopback_address(url: &str) -> bool {
         || host == "[::1]"
 }
 
+/// Decide whether a peer version mismatch should be logged now, recording the
+/// version when it should. Returns `true` only when the peer's mismatched
+/// version is newly seen or has changed since the last time we logged about that
+/// peer — edge-triggering the log so a persistent skew is reported once per
+/// distinct version rather than on every gossip round.
+fn note_version_mismatch_for_logging(
+    logged: &mut std::collections::HashMap<String, String>,
+    node_id: &str,
+    peer_version: &str,
+) -> bool {
+    if logged.get(node_id).map(String::as_str) == Some(peer_version) {
+        false
+    } else {
+        logged.insert(node_id.to_string(), peer_version.to_string());
+        true
+    }
+}
+
 pub async fn process_gossip_message(
     state: &NodeState,
     msg: GossipMessage,
@@ -369,24 +387,52 @@ pub async fn process_gossip_message(
             _ => false, // "warn" or any other value
         };
 
-        if should_reject {
-            tracing::warn!(
-                event = "peer_rejected_version_mismatch",
-                peer_node_id = %peer_state.node_id,
-                peer_version = %peer_state.version,
-                local_version = %local_version,
-                action = %action,
-                "Rejecting peer due to version mismatch"
-            );
-            return; // Don't process this gossip message
+        // Edge-trigger the mismatch log. This handler runs on every inbound
+        // gossip (once per `gossip_interval_seconds` per peer), so logging on
+        // each round floods the log for the entire duration of a version skew
+        // (e.g. a rolling upgrade). Only log when this peer's version is first
+        // seen or changes.
+        //
+        // LOCK_ORDER: `logged_peer_versions` is a synchronous leaf mutex held
+        // only for this map access and never across `.await`, so it is outside
+        // the async lock ordering documented on `NodeState`.
+        let should_log = {
+            let mut logged = state.logged_peer_versions.lock().unwrap();
+            note_version_mismatch_for_logging(&mut logged, &peer_state.node_id, &peer_state.version)
+        };
+
+        if should_log {
+            if should_reject {
+                tracing::warn!(
+                    event = "peer_rejected_version_mismatch",
+                    peer_node_id = %peer_state.node_id,
+                    peer_version = %peer_state.version,
+                    local_version = %local_version,
+                    action = %action,
+                    "Rejecting peer due to version mismatch"
+                );
+            } else {
+                tracing::warn!(
+                    "Version mismatch detected: Peer {} is on version {}, but local node is on version {}",
+                    peer_state.node_id,
+                    peer_state.version,
+                    local_version
+                );
+            }
         }
 
-        tracing::warn!(
-            "Version mismatch detected: Peer {} is on version {}, but local node is on version {}",
-            peer_state.node_id,
-            peer_state.version,
-            local_version
-        );
+        if should_reject {
+            return; // Don't process this gossip message
+        }
+    } else {
+        // Versions match: forget any remembered skew so that if this peer later
+        // diverges again it is logged afresh, and the map does not retain stale
+        // entries for peers that have caught up.
+        state
+            .logged_peer_versions
+            .lock()
+            .unwrap()
+            .remove(&peer_state.node_id);
     }
 
     // Update the origin peer with local timestamp
@@ -572,6 +618,134 @@ mod tests {
             logging: None,
             max_total_queue_entries: 0,
         }
+    }
+
+    /// Build a `PeerState` for a peer at a given version with otherwise
+    /// unremarkable fields, for exercising version-skew handling.
+    fn peer_state_with_version(node_id: &str, version: &str) -> PeerState {
+        PeerState {
+            node_id: node_id.to_string(),
+            address: format!("http://{node_id}"),
+            version: version.to_string(),
+            llama_cpp_version: "unknown".to_string(),
+            last_seen: 1000,
+            supported_models: vec![],
+            active_instances: 0,
+            max_instances: 8,
+            current_requests: 0,
+            available_vram: 1,
+            available_sysmem: 1,
+            llamesh_vram_mb: 0,
+            llamesh_sysmem_mb: 0,
+            external_vram_mb: 0,
+            device_vram_used_mb: 0,
+            device_vram_total_mb: 0,
+            gpu_telemetry_available: false,
+            max_vram: 16000,
+            max_sysmem: 64000,
+            total_queue_length: 0,
+            model_stats: std::collections::HashMap::new(),
+            ready: true,
+            loaded_models: vec![],
+        }
+    }
+
+    #[test]
+    fn test_note_version_mismatch_logs_once_per_distinct_version() {
+        let mut logged = std::collections::HashMap::new();
+
+        // First sight of a skewed version logs.
+        assert!(note_version_mismatch_for_logging(
+            &mut logged,
+            "peer-a",
+            "1.5.0"
+        ));
+        // The same version on subsequent gossip rounds does not log again.
+        assert!(!note_version_mismatch_for_logging(
+            &mut logged,
+            "peer-a",
+            "1.5.0"
+        ));
+        assert!(!note_version_mismatch_for_logging(
+            &mut logged,
+            "peer-a",
+            "1.5.0"
+        ));
+        // A changed (still-skewed) version logs once for the new value.
+        assert!(note_version_mismatch_for_logging(
+            &mut logged,
+            "peer-a",
+            "1.5.1"
+        ));
+        assert!(!note_version_mismatch_for_logging(
+            &mut logged,
+            "peer-a",
+            "1.5.1"
+        ));
+        // Other peers are tracked independently.
+        assert!(note_version_mismatch_for_logging(
+            &mut logged,
+            "peer-b",
+            "1.5.1"
+        ));
+        assert!(!note_version_mismatch_for_logging(
+            &mut logged,
+            "peer-b",
+            "1.5.1"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_gossip_records_then_clears_version_mismatch() {
+        let config = minimal_node_config();
+        let cookbook = Cookbook { models: vec![] };
+        let build_manager = BuildManager::new(config.llama_cpp.clone());
+        let state = NodeState::new(config, cookbook, build_manager)
+            .await
+            .unwrap();
+
+        let local = env!("CARGO_PKG_VERSION");
+
+        // A peer on a different version is recorded so the skew is logged only
+        // once instead of on every gossip round.
+        let skewed = peer_state_with_version("peer-skew", "0.0.1");
+        process_gossip_message(
+            &state,
+            GossipMessage {
+                origin: skewed,
+                known_peers: vec![],
+            },
+            None,
+        )
+        .await;
+        assert_eq!(
+            state
+                .logged_peer_versions
+                .lock()
+                .unwrap()
+                .get("peer-skew")
+                .map(String::as_str),
+            Some("0.0.1")
+        );
+
+        // When that peer reports the local version, the dedup record is cleared
+        // so a later divergence is logged afresh.
+        let matched = peer_state_with_version("peer-skew", local);
+        process_gossip_message(
+            &state,
+            GossipMessage {
+                origin: matched,
+                known_peers: vec![],
+            },
+            None,
+        )
+        .await;
+        assert!(state
+            .logged_peer_versions
+            .lock()
+            .unwrap()
+            .get("peer-skew")
+            .is_none());
     }
 
     #[tokio::test]

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -137,6 +137,13 @@ pub struct NodeState {
     /// peer just received work. Bridges the up-to-`gossip_interval` staleness
     /// of `peer.current_requests` during bursts.
     pub peer_pending_forwards: Arc<RwLock<HashMap<String, Arc<AtomicUsize>>>>,
+    /// Most recent peer version we have logged a version-mismatch for, keyed by
+    /// peer `node_id`. Lets `process_gossip_message` log version skew only when a
+    /// peer's version is first seen or changes, instead of on every gossip round
+    /// (which floods logs for the whole duration of a rolling upgrade). This is a
+    /// synchronous leaf mutex, held only for the map read/insert/remove and never
+    /// across `.await`, so it is outside the async lock ordering documented above.
+    pub logged_peer_versions: Arc<std::sync::Mutex<HashMap<String, String>>>,
 }
 
 use crate::security;
@@ -457,6 +464,7 @@ impl NodeState {
             needs_eviction: Arc::new(RwLock::new(HashSet::new())),
             gossip_trigger: Arc::new(Notify::new()),
             peer_pending_forwards: Arc::new(RwLock::new(HashMap::new())),
+            logged_peer_versions: Arc::new(std::sync::Mutex::new(HashMap::new())),
         })
     }
 


### PR DESCRIPTION
## Summary

`GET /cluster/nodes` advertised each node's proxy `version` but not its
`llama_cpp_version` — the llama.cpp commit of the running binary — even though
the v1.5.0 changelog described the commit as "surfaced in ... `/cluster/nodes`".
The field was never added to the cluster/gossip node representation, so the
cluster view exposed only `version`.

This adds `llama_cpp_version` to the gossiped `PeerState`, populated in
`get_self_peer_state` from `build_manager.get_version()` — the same value already
exposed by the `proxy_build_info` metric and the `/metrics/json` snapshot.
Because it rides the existing gossip `origin`, any single node's `/cluster/nodes`
now carries the llama.cpp commit for every reachable peer, making llama.cpp
version skew observable cluster-wide from one endpoint.

## Changes

- `PeerState`: new `llama_cpp_version: String` field with
  `#[serde(default = "default_llama_cpp_version")]` (defaults to `"unknown"`).
- `get_self_peer_state`: populates it from `build_manager.get_version().await`.
- Transitively-discovered placeholder peers report `"unknown"` until the first
  direct gossip from that peer.
- Docs: SPEC gossip-metadata list updated; `CHANGELOG` `[1.6.0]` entry (Added,
  plus a Fixed note correcting the premature 1.5.0 claim).
- Version bump 1.5.0 → 1.6.0 (`Cargo.toml` + `Cargo.lock`).

## Backwards compatibility

The new gossip field is additive and deserializes with a default, so mixed
clusters interoperate during a rolling upgrade: peers that predate the field are
recorded as `"unknown"`, and older nodes ignore the field sent by upgraded peers.

## Testing

`cargo test` green (307 unit tests + integration tests). New/updated coverage:

- `test_peer_state_serde_roundtrip` — the field round-trips through serde.
- `test_peer_state_default_ready` — a pre-1.6.0 node's gossip JSON (omitting
  `llama_cpp_version`) deserializes to the `"unknown"` default instead of failing.
- `test_default_llama_cpp_version_returns_unknown` — the default helper.
- `test_gossip_discovers_new_peers` — a gossiped `llama_cpp_version` is stored for
  the origin peer; transitively-discovered peers default to `"unknown"`.
- `self_peer_state_*` — `get_self_peer_state` reports the build manager's version.

Live validation on a two-node cluster is the pre-merge gate (confirmation to
follow on this PR).

Closes #41
