### PR TITLE
fix: reject duplicate model:profile identifiers in the cookbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-05-30
+
+### Fixed
+
+- The cookbook now rejects duplicate `model:profile` identifiers at load time
+  instead of silently shadowing one of them. `build_model_index` keys the model
+  index by a case-insensitive `"<model>:<profile>"` string in a `HashMap`, so two
+  entries that resolve to the same key — a repeated profile `id` within a model,
+  or a model `name` reused with an overlapping profile id (matching is
+  case-insensitive) — would overwrite each other, leaving one configuration
+  unreachable with no error or warning at startup or on hot-reload.
+  `Cookbook::validate()` now detects this collision among the enabled
+  `(model, profile)` pairs that the index actually builds and fails with an error
+  naming both conflicting identifiers. Because hot-reload validates before
+  swapping the index, a live edit that introduces a duplicate is rejected and the
+  previously loaded cookbook keeps serving.
+
 ## [1.8.0] - 2026-05-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.8.0"
+version = "1.8.1"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -462,9 +462,33 @@ pub struct Cookbook {
 
 impl Cookbook {
     pub fn validate(&self) -> anyhow::Result<()> {
+        // Tracks the first display name seen for each case-insensitive
+        // "model:profile" key, mirroring how `build_model_index` keys the model
+        // index. The index inserts into a HashMap, so a duplicate key would
+        // silently overwrite (shadow) one definition; reject it here instead.
+        // Only enabled pairs are indexed, so only those can actually collide.
+        let mut seen: std::collections::HashMap<String, String> = std::collections::HashMap::new();
         for model in &self.models {
             for profile in &model.profiles {
                 profile.validate(&model.name)?;
+
+                if model.enabled && profile.enabled {
+                    let key = format!(
+                        "{}:{}",
+                        model.name.to_lowercase(),
+                        profile.id.to_lowercase()
+                    );
+                    let display = format!("{}:{}", model.name, profile.id);
+                    if let Some(first) = seen.get(&key) {
+                        return Err(anyhow::anyhow!(
+                            "Duplicate model:profile identifier: '{first}' and '{display}' both \
+                             resolve to '{key}'. Model and profile names are matched \
+                             case-insensitively, so these would shadow each other in the model \
+                             index; make each model:profile unique."
+                        ));
+                    }
+                    seen.insert(key, display);
+                }
             }
         }
         Ok(())
@@ -987,6 +1011,87 @@ mod tests {
             min_eviction_tenure_secs: None,
         };
         assert!(profile.validate("test_model").is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_duplicate_profile_id() {
+        // Two enabled profiles with the same id in one model collide on the
+        // model-index key "foo:fast" and would silently shadow each other.
+        let yaml = r#"
+models:
+  - name: foo
+    profiles:
+      - id: fast
+        model_path: /tmp/m.gguf
+        llama_server_args: ""
+      - id: fast
+        model_path: /tmp/m.gguf
+        llama_server_args: ""
+"#;
+        let cb: Cookbook = serde_yaml::from_str(yaml).unwrap();
+        assert!(cb.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_case_insensitive_duplicate() {
+        // "Foo:Default" and "foo:default" lowercase to the same index key.
+        let yaml = r#"
+models:
+  - name: Foo
+    profiles:
+      - id: Default
+        model_path: /tmp/m.gguf
+        llama_server_args: ""
+  - name: foo
+    profiles:
+      - id: default
+        model_path: /tmp/m.gguf
+        llama_server_args: ""
+"#;
+        let cb: Cookbook = serde_yaml::from_str(yaml).unwrap();
+        assert!(cb.validate().is_err());
+    }
+
+    #[test]
+    fn validate_allows_disabled_duplicate() {
+        // A disabled profile is never indexed, so it cannot collide.
+        let yaml = r#"
+models:
+  - name: foo
+    profiles:
+      - id: fast
+        model_path: /tmp/m.gguf
+        llama_server_args: ""
+      - id: fast
+        enabled: false
+        model_path: /tmp/m.gguf
+        llama_server_args: ""
+"#;
+        let cb: Cookbook = serde_yaml::from_str(yaml).unwrap();
+        assert!(cb.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_unique_identifiers() {
+        // Same profile id under different model names is fine (distinct keys).
+        let yaml = r#"
+models:
+  - name: foo
+    profiles:
+      - id: fast
+        model_path: /tmp/m.gguf
+        llama_server_args: ""
+      - id: quality
+        model_path: /tmp/m.gguf
+        llama_server_args: ""
+  - name: bar
+    profiles:
+      - id: fast
+        model_path: /tmp/m.gguf
+        llama_server_args: ""
+"#;
+        let cb: Cookbook = serde_yaml::from_str(yaml).unwrap();
+        assert!(cb.validate().is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The cookbook silently shadowed two entries that resolve to the same
`model:profile` identifier, keeping only one. This adds validation that rejects
the collision at load time with a clear error, instead of leaving one
configuration unreachable.

## Root cause

`build_model_index` keys the model index by a case-insensitive
`"<model>:<profile>"` string and inserts into a `HashMap`:

```rust
let key = format!("{}:{}", model.name.to_lowercase(), profile.id.to_lowercase());
index.insert(key, (model.name.clone(), profile.clone()));
```

Duplicate keys overwrite — the last one wins. `Cookbook::validate()` checked
model sources but never identifier uniqueness, so a repeated profile `id`, or a
model `name` reused with an overlapping profile id (matching is
case-insensitive), silently dropped one definition with no error or warning.

## Changes

- `Cookbook::validate()` now detects when two **enabled** `(model, profile)`
  pairs resolve to the same case-insensitive `model:profile` key — exactly the
  key `build_model_index` inserts — and fails with an error naming both
  conflicting identifiers. Only enabled pairs are indexed, so only those can
  collide; disabled entries are unaffected.
- Unit tests: duplicate profile id within a model, case-insensitive collision
  across models, a disabled duplicate that is allowed, and a clean cookbook with
  reused profile ids under distinct model names.

## Behavior / compatibility

Validation already runs at startup (`main.rs`) and before each hot-reload swaps
the index (`reload_cookbook` calls `validate()?` prior to `model_index.rebuild`).
A live edit that introduces a duplicate is therefore rejected and the previously
loaded cookbook keeps serving — no disruption to the running node. Only configs
that were already silently broken (shadowing) are rejected; valid cookbooks are
unaffected.

## Versioning

Patch bump (`1.8.0` → `1.8.1`): a correctness fix that surfaces a previously
silent misconfiguration. `Cargo.lock` and `CHANGELOG.md` are updated in this PR.

## Testing

- `cargo test --bin llamesh`: 317 passed, including the four new validation tests.
- `cargo clippy` / `cargo fmt --check`: no new findings (a pre-existing
  `too_many_arguments` lint and an unrelated formatting drift are untouched).
- Live-validated against a running node: it starts cleanly on a duplicate-free
  cookbook, and a hot-reload that introduces a duplicate is rejected with the new
  error while the node stays healthy and keeps serving the prior cookbook;
  restoring the file reloads it successfully.

Closes #49
