### PR TITLE
feat: surface active instance count as proxy_node_active_instances gauge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-05-30
+
+### Added
+
+- `GET /metrics` now exposes `proxy_node_active_instances`, a gauge reporting the
+  number of llama-server instances this node is currently managing (spawned and
+  not yet evicted). It matches the `active_instances` field already shown per
+  node in `/cluster/nodes`, but as a scrapeable Prometheus time series it lets
+  operators dashboard and alert on instance count and churn directly — for
+  example, catching a node that is backing up requests while running zero
+  instances (`proxy_queue_pending_tokens > 0` with `proxy_node_active_instances
+  == 0`), or watching spawn/evict thrash. The same count is added to the
+  `node_resources` object in the `/metrics/json` snapshot. The gauge is
+  recomputed from live instance state on every scrape (the metrics handler
+  refreshes the node resource snapshot before rendering), so it does not go
+  stale. This is additive and backward-compatible: the new
+  `node_resources.active_instances` snapshot field is `#[serde(default)]`, so
+  metrics snapshots written by older versions still load and historical counters
+  are preserved across the upgrade.
+
 ## [1.8.3] - 2026-05-30
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.8.3"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.8.3"
+version = "1.9.0"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -100,6 +100,10 @@ pub struct Metrics {
     pub node_device_vram_used_mb: AtomicU64,
     pub node_device_vram_total_mb: AtomicU64,
     pub node_gpu_telemetry_available: AtomicBool,
+    /// Number of llama-server instances currently managed on this node
+    /// (spawned and not yet evicted), matching `active_instances` in
+    /// `/cluster/nodes`.
+    pub node_active_instances: AtomicU64,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -135,6 +139,10 @@ pub struct NodeResourceMetricsSnapshot {
     pub device_vram_used_mb: u64,
     pub device_vram_total_mb: u64,
     pub gpu_telemetry_available: bool,
+    /// Number of llama-server instances managed on this node. `#[serde(default)]`
+    /// keeps snapshots written by older versions (without this field) loadable.
+    #[serde(default)]
+    pub active_instances: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -220,6 +228,7 @@ impl Metrics {
             node_device_vram_used_mb: AtomicU64::new(0),
             node_device_vram_total_mb: AtomicU64::new(0),
             node_gpu_telemetry_available: AtomicBool::new(false),
+            node_active_instances: AtomicU64::new(0),
         }
     }
 
@@ -319,6 +328,8 @@ impl Metrics {
             .store(snapshot.device_vram_total_mb, Ordering::Relaxed);
         self.node_gpu_telemetry_available
             .store(snapshot.gpu_telemetry_available, Ordering::Relaxed);
+        self.node_active_instances
+            .store(snapshot.active_instances, Ordering::Relaxed);
     }
 
     /// Check if we have any memory data for a given args_hash (for cold start detection).
@@ -403,6 +414,7 @@ impl Metrics {
                 device_vram_used_mb: self.node_device_vram_used_mb.load(Ordering::Relaxed),
                 device_vram_total_mb: self.node_device_vram_total_mb.load(Ordering::Relaxed),
                 gpu_telemetry_available: self.node_gpu_telemetry_available.load(Ordering::Relaxed),
+                active_instances: self.node_active_instances.load(Ordering::Relaxed),
             },
         }
     }
@@ -515,6 +527,14 @@ pub async fn render_prometheus_with_circuit_breaker(
         } else {
             0
         }
+    ));
+    out.push_str(
+        "# HELP proxy_node_active_instances Number of llama-server instances currently managed on this node.\n",
+    );
+    out.push_str("# TYPE proxy_node_active_instances gauge\n");
+    out.push_str(&format!(
+        "proxy_node_active_instances {}\n",
+        metrics.node_active_instances.load(Ordering::Relaxed)
     ));
 
     // Queue fairness metrics
@@ -710,6 +730,7 @@ mod tests {
             device_vram_used_mb: 3500,
             device_vram_total_mb: 24000,
             gpu_telemetry_available: true,
+            active_instances: 2,
         });
 
         let snapshot = metrics
