### PR TITLE
feat: surface configured VRAM/sysmem admission guardrails as Prometheus gauges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-05-30
+
+### Added
+
+- `GET /metrics` now exposes `proxy_node_max_vram_mb` and
+  `proxy_node_max_sysmem_mb`, gauges reporting this node's configured VRAM and
+  system-memory admission guardrails (`max_vram_mb` / `max_sysmem_mb`). Admission
+  spawns a new instance only while `effective + required <= max_*`, so the
+  configured maximum is the denominator for any "how close am I to the
+  guardrail" calculation. Previously `/metrics` exposed the numerator
+  (`proxy_node_effective_vram_mb` / `proxy_node_effective_sysmem_mb`) but not the
+  limit, so operators could not compute guardrail utilization
+  (`proxy_node_effective_vram_mb / proxy_node_max_vram_mb`) or headroom in PromQL
+  without hard-coding the configured value into every query and alert. The limit
+  is also distinct from `proxy_node_device_vram_total_mb` (physical device VRAM):
+  the guardrail is typically set below physical capacity to leave headroom, so
+  the device total cannot substitute for it. These limits were already surfaced
+  per node in `/cluster/nodes` (`max_vram`, `max_sysmem`); this adds them to the
+  Prometheus scrape surface. The same two values are added to the
+  `node_resources` object in the `/metrics/json` snapshot. The gauges are
+  refreshed from node config on every scrape (the metrics handler recomputes the
+  resource snapshot before rendering). This is additive and
+  backward-compatible: the new `node_resources.max_vram_mb` /
+  `node_resources.max_sysmem_mb` snapshot fields are `#[serde(default)]`, so
+  metrics snapshots written by older versions still load and historical counters
+  are preserved across the upgrade.
+
 ## [1.9.0] - 2026-05-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.9.0"
+version = "1.10.0"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/SPEC.md
+++ b/SPEC.md
@@ -437,7 +437,10 @@ Per node, metrics snapshots are stored as JSON files at the path specified by `m
     "effective_sysmem_mb": 8192,
     "device_vram_used_mb": 24576,
     "device_vram_total_mb": 81920,
-    "gpu_telemetry_available": true
+    "gpu_telemetry_available": true,
+    "active_instances": 3,
+    "max_vram_mb": 71680,
+    "max_sysmem_mb": 131072
   },
   "hashes": {
     "<sha256-of-launch-args>": {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -104,6 +104,17 @@ pub struct Metrics {
     /// (spawned and not yet evicted), matching `active_instances` in
     /// `/cluster/nodes`.
     pub node_active_instances: AtomicU64,
+    /// Configured VRAM admission guardrail in MB (`max_vram_mb` from node
+    /// config), mirrored here so the limit is scrapeable alongside the
+    /// effective-usage gauges. Admission spawns a new instance only while
+    /// `effective_vram + required <= max_vram_mb`, so this is the denominator
+    /// for guardrail utilization (`effective / max`) and headroom
+    /// (`max - effective`). It is a static config value, refreshed on every
+    /// resource snapshot.
+    pub node_max_vram_mb: AtomicU64,
+    /// Configured system-memory admission guardrail in MB (`max_sysmem_mb` from
+    /// node config). The system-memory counterpart to `node_max_vram_mb`.
+    pub node_max_sysmem_mb: AtomicU64,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -143,6 +154,15 @@ pub struct NodeResourceMetricsSnapshot {
     /// keeps snapshots written by older versions (without this field) loadable.
     #[serde(default)]
     pub active_instances: u64,
+    /// Configured VRAM admission guardrail in MB (`max_vram_mb` from node
+    /// config). `#[serde(default)]` keeps snapshots written by older versions
+    /// (without this field) loadable.
+    #[serde(default)]
+    pub max_vram_mb: u64,
+    /// Configured system-memory admission guardrail in MB (`max_sysmem_mb` from
+    /// node config). `#[serde(default)]` keeps older snapshots loadable.
+    #[serde(default)]
+    pub max_sysmem_mb: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -229,6 +249,8 @@ impl Metrics {
             node_device_vram_total_mb: AtomicU64::new(0),
             node_gpu_telemetry_available: AtomicBool::new(false),
             node_active_instances: AtomicU64::new(0),
+            node_max_vram_mb: AtomicU64::new(0),
+            node_max_sysmem_mb: AtomicU64::new(0),
         }
     }
 
