### PR TITLE
fix: parse model params from current llama.cpp startup log format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-05-30
+
+### Added
+
+- The `parsed_model_params` reported per profile by `GET /v1/models` now includes
+  `n_ctx` — the effective per-request context window the running instance is
+  serving (parsed from llama-server's `new slot, n_ctx = <N>` line). This is the
+  context length a client can actually use, which may be smaller than the model's
+  trained maximum (`n_ctx_train`) when an instance is launched with a reduced
+  context.
+
+### Fixed
+
+- Restore model-parameter parsing against current `llama-server` builds. Recent
+  llama.cpp releases (build ~9425) raised the verbosity of the `print_info:`
+  model-metadata block above the default log threshold, so it no longer appears
+  in a default-verbosity startup log. The startup-log parser recognized only that
+  block, so on current builds it extracted nothing and logged `Failed to parse
+  model params from startup log` on essentially every instance spawn, while
+  `parsed_model_params` in `/v1/models` was always null. The parser now also reads
+  the fields that remain available at default verbosity — the effective context
+  window (`new slot, n_ctx = <N>`) and the trained context length (from the
+  `n_ctx_seq (<x>) < n_ctx_train (<N>)` capacity warning) — so model params are
+  observable again without raising llama-server verbosity. Existing `print_info:`
+  parsing is retained (its regex already tolerates the new timestamp/severity log
+  prefix), so older builds and instances launched with raised verbosity continue
+  to yield the full metadata set. Because `n_ctx` is present in every healthy
+  startup log regardless of verbosity, the "failed to parse" warning is now
+  emitted only when a startup log is genuinely unparseable rather than on every
+  spawn.
+
 ## [1.6.1] - 2026-05-29
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.6.1"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.6.1"
+version = "1.7.0"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -20,6 +20,12 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 pub struct ParsedModelParams {
     // Core context/batch
     pub n_ctx_train: Option<u64>,
+    /// Effective per-request context window the instance is serving, parsed from
+    /// `new slot, n_ctx = <N>`. May be smaller than `n_ctx_train` when the
+    /// instance is launched with a reduced context. Unlike the other fields here
+    /// (which come from the model-metadata block), this line is present in every
+    /// healthy startup log regardless of llama.cpp log verbosity.
+    pub n_ctx: Option<u64>,
     pub n_batch: Option<u64>,
     pub n_ubatch: Option<u64>,
 
@@ -44,9 +50,27 @@ pub struct ParsedModelParams {
     pub freq_base_train: Option<f64>,
 }
 
-/// Static compiled regex for parsing llama-server log lines.
+/// Static compiled regex for the model-metadata block (`print_info: <key> = <value>`).
+///
+/// Since llama.cpp build ~9425 these lines are emitted only *above* the default
+/// log verbosity threshold (`-lv 3`), so they are typically absent from a
+/// default-verbosity startup log; they are still parsed here for older builds
+/// and for instances launched with raised verbosity. The pattern is
+/// intentionally unanchored so the timestamp/severity prefix that newer builds
+/// prepend (e.g. `0.00.670.006 I print_info: ...`) is ignored.
 static LOG_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"print_info:\s+(\S+)\s+=\s+(.+)").unwrap());
+
+/// Effective per-slot context window, logged at default verbosity as
+/// `slot load_model: ... new slot, n_ctx = <N>`.
+static SLOT_N_CTX_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"new slot, n_ctx = (\d+)").unwrap());
+
+/// Trained context length, logged at default verbosity only inside the capacity
+/// warning `n_ctx_seq (<x>) < n_ctx_train (<N>)` (printed when an instance is
+/// launched with a context smaller than the model was trained on).
+static N_CTX_TRAIN_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"n_ctx_train \((\d+)\)").unwrap());
 
 /// Maximum number of startup log lines to buffer per instance.
 /// Prevents unbounded memory growth if an instance floods stdout before becoming ready.
@@ -101,6 +125,24 @@ pub fn parse_llama_server_log(lines: &[String]) -> ParsedModelParams {
         } else if line.contains("print_info: model params") {
             if let Some(idx) = line.find('=') {
                 params.model_params = Some(line[idx + 1..].trim().to_string());
+            }
+        }
+
+        // New default-verbosity format (llama.cpp build ~9425+): the verbose
+        // `print_info:` block above is suppressed, but the effective context
+        // window is always logged per slot, and the trained context length is
+        // logged (when the running context is reduced) in a capacity warning.
+        // Parsing these keeps model params observable without raising verbosity.
+        // `print_info:` values, when present, are parsed first and take
+        // precedence, hence the `is_none` guards.
+        if params.n_ctx.is_none() {
+            if let Some(caps) = SLOT_N_CTX_REGEX.captures(line) {
+                params.n_ctx = caps.get(1).and_then(|m| m.as_str().parse().ok());
+            }
+        }
+        if params.n_ctx_train.is_none() {
+            if let Some(caps) = N_CTX_TRAIN_REGEX.captures(line) {
+                params.n_ctx_train = caps.get(1).and_then(|m| m.as_str().parse().ok());
             }
         }
     }