@@ -732,6 +753,7 @@ mod tests {
         assert_eq!(snapshot.node_resources.llamesh_vram_mb, 3000);
         assert_eq!(snapshot.node_resources.external_vram_mb, 500);
         assert!(snapshot.node_resources.gpu_telemetry_available);
+        assert_eq!(snapshot.node_resources.active_instances, 2);
     }
 
     #[tokio::test]
@@ -747,6 +769,7 @@ mod tests {
             device_vram_used_mb: 150,
             device_vram_total_mb: 1000,
             gpu_telemetry_available: true,
+            active_instances: 3,
         });
 
         let hm = metrics.get_hash_metrics("abc123").await;
@@ -759,6 +782,7 @@ mod tests {
         assert!(output.contains("proxy_requests_total 1"));
         assert!(output.contains("proxy_node_external_vram_mb 50"));
         assert!(output.contains("proxy_node_gpu_telemetry_available 1"));
+        assert!(output.contains("proxy_node_active_instances 3"));
         assert!(output.contains("proxy_hash_requests_total{hash=\"abc123\""));
         assert!(output.contains("names=\"gpt\\\"cool\\\"\""));
     }
@@ -790,6 +814,39 @@ mod tests {
             "proxy_build_info{{version=\"{}\",llama_cpp_version=\"weird\\\"\\\\\\nver\"}} 1",
             env!("CARGO_PKG_VERSION")
         )));
+    }
+
+    #[test]
+    fn snapshot_without_active_instances_field_still_loads() {
+        // A node_resources object written by a pre-1.9.0 version has no
+        // `active_instances` field. `#[serde(default)]` on that field must keep
+        // the snapshot loadable so an in-place upgrade preserves persisted
+        // counters (e.g. requests_total) instead of resetting them via the
+        // parse-error fallback in `Metrics::load`. This JSON mirrors the
+        // node_resources shape written by older releases.
+        let json = r#"{
+            "node_id": "n",
+            "llama_cpp_version": "abc",
+            "requests_total": 1421955,
+            "errors_total": 10,
+            "current_requests": 0,
+            "hashes": {},
+            "updated_at": "2026-05-30T00:00:00Z",
+            "node_resources": {
+                "llamesh_vram_mb": 0,
+                "llamesh_sysmem_mb": 0,
+                "external_vram_mb": 3686,
+                "effective_vram_mb": 3686,
+                "effective_sysmem_mb": 0,
+                "device_vram_used_mb": 3686,
+                "device_vram_total_mb": 24564,
+                "gpu_telemetry_available": true
+            }
+        }"#;
+        let snapshot: MetricsSnapshot =
+            serde_json::from_str(json).expect("pre-1.9.0 snapshot must still deserialize");
+        assert_eq!(snapshot.requests_total, 1_421_955);
+        assert_eq!(snapshot.node_resources.active_instances, 0);
     }
 
     #[tokio::test]

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -258,6 +258,8 @@ pub struct ResourceSnapshot {
     pub device_vram_used_mb: u64,
     pub device_vram_total_mb: u64,
     pub gpu_telemetry_available: bool,
+    /// Number of llama-server instances managed on this node at snapshot time.
+    pub active_instances: u64,
 }
 
 impl ResourceSnapshot {
@@ -265,6 +267,7 @@ impl ResourceSnapshot {
         llamesh_vram_mb: u64,
         llamesh_sysmem_mb: u64,
         device_vram: Option<GpuMemorySnapshot>,
+        active_instances: u64,
     ) -> Self {
         let (device_vram_used_mb, device_vram_total_mb, gpu_telemetry_available) = match device_vram
         {
@@ -283,6 +286,7 @@ impl ResourceSnapshot {
             device_vram_used_mb,
             device_vram_total_mb,
             gpu_telemetry_available,
+            active_instances,
         }
     }
 }
@@ -764,7 +768,12 @@ impl NodeState {
             vram += v;
             sysmem += s;
         }
-        ResourceSnapshot::from_samples(vram, sysmem, self.memory_sampler.sample_device_vram())
+        ResourceSnapshot::from_samples(
+            vram,
+            sysmem,
+            self.memory_sampler.sample_device_vram(),
+            instances.len() as u64,
+        )
     }
 
     fn observe_resource_snapshot(&self, snapshot: &ResourceSnapshot) {
@@ -778,6 +787,7 @@ impl NodeState {
                 device_vram_used_mb: snapshot.device_vram_used_mb,
                 device_vram_total_mb: snapshot.device_vram_total_mb,
                 gpu_telemetry_available: snapshot.gpu_telemetry_available,
+                active_instances: snapshot.active_instances,
             });
     }
 