@@ -330,6 +352,10 @@ impl Metrics {
             .store(snapshot.gpu_telemetry_available, Ordering::Relaxed);
         self.node_active_instances
             .store(snapshot.active_instances, Ordering::Relaxed);
+        self.node_max_vram_mb
+            .store(snapshot.max_vram_mb, Ordering::Relaxed);
+        self.node_max_sysmem_mb
+            .store(snapshot.max_sysmem_mb, Ordering::Relaxed);
     }
 
     /// Check if we have any memory data for a given args_hash (for cold start detection).
@@ -415,6 +441,8 @@ impl Metrics {
                 device_vram_total_mb: self.node_device_vram_total_mb.load(Ordering::Relaxed),
                 gpu_telemetry_available: self.node_gpu_telemetry_available.load(Ordering::Relaxed),
                 active_instances: self.node_active_instances.load(Ordering::Relaxed),
+                max_vram_mb: self.node_max_vram_mb.load(Ordering::Relaxed),
+                max_sysmem_mb: self.node_max_sysmem_mb.load(Ordering::Relaxed),
             },
         }
     }
@@ -535,6 +563,18 @@ pub async fn render_prometheus_with_circuit_breaker(
     out.push_str(&format!(
         "proxy_node_active_instances {}\n",
         metrics.node_active_instances.load(Ordering::Relaxed)
+    ));
+    out.push_str("# HELP proxy_node_max_vram_mb Configured VRAM admission guardrail in MB (max_vram_mb); a new instance is spawned only while effective VRAM plus its estimated usage stays within this limit.\n");
+    out.push_str("# TYPE proxy_node_max_vram_mb gauge\n");
+    out.push_str(&format!(
+        "proxy_node_max_vram_mb {}\n",
+        metrics.node_max_vram_mb.load(Ordering::Relaxed)
+    ));
+    out.push_str("# HELP proxy_node_max_sysmem_mb Configured system-memory admission guardrail in MB (max_sysmem_mb).\n");
+    out.push_str("# TYPE proxy_node_max_sysmem_mb gauge\n");
+    out.push_str(&format!(
+        "proxy_node_max_sysmem_mb {}\n",
+        metrics.node_max_sysmem_mb.load(Ordering::Relaxed)
     ));
 
     // Queue fairness metrics
@@ -731,6 +771,8 @@ mod tests {
             device_vram_total_mb: 24000,
             gpu_telemetry_available: true,
             active_instances: 2,
+            max_vram_mb: 23500,
+            max_sysmem_mb: 185000,
         });
 
         let snapshot = metrics
@@ -754,6 +796,8 @@ mod tests {
         assert_eq!(snapshot.node_resources.external_vram_mb, 500);
         assert!(snapshot.node_resources.gpu_telemetry_available);
         assert_eq!(snapshot.node_resources.active_instances, 2);
+        assert_eq!(snapshot.node_resources.max_vram_mb, 23500);
+        assert_eq!(snapshot.node_resources.max_sysmem_mb, 185000);
     }
 
     #[tokio::test]
@@ -770,6 +814,8 @@ mod tests {
             device_vram_total_mb: 1000,
             gpu_telemetry_available: true,
             active_instances: 3,
+            max_vram_mb: 900,
+            max_sysmem_mb: 4096,
         });
 
         let hm = metrics.get_hash_metrics("abc123").await;
@@ -783,6 +829,8 @@ mod tests {
         assert!(output.contains("proxy_node_external_vram_mb 50"));
         assert!(output.contains("proxy_node_gpu_telemetry_available 1"));
         assert!(output.contains("proxy_node_active_instances 3"));
+        assert!(output.contains("proxy_node_max_vram_mb 900"));
+        assert!(output.contains("proxy_node_max_sysmem_mb 4096"));
         assert!(output.contains("proxy_hash_requests_total{hash=\"abc123\""));
         assert!(output.contains("names=\"gpt\\\"cool\\\"\""));
     }
