### PR TITLE
feat: surface llama-server slot count (n_slots) in /v1/models parsed_model_params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-05-30
+
+### Added
+
+- The `parsed_model_params` reported per profile by `GET /v1/models` now includes
+  `n_slots` — the number of parallel decode slots the running instance
+  initialized, i.e. the number of requests it can serve concurrently. This is
+  parsed from llama-server's `initializing slots, n_slots = <N>` startup line,
+  which (like the `new slot, n_ctx = <N>` line added in 1.7.0) is present at the
+  default log verbosity. When a profile does not pin `--parallel`/`-np`,
+  llama-server resolves the slot count automatically, so the running instance's
+  real concurrency can differ from the proxy's configured
+  `max_concurrent_requests_per_instance`; surfacing `n_slots` makes that
+  divergence observable through the API. This is observability only — admission
+  and slot-aware scheduling are unchanged, and the field is an additive,
+  backward-compatible addition to the JSON response (absent as `null` until an
+  instance is running).
+
 ## [1.7.0] - 2026-05-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/SPEC.md
+++ b/SPEC.md
@@ -561,7 +561,11 @@ Response:
         "profile_description": "Lower context, higher throughput",
         "idle_timeout_seconds": 600,
         "estimated_tokens_per_second": 42.5,
-        "parsed_model_params": "20B"
+        "parsed_model_params": {
+          "n_ctx": 4096,
+          "n_ctx_train": 131072,
+          "n_slots": 4
+        }
       }
     },
     {
@@ -575,7 +579,8 @@ Response:
       "metadata": {
         "model": "gpt-oss-20b",
         "profile_id": "quality",
-        "profile_description": "Larger context, more careful settings"
+        "profile_description": "Larger context, more careful settings",
+        "parsed_model_params": null
       }
     }
   ],
@@ -586,7 +591,7 @@ Response:
 Implementation notes:
 
 * `owned_by` is set to the `node_id` of the node that hosts the model.
-* Metadata includes `model`, `profile_id`, `profile_description`, `idle_timeout_seconds`, `estimated_tokens_per_second` (from learned metrics), and `parsed_model_params` (extracted from startup logs, e.g. `"20B"`).
+* Metadata includes `model`, `profile_id`, `profile_description`, `idle_timeout_seconds`, `estimated_tokens_per_second` (from learned metrics), and `parsed_model_params` (an object extracted from the running instance's startup log, or `null` when no instance is running). At default llama.cpp log verbosity it carries the effective context window (`n_ctx`), the trained context length (`n_ctx_train`), and the resolved slot count (`n_slots`); the model-metadata fields (architecture, layer/head counts, etc.) are additionally populated on older builds or when the instance is launched at raised verbosity, and are `null` otherwise.
 * For models advertised by cluster peers, metadata is `{ "source": "cluster", "advertised_by": "<peer_node_id>", "cluster_url": "<peer_url>" }`.
 * When in cluster mode, returns the union of models supported by the cluster.
 
@@ -925,7 +930,7 @@ Each instance is a `llama-server` process spawned by the proxy:
 
 * Startup log parsing:
 
-  * The proxy parses `llama-server` startup logs to extract model parameters (`n_ctx_train`, `n_layer`, architecture). These are exposed in `/v1/models` metadata as `parsed_model_params`.
+  * The proxy parses `llama-server` startup logs to extract model parameters. At default log verbosity it reads the effective context window (`n_ctx`), the trained context length (`n_ctx_train`), and the resolved parallel-slot count (`n_slots`); the model-metadata block (`n_layer`, architecture, etc.) is also parsed when present (older builds or raised verbosity). These are exposed in `/v1/models` metadata as `parsed_model_params`.
 
 * Idle eviction:
 

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -26,6 +26,13 @@ pub struct ParsedModelParams {
     /// (which come from the model-metadata block), this line is present in every
     /// healthy startup log regardless of llama.cpp log verbosity.
     pub n_ctx: Option<u64>,
+    /// Number of parallel decode slots the instance initialized, parsed from
+    /// `initializing slots, n_slots = <N>`. This is the number of requests the
+    /// instance can serve concurrently. When a profile does not pin
+    /// `--parallel`/`-np`, llama-server derives this automatically, so it may
+    /// differ from the proxy's configured `max_concurrent_requests_per_instance`.
+    /// Like `n_ctx`, this line is present at default llama.cpp log verbosity.
+    pub n_slots: Option<u64>,
     pub n_batch: Option<u64>,
     pub n_ubatch: Option<u64>,
 
@@ -65,6 +72,13 @@ static LOG_REGEX: LazyLock<Regex> =
 /// `slot load_model: ... new slot, n_ctx = <N>`.
 static SLOT_N_CTX_REGEX: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"new slot, n_ctx = (\d+)").unwrap());