@@ -3370,18 +3380,20 @@ mod tests {
     #[test]
     fn resource_snapshot_includes_external_vram() {
         let snapshot =
-            ResourceSnapshot::from_samples(6000, 1200, Some(gpu_snapshot(10_000, 24_000)));
+            ResourceSnapshot::from_samples(6000, 1200, Some(gpu_snapshot(10_000, 24_000)), 2);
 
         assert_eq!(snapshot.llamesh_vram_mb, 6000);
         assert_eq!(snapshot.external_vram_mb, 4000);
         assert_eq!(snapshot.effective_vram_mb, 10_000);
         assert_eq!(snapshot.effective_sysmem_mb, 1200);
         assert!(snapshot.gpu_telemetry_available);
+        assert_eq!(snapshot.active_instances, 2);
     }
 
     #[test]
     fn resource_snapshot_keeps_tracked_peak_when_device_sample_is_lower() {
-        let snapshot = ResourceSnapshot::from_samples(6000, 1200, Some(gpu_snapshot(5000, 24_000)));
+        let snapshot =
+            ResourceSnapshot::from_samples(6000, 1200, Some(gpu_snapshot(5000, 24_000)), 1);
 
         assert_eq!(snapshot.external_vram_mb, 0);
         assert_eq!(snapshot.effective_vram_mb, 6000);


### PR DESCRIPTION
## Summary

`GET /metrics` exposes node-level gauges for VRAM / system-memory accounting and GPU telemetry, but not the number of llama-server instances the node is currently running — even though that count is already tracked and surfaced per node in `/cluster/nodes` as `active_instances`.

This adds a **`proxy_node_active_instances`** gauge to `/metrics` reporting the instances this node is currently managing (spawned and not yet evicted), with the same semantics as `/cluster/nodes`, and mirrors the count in the `node_resources` object of the `/metrics/json` snapshot.

As a scrapeable time series it enables dashboards and alerts the point-in-time cluster view can't easily support, e.g.:

- A node backing up requests while running zero instances: `proxy_queue_pending_tokens > 0` with `proxy_node_active_instances == 0`.
- Spawn/evict thrash (instance count flapping).
- Capacity utilization against `max_instances_per_node`.

The count is threaded through `ResourceSnapshot` (`instances.len()` at snapshot time) into the metrics node-resource snapshot. The `/metrics` handler already refreshes that snapshot before rendering, so the gauge is recomputed from live instance state on every scrape and does not go stale.

## Compatibility

The new `node_resources.active_instances` snapshot field is `#[serde(default)]`, so metrics snapshots written by older versions still deserialize. Without this, a missing field would make `Metrics::load` fall back to a fresh `Metrics` on the first restart after upgrade, **resetting persisted counters** (`requests_total`, per-hash stats). Verified that an existing pre-1.9.0 `node-metrics.json` (8-field `node_resources`, no `active_instances`) loads cleanly and preserves counters — see Testing.

## Versioning

Minor bump (`1.8.3` → `1.9.0`): a new, backward-compatible observability surface, consistent with prior additive metric/feature releases. `Cargo.lock` and `CHANGELOG.md` are updated in this PR.

## Testing

- `cargo test --bin llamesh`: 328 passed, including a new regression test that deserializes an old-shape snapshot (no `active_instances`) and asserts `requests_total` is preserved and the field defaults to `0`, plus render/round-trip assertions for the new gauge.
- `cargo clippy` / `cargo fmt --check`: no new findings (a pre-existing `too_many_arguments` lint and an unrelated formatting drift are untouched).
- Live-validated against the release binary on a running node: after upgrading in place, `proxy_requests_total` was preserved at its prior value (no metrics reset, no "Failed to parse metrics snapshot" warning), `proxy_node_active_instances` rendered `0` while idle, then read `1` during a spawned request — agreeing with both `/cluster/nodes` `active_instances` and `/metrics/json` `node_resources.active_instances` throughout the instance's lifetime — and returned to `0` after idle eviction.

Closes #55