@@ -330,14 +372,19 @@ impl Instance {
         let params = parse_llama_server_log(&lines);
 
         // Check if we got any meaningful data
-        let has_data =
-            params.n_ctx_train.is_some() || params.arch.is_some() || params.model_name.is_some();
+        // `n_ctx` is present in every healthy startup log regardless of
+        // verbosity, so a parse yielding no data at all now reliably indicates a
+        // genuinely malformed/empty log rather than an upstream log-format change.
+        let has_data = params.n_ctx.is_some()
+            || params.n_ctx_train.is_some()
+            || params.arch.is_some()
+            || params.model_name.is_some();
 
         if has_data {
             info!(
                 instance_id = %self.id,
-                "Parsed model params: arch={:?}, n_ctx_train={:?}, n_layer={:?}, model_name={:?}",
-                params.arch, params.n_ctx_train, params.n_layer, params.model_name
+                "Parsed model params: n_ctx={:?}, n_ctx_train={:?}, arch={:?}, n_layer={:?}, model_name={:?}",
+                params.n_ctx, params.n_ctx_train, params.arch, params.n_layer, params.model_name
             );
             *self.parsed_params.lock() = Some(params);
         } else {
@@ -737,11 +784,49 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_llama_server_log_new_default_verbosity_format() {
+        // Real default-verbosity startup output from llama.cpp build 9425: the
+        // verbose `print_info:` block is suppressed, but the effective context
+        // window (per slot) and the trained context length (capacity warning)
+        // are still present. Both lines carry the new timestamp/severity prefix.
+        let lines = vec![
+            "0.04.710.907 W llama_context: n_ctx_seq (4096) < n_ctx_train (131072) -- the full capacity of the model will not be utilized".to_string(),
+            "0.04.730.906 I srv    load_model: initializing slots, n_slots = 4".to_string(),
+            "0.04.789.423 I slot   load_model: id  0 | task -1 | new slot, n_ctx = 4096".to_string(),
+            "0.04.789.437 I slot   load_model: id  1 | task -1 | new slot, n_ctx = 4096".to_string(),
+        ];
+        let params = parse_llama_server_log(&lines);
+        assert_eq!(params.n_ctx, Some(4096));
+        assert_eq!(params.n_ctx_train, Some(131072));
+    }
+
+    #[test]
+    fn test_parse_llama_server_log_high_verbosity_prefixed_print_info() {
+        // At raised verbosity (or on older builds) the `print_info:` block
+        // returns, prefixed with a timestamp/severity. The unanchored regex must
+        // still extract it, and `print_info: n_ctx_train` must take precedence
+        // over the capacity warning's value.
+        let lines = vec![
+            "0.00.670.006 I print_info: arch                  = gemma4".to_string(),
+            "0.00.670.006 I print_info: n_ctx_train           = 131072".to_string(),
+            "0.00.670.008 I print_info: n_layer               = 35".to_string(),
+            "0.04.710.907 W llama_context: n_ctx_seq (4096) < n_ctx_train (131072) -- the full capacity of the model will not be utilized".to_string(),
+            "0.04.789.423 I slot   load_model: id  0 | task -1 | new slot, n_ctx = 4096".to_string(),
+        ];
+        let params = parse_llama_server_log(&lines);
+        assert_eq!(params.arch, Some("gemma4".to_string()));
+        assert_eq!(params.n_ctx_train, Some(131072));
+        assert_eq!(params.n_layer, Some(35));
+        assert_eq!(params.n_ctx, Some(4096));
+    }
+
+    #[test]
     fn test_parse_llama_server_log_empty() {
         let lines: Vec<String> = vec!["no matching lines here".to_string()];
         let params = parse_llama_server_log(&lines);
         // All fields should be None
         assert!(params.n_ctx_train.is_none());
+        assert!(params.n_ctx.is_none());
         assert!(params.arch.is_none());
     }
 


### PR DESCRIPTION
## Summary

On current `llama-server` builds the startup-log parser extracted no model parameters, so `WARN "Failed to parse model params from startup log"` was logged on essentially every instance spawn, and `parsed_model_params` in `GET /v1/models` was always `null`. This restores parsing and adds the effective context window to the reported metadata.

Fixes #45.

## Root cause

`parse_llama_server_log` recognizes only the `print_info: <key> = <value>` model-metadata block. Recent llama.cpp releases (build ~9425) raised the verbosity of that block above the default log threshold (`-lv 3`), so it is absent from a default-verbosity startup log. The lines were not removed — they reappear at raised verbosity — so the parser simply never saw them.

## Changes

- Parse the fields that remain present at default verbosity:
  - the effective per-request context window from `new slot, n_ctx = <N>` (new `n_ctx` field);
  - the trained context length from the `n_ctx_seq (<x>) < n_ctx_train (<N>)` capacity warning.
- Add `n_ctx` to `ParsedModelParams`, surfaced in `GET /v1/models` → `metadata.parsed_model_params`.
- Retain the existing `print_info:` parsing. Its regex is unanchored, so it already tolerates the new timestamp/severity prefix (e.g. `0.00.670.006 I print_info: ...`); older builds and raised-verbosity instances continue to yield the full metadata set. `print_info:` values, when present, take precedence (the new extraction is guarded by `is_none()`).
- Base the "failed to parse" warning on `n_ctx`, which is present in every healthy startup log regardless of verbosity, so the warning now fires only on genuinely unparseable logs rather than on every spawn.

Routing and admission are unaffected — they rely on cookbook estimates rather than parsed params — so this is observability-only.

## Versioning

Minor bump (`1.6.1` → `1.7.0`): the change adds a new `n_ctx` field to the public `GET /v1/models` metadata surface (a backward-compatible addition), alongside the parsing fix. `Cargo.lock` and `CHANGELOG.md` are updated in this PR.

## Testing

- New unit tests parse **real captured startup logs** from `llama-server` build 9425 (`0821c5fcf`) at both default and raised verbosity; the existing `print_info:` tests are retained.
- `cargo test --bin llamesh`: 311 passed.
- `cargo clippy` / `cargo fmt --check`: no new findings attributable to this change (a pre-existing `too_many_arguments` lint and an unrelated formatting drift are untouched).
- End-to-end validation against a live node running this build is underway and will be confirmed in a comment before merge.