+
+/// Number of parallel decode slots the instance initialized, logged at default
+/// verbosity as `srv load_model: initializing slots, n_slots = <N>`. This is the
+/// instance's real concurrency capacity, present whether `--parallel`/`-np` was
+/// set explicitly or left for llama-server to resolve automatically.
+static N_SLOTS_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"initializing slots, n_slots = (\d+)").unwrap());
 
 /// Trained context length, logged at default verbosity only inside the capacity
 /// warning `n_ctx_seq (<x>) < n_ctx_train (<N>)` (printed when an instance is
@@ -143,6 +157,11 @@ pub fn parse_llama_server_log(lines: &[String]) -> ParsedModelParams {
         if params.n_ctx_train.is_none() {
             if let Some(caps) = N_CTX_TRAIN_REGEX.captures(line) {
                 params.n_ctx_train = caps.get(1).and_then(|m| m.as_str().parse().ok());
+            }
+        }
+        if params.n_slots.is_none() {
+            if let Some(caps) = N_SLOTS_REGEX.captures(line) {
+                params.n_slots = caps.get(1).and_then(|m| m.as_str().parse().ok());
             }
         }
     }
@@ -383,8 +402,8 @@ impl Instance {
         if has_data {
             info!(
                 instance_id = %self.id,
-                "Parsed model params: n_ctx={:?}, n_ctx_train={:?}, arch={:?}, n_layer={:?}, model_name={:?}",
-                params.n_ctx, params.n_ctx_train, params.arch, params.n_layer, params.model_name
+                "Parsed model params: n_ctx={:?}, n_ctx_train={:?}, n_slots={:?}, arch={:?}, n_layer={:?}, model_name={:?}",
+                params.n_ctx, params.n_ctx_train, params.n_slots, params.arch, params.n_layer, params.model_name
             );
             *self.parsed_params.lock() = Some(params);
         } else {
@@ -798,6 +817,22 @@ mod tests {
         let params = parse_llama_server_log(&lines);
         assert_eq!(params.n_ctx, Some(4096));
         assert_eq!(params.n_ctx_train, Some(131072));
+        assert_eq!(params.n_slots, Some(4));
+    }
+
+    #[test]
+    fn test_parse_llama_server_log_n_slots() {
+        // The per-slot-init line is present at default verbosity (same tier as
+        // `new slot, n_ctx`) and carries the timestamp/severity prefix; the
+        // unanchored regex must still extract the resolved slot count.
+        let lines = vec![
+            "5.08.226.892 I srv  llama_server: n_parallel is set to auto, using n_parallel = 4 and kv_unified = true".to_string(),
+            "5.09.925.994 I srv    load_model: initializing slots, n_slots = 8".to_string(),
+            "5.10.028.388 I slot   load_model: id  0 | task -1 | new slot, n_ctx = 202752".to_string(),
+        ];
+        let params = parse_llama_server_log(&lines);
+        assert_eq!(params.n_slots, Some(8));
+        assert_eq!(params.n_ctx, Some(202752));
     }
 
     #[test]
@@ -827,6 +862,7 @@ mod tests {
         // All fields should be None
         assert!(params.n_ctx_train.is_none());
         assert!(params.n_ctx.is_none());
+        assert!(params.n_slots.is_none());
         assert!(params.arch.is_none());
     }
 
@@ -834,6 +870,7 @@ mod tests {
     fn test_parsed_model_params_default() {
         let params = ParsedModelParams::default();
         assert!(params.n_ctx_train.is_none());
+        assert!(params.n_slots.is_none());
         assert!(params.n_layer.is_none());
         assert!(params.arch.is_none());
         assert!(params.model_name.is_none());

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -390,11 +390,14 @@ impl Instance {
         let lines = self.startup_log.lock();
         let params = parse_llama_server_log(&lines);
 
-        // Check if we got any meaningful data
-        // `n_ctx` is present in every healthy startup log regardless of
-        // verbosity, so a parse yielding no data at all now reliably indicates a
-        // genuinely malformed/empty log rather than an upstream log-format change.
+        // Check if we got any meaningful data. Both `n_ctx` and `n_slots` are
+        // present in every healthy startup log regardless of verbosity, so a
+        // parse yielding none of these reliably indicates a genuinely
+        // malformed/empty log rather than an upstream log-format change. Each
+        // extracted field is included so a successfully parsed value is never
+        // discarded just because a sibling line drifted in spelling.
         let has_data = params.n_ctx.is_some()
+            || params.n_slots.is_some()
             || params.n_ctx_train.is_some()
             || params.arch.is_some()
             || params.model_name.is_some();
@@ -787,6 +790,35 @@ mod tests {
         );
         // Before parsing, should be None
         assert!(instance.get_parsed_params().is_none());
+    }
+
+    #[test]
+    fn test_parse_and_store_keeps_n_slots_only() {
+        // If a future llama.cpp build drifts the spelling of the `new slot,
+        // n_ctx` line (or it is missing from the buffered log), the slot-init
+        // line may be the only recognized value. `has_data` must still treat
+        // that as a successful parse rather than discarding n_slots and logging
+        // a spurious "Failed to parse" warning.
+        let instance = Instance::new(
+            "test-id".to_string(),
+            "test-model".to_string(),
+            "default".to_string(),
+            "127.0.0.1".to_string(),
+            8080,
+            "hash123".to_string(),
+            false,
+        );
+        instance
+            .startup_log
+            .lock()
+            .push("5.09.925.994 I srv    load_model: initializing slots, n_slots = 4".to_string());
+        instance.parse_and_store_startup_params();
+
+        let parsed = instance
+            .get_parsed_params()
+            .expect("slot count alone should count as parseable data");
+        assert_eq!(parsed.n_slots, Some(4));
+        assert_eq!(parsed.n_ctx, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`GET /v1/models` exposes per-profile `parsed_model_params` extracted from the
`llama-server` startup log (`n_ctx`, `n_ctx_train`, architecture, etc.). This
adds `n_slots` — the number of parallel decode slots the running instance
initialized, i.e. the number of requests it can serve concurrently.

`llama-server` resolves the slot count automatically when a profile does not pin
`--parallel`/`-np`, and logs it at default verbosity as:

```
srv    load_model: initializing slots, n_slots = <N>
```

The proxy schedules against its configured `max_concurrent_requests_per_instance`
and never reads the slot count the instance actually initialized; when
`--parallel` is left to auto, the two can differ. Surfacing `n_slots` makes the
instance's real concurrency observable through the API, so an operator can detect
when the configured concurrency exceeds the slots an instance actually has — and
either pin `--parallel` in the cookbook or align the proxy setting.

This mirrors the `n_ctx` field added in 1.7.0: both are runtime-resolved values
present at default log verbosity that were previously invisible.

## Changes

- Parse `initializing slots, n_slots = <N>` into a new `n_slots: Option<u64>`
  field on `ParsedModelParams`. The line is present at default verbosity (the
  same tier as `new slot, n_ctx = <N>`), whether `--parallel` is pinned or
  auto-resolved; the unanchored regex tolerates the timestamp/severity prefix.
- Include `n_slots` in the per-instance "Parsed model params" startup log line.
- Correct the SPEC.md `/v1/models` example, which still showed the obsolete
  string form of `parsed_model_params` (`"20B"`) instead of the structured
  object; document the field set and `null` semantics.
- Unit tests for the new field at default verbosity.

## Behavior / compatibility

Observability only — admission and slot-aware scheduling are unchanged.
`ParsedModelParams` is serialize-only (it is not part of the gossip wire
format), so the new field is an additive, backward-compatible addition to the
`GET /v1/models` JSON (absent as `null` until an instance is running).

## Versioning

Minor bump (`1.7.0` → `1.8.0`): adds a new `n_slots` field to the public
`GET /v1/models` metadata surface (a backward-compatible addition). `Cargo.lock`
and `CHANGELOG.md` are updated in this PR.

## Testing

- `cargo test --bin llamesh`: 312 passed, including the new parser tests.
- `cargo clippy` / `cargo fmt --check`: no new findings attributable to this
  change (a pre-existing `too_many_arguments` lint and an unrelated formatting
  drift are untouched).
- End-to-end validation against a live node on the current llama.cpp build: the
  startup-log parser populates `n_slots`, and it appears in the `GET /v1/models`
  `parsed_model_params` object alongside `n_ctx`.

Closes #47