@@ -818,9 +866,10 @@ mod tests {
 
     #[test]
     fn snapshot_without_active_instances_field_still_loads() {
-        // A node_resources object written by a pre-1.9.0 version has no
-        // `active_instances` field. `#[serde(default)]` on that field must keep
-        // the snapshot loadable so an in-place upgrade preserves persisted
+        // A node_resources object written by an older version lacks the fields
+        // added since (`active_instances`, and the `max_vram_mb`/`max_sysmem_mb`
+        // guardrail limits). `#[serde(default)]` on each of those fields must
+        // keep the snapshot loadable so an in-place upgrade preserves persisted
         // counters (e.g. requests_total) instead of resetting them via the
         // parse-error fallback in `Metrics::load`. This JSON mirrors the
         // node_resources shape written by older releases.
@@ -847,6 +896,8 @@ mod tests {
             serde_json::from_str(json).expect("pre-1.9.0 snapshot must still deserialize");
         assert_eq!(snapshot.requests_total, 1_421_955);
         assert_eq!(snapshot.node_resources.active_instances, 0);
+        assert_eq!(snapshot.node_resources.max_vram_mb, 0);
+        assert_eq!(snapshot.node_resources.max_sysmem_mb, 0);
     }
 
     #[tokio::test]

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -788,6 +788,8 @@ impl NodeState {
                 device_vram_total_mb: snapshot.device_vram_total_mb,
                 gpu_telemetry_available: snapshot.gpu_telemetry_available,
                 active_instances: snapshot.active_instances,
+                max_vram_mb: self.config.max_vram_mb,
+                max_sysmem_mb: self.config.max_sysmem_mb,
             });
     }
 


### PR DESCRIPTION
## Summary

Adds two gauges to `GET /metrics` reporting this node's configured admission
guardrails:

- `proxy_node_max_vram_mb` — configured VRAM admission guardrail (`max_vram_mb`)
- `proxy_node_max_sysmem_mb` — configured system-memory admission guardrail
  (`max_sysmem_mb`)

The same two values are mirrored in the `node_resources` object of the
`/metrics/json` snapshot.

Closes #57.

## Motivation

Admission spawns a new instance only while `effective + required <= max_*`, so
the configured maximum is the denominator for any "how close am I to the
guardrail" calculation. `/metrics` already exposed the numerator
(`proxy_node_effective_vram_mb` / `proxy_node_effective_sysmem_mb`) but not the
limit, so operators could not compute utilization
(`proxy_node_effective_vram_mb / proxy_node_max_vram_mb`) or headroom in PromQL
without hard-coding the configured value into every query and alert.

The limit is also distinct from `proxy_node_device_vram_total_mb` (physical
device VRAM): the guardrail is typically set below physical capacity to leave
headroom, so the device total cannot substitute for it. Both limits were already
surfaced per node in `/cluster/nodes` (`max_vram`, `max_sysmem`); this brings
them to the Prometheus scrape surface.

## Changes

- `Metrics`: two new atomics (`node_max_vram_mb`, `node_max_sysmem_mb`),
  refreshed from node config on every resource snapshot (the same path that
  feeds the existing `node_*` gauges, recomputed before each scrape).
- `render_prometheus_with_circuit_breaker`: emit the two gauges with HELP/TYPE
  headers, grouped with the other `proxy_node_*` gauges.
- `NodeResourceMetricsSnapshot`: two new `#[serde(default)]` fields, surfaced in
  `/metrics/json` and sourced from `max_vram_mb` / `max_sysmem_mb`.
- SPEC.md: refresh the `node_resources` JSON example to match the current shape.

## Backward compatibility

Additive only. The new `node_resources.max_vram_mb` / `max_sysmem_mb` snapshot
fields are `#[serde(default)]`, so metrics snapshots written by older versions
still deserialize and persisted counters (e.g. `requests_total`) are preserved
across an in-place upgrade rather than being reset by the parse-error fallback in
`Metrics::load`. The cluster gossip wire format (`PeerState`) is unchanged, so
mixed-version clusters during a rolling upgrade are unaffected.

## Validation

- `cargo build --release`, `cargo fmt --check` (no new drift), `cargo clippy`
  (no new warnings), full test suite green (340 tests: 328 unit + 12
  integration), including extended assertions in `test_hash_metrics`,
  `test_prometheus_rendering`, and the snapshot backward-compat test.
- Validated live on a running node: after an in-place restart, the gauges report
  the node's configured caps, `/metrics/json` carries the matching fields,
  `requests_total` is preserved across the upgrade, and a mixed-version cluster
  remained healthy and `ready`.
