### PR TITLE
fix: validate cluster gossip settings at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.3] - 2026-05-30
+
+### Fixed
+
+- Cluster gossip settings are now validated at startup when cluster mode is
+  enabled. `gossip_interval_seconds` (a required field with no default) and
+  `max_concurrent_gossip` previously deserialized cleanly even when set to `0`,
+  but both break the gossip loop at runtime: a `0` interval makes
+  `tokio::time::interval` panic (`"interval period must be non-zero"`), killing
+  the gossip task so the node silently never advertises itself or polls peers;
+  a `0` `max_concurrent_gossip` leaves the gossip semaphore with no permits, so
+  every outbound gossip attempt times out and is skipped. `NodeConfig::validate()`
+  now rejects either value being `0` while `cluster.enabled` is true, failing
+  fast with a message that names the offending setting, instead of surfacing the
+  misconfiguration as a runtime panic or a silent mesh dropout. The checks are
+  gated on `cluster.enabled` because the gossip loop — and these fields — are
+  unused when cluster mode is off. Startup-only, consistent with the other node
+  config validations (node config is not hot-reloaded).
+
 ## [1.8.2] - 2026-05-30
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.8.2"
+version = "1.8.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.8.2"
+version = "1.8.3"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -137,6 +137,36 @@ impl NodeConfig {
             }
         }
 
+        // Validate cluster gossip settings. When cluster mode is enabled, the
+        // gossip loop drives a `tokio::time::interval` from
+        // `gossip_interval_seconds` and a `Semaphore` from
+        // `max_concurrent_gossip`. A zero interval panics `tokio::time::interval`
+        // ("interval period must be non-zero"), killing the gossip task so the
+        // node silently never advertises itself or polls peers; a zero
+        // `max_concurrent_gossip` leaves the semaphore with no permits, so every
+        // outbound gossip attempt times out and is skipped. Both deserialize
+        // cleanly otherwise, so catch them at startup. `gossip_interval_seconds`
+        // is required and has no default, which makes a stray 0 easy to
+        // introduce. Only checked when cluster mode is on, since the gossip loop
+        // (and these fields) are otherwise unused.
+        if self.cluster.enabled {
+            if self.cluster.gossip_interval_seconds == 0 {
+                return Err(anyhow::anyhow!(
+                    "cluster.gossip_interval_seconds is 0, but cluster mode is enabled; \
+                     the gossip loop requires a non-zero interval (a zero interval panics \
+                     the gossip task). Set gossip_interval_seconds to at least 1."
+                ));
+            }
+            if self.cluster.max_concurrent_gossip == 0 {
+                return Err(anyhow::anyhow!(
+                    "cluster.max_concurrent_gossip is 0, but cluster mode is enabled; \
+                     with no permits every outbound gossip attempt times out and is skipped, \
+                     so the node never gossips. Set max_concurrent_gossip to at least 1, \
+                     or disable cluster mode."
+                ));
+            }
+        }
+
         Ok(())
     }
 }
@@ -1062,6 +1092,44 @@ mod tests {
             ranges: None,
         };
         assert!(config_with_ports(Some(none_none)).validate().is_err());
+    }
+
+    fn config_with_cluster(
+        enabled: bool,
+        gossip_interval_seconds: u64,
+        max_concurrent_gossip: usize,
+    ) -> NodeConfig {
+        let mut config = config_with_ports(None);
+        config.cluster.enabled = enabled;
+        config.cluster.gossip_interval_seconds = gossip_interval_seconds;
+        config.cluster.max_concurrent_gossip = max_concurrent_gossip;
+        config
+    }
+
+    #[test]
+    fn validate_accepts_valid_gossip_settings_when_cluster_enabled() {
+        assert!(config_with_cluster(true, 5, 16).validate().is_ok());
+        // A 1-second interval and a single gossip permit are the minimum valid values.
+        assert!(config_with_cluster(true, 1, 1).validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_zero_gossip_interval_when_cluster_enabled() {
+        // A zero interval panics tokio::time::interval in the gossip loop.
+        assert!(config_with_cluster(true, 0, 16).validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_zero_max_concurrent_gossip_when_cluster_enabled() {
+        // A zero-permit semaphore makes every outbound gossip attempt time out.
+        assert!(config_with_cluster(true, 5, 0).validate().is_err());
+    }
+
+    #[test]
+    fn validate_ignores_zero_gossip_settings_when_cluster_disabled() {
+        // The gossip loop never runs with cluster disabled, so these unused
+        // fields must not be rejected (avoids breaking single-node configs).
+        assert!(config_with_cluster(false, 0, 0).validate().is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When cluster mode is enabled, two gossip settings deserialize cleanly but break
the gossip loop at runtime when set to `0`:

- **`gossip_interval_seconds: 0`** — the gossip loop builds its timer with
  `tokio::time::interval(Duration::from_secs(gossip_interval_seconds))`, which
  panics (`"interval period must be non-zero"`) on a zero period. The gossip
  task dies on startup, so the node silently never advertises itself or polls
  peers — only a panic traceback in the logs signals it.
- **`max_concurrent_gossip: 0`** — the loop gates concurrent sends with
  `Semaphore::new(max_concurrent_gossip)`. With zero permits, every
  `acquire_owned()` hits its 5s timeout and the peer is skipped, so no outbound
  gossip is ever sent.

`gossip_interval_seconds` is a required field with no default, so every cluster
operator sets it explicitly and a stray `0` is easy to introduce.

`NodeConfig::validate()` now rejects either value being `0` while
`cluster.enabled` is true, failing fast at startup with a message that names the
offending setting — consistent with the existing `llama_cpp_ports` and cookbook
duplicate-identifier validations. The checks are gated on `cluster.enabled`
because the gossip loop and these fields are unused when cluster mode is off, so
configs that leave them at `0` while clustering is disabled are unaffected. The
staleness math that also reads `gossip_interval_seconds` already floors at 15s
(`.saturating_mul(3).max(15)`) and is unchanged.

This is startup-only; node config is not hot-reloaded.

## Versioning

Patch bump (`1.8.2` → `1.8.3`): a correctness fix that converts a previously
silent misconfiguration (runtime panic / silent mesh dropout) into a clear
startup error. `Cargo.lock` and `CHANGELOG.md` are updated in this PR.

## Testing

- `cargo test --bin llamesh`: 327 passed, including four new gossip-validation
  tests (reject zero interval, reject zero concurrency, accept valid settings,
  and ignore both when cluster mode is disabled).
- `cargo clippy` / `cargo fmt --check`: no new findings (a pre-existing
  `too_many_arguments` lint and an unrelated formatting drift are untouched).
- Live-validated against the release binary: a node starts cleanly on a valid
  cluster config and gossips normally, while running the binary against
  `gossip_interval_seconds: 0` and `max_concurrent_gossip: 0` configs each exits
  non-zero at startup with `Invalid config: cluster.gossip_interval_seconds is 0
  ...` / `Invalid config: cluster.max_concurrent_gossip is 0 ...` before binding
  or any other side effect.

Closes #53
