### PR TITLE
fix(security): compare API keys in constant time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.2] - 2026-05-31
+
+### Security
+
+- API key authentication now compares the presented key against the configured
+  keys in **constant time**, matching how the cluster handshake token is already
+  verified (`noise::handshake::verify_token`). The previous check used
+  `Vec::contains` — a short-circuiting `==` on `String` — whose running time
+  depends on how many leading bytes of the candidate match a configured key.
+  Comparing a bearer secret this way is a timing side channel (low severity in
+  practice, since exploiting it requires measuring response timing remotely,
+  across TLS) and was inconsistent with the constant-time token comparison used
+  for inter-node authentication. The comparison now runs over every configured
+  key without short-circuiting and uses a byte-wise constant-time equality, so a
+  partial match is not distinguishable from a full mismatch by response timing.
+  No behavior or configuration change: valid keys authorize and invalid keys are
+  rejected exactly as before, and no new dependency is introduced.
+
 ## [1.10.1] - 2026-05-31
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.10.1"
+version = "1.10.2"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/src/security.rs
+++ b/src/security.rs
@@ -17,6 +17,11 @@ pub struct PeerIdentity {
 /// Check API key authentication against the provided config and headers.
 /// Returns Ok(()) if authentication succeeds or is not required.
 /// Returns Err("Unauthorized") if authentication fails.
+///
+/// The presented key is compared against the configured keys in constant time
+/// (see [`allowed_key_matches`]), matching how the cluster handshake token is
+/// verified, so a partial match is not distinguishable from a full mismatch by
+/// response timing.
 pub fn check_api_key_auth(
     auth_config: Option<&AuthConfig>,
     headers: &HeaderMap,
@@ -25,7 +30,7 @@ pub fn check_api_key_auth(
         if config.enabled {
             let api_key = config.get_header_value(headers);
             let authorized = match api_key {
-                Some(key) => config.allowed_keys.contains(&key.to_string()),
+                Some(key) => allowed_key_matches(&config.allowed_keys, key),
                 None => false,
             };
             if !authorized {
@@ -34,6 +39,38 @@ pub fn check_api_key_auth(
         }
     }
     Ok(())
+}
+
+/// Compare two byte strings in constant time.
+///
+/// Returns early when the lengths differ — the length of a configured key is
+/// not treated as secret — but when the lengths match, every byte is compared
+/// with no short-circuit, so the running time does not reveal how many leading
+/// bytes of a candidate match a real key. Mirrors the constant-time token
+/// comparison used for the cluster handshake (`noise::handshake::verify_token`).
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// Return whether `candidate` matches any configured API key, comparing in
+/// constant time. Every configured key is checked — the loop does not stop at
+/// the first match — so that neither which key matched nor how many keys were
+/// examined is exposed through response timing.
+fn allowed_key_matches(allowed_keys: &[String], candidate: &str) -> bool {
+    let mut authorized = false;
+    for key in allowed_keys {
+        // Bitwise `|=` (not `||`) so every key is always compared; short-circuit
+        // evaluation here would reintroduce a timing side channel.
+        authorized |= constant_time_eq(key.as_bytes(), candidate.as_bytes());
+    }
+    authorized
 }
 
 pub fn extract_peer_identity(certs: &[rustls::pki_types::CertificateDer<'_>]) -> PeerIdentity {
@@ -256,6 +293,52 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("Authorization", "key2".parse().unwrap());
         assert!(check_api_key_auth(Some(&config), &headers).is_ok());
+    }
+
+    #[test]
+    fn test_auth_last_allowed_key_matches() {
+        // The match is on the last configured key; the constant-time check must
+        // not stop early at an earlier non-match.
+        let config = make_auth_config(true, "Authorization", vec!["key1", "key2", "key3"]);
+        let mut headers = HeaderMap::new();
+        headers.insert("Authorization", "key3".parse().unwrap());
+        assert!(check_api_key_auth(Some(&config), &headers).is_ok());
+    }
+
+    #[test]
+    fn test_auth_one_byte_off_rejected() {
+        let config = make_auth_config(true, "Authorization", vec!["Bearer sk-test123"]);
+        let mut headers = HeaderMap::new();
+        // Identical length, only the final byte differs.
+        headers.insert("Authorization", "Bearer sk-test124".parse().unwrap());
+        assert_eq!(
+            check_api_key_auth(Some(&config), &headers),
+            Err("Unauthorized")
+        );
+    }
+
+    #[test]
+    fn test_constant_time_eq() {
+        assert!(constant_time_eq(b"sk-secret", b"sk-secret"));
+        assert!(constant_time_eq(b"", b""));
+        // One byte off, same length.
+        assert!(!constant_time_eq(b"sk-secret", b"sk-secreT"));
+        // Length mismatches.
+        assert!(!constant_time_eq(b"sk-secret", b"sk-secre"));
+        assert!(!constant_time_eq(b"sk-secret", b"sk-secret-extra"));
+        assert!(!constant_time_eq(b"", b"x"));
+    }
+
+    #[test]
+    fn test_allowed_key_matches() {
+        let keys = vec!["key1".to_string(), "key2".to_string(), "key3".to_string()];
+        assert!(allowed_key_matches(&keys, "key1"));
+        assert!(allowed_key_matches(&keys, "key3"));
+        assert!(!allowed_key_matches(&keys, "key4"));
+        // Prefix of a real key: rejected (length differs).
+        assert!(!allowed_key_matches(&keys, "key"));
+        // No keys configured: nothing matches.
+        assert!(!allowed_key_matches(&[], "anything"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Hardens API key authentication to compare the presented key against the
configured keys in **constant time**, aligning it with the constant-time
comparison already used for the cluster handshake token.

Closes #61.

## The issue

`check_api_key_auth` compared the presented key with `Vec::contains`:

```rust
Some(key) => config.allowed_keys.contains(&key.to_string()),
```

`Vec::contains` compares each `String` with `==`, which short-circuits on the
first differing byte, so the time taken leaks how many leading bytes of the
candidate match a configured key — a timing side channel for a bearer secret.
The inter-node path already avoids this (`noise::handshake::verify_token` does a
length check plus a byte-wise XOR-accumulate compare), so the API-key path was
the inconsistent one.

## The change

- `constant_time_eq(a, b)` — length check (a key's length is not treated as
  secret), then a no-short-circuit byte-wise compare. Mirrors `verify_token`.
- `allowed_key_matches(keys, candidate)` — checks every configured key with
  `|=` (not `||`), so it does not stop at the first match; neither which key
  matched nor how many were examined is exposed through timing.
- `check_api_key_auth` now calls `allowed_key_matches`.

No new dependency (the in-repo pattern is reused rather than pulling in a crypto
crate), and no behavior or configuration change.

## Severity

Low in practice: exploiting the side channel requires measuring response timing
remotely, across TLS, against a string comparison — extremely noisy. This is
standard hardening and consistency, not a response to a known exploit.

## Validation

- Full suite green: 332 unit tests (up from 328) + integration tests, including
  `integration_test_admin_auth`.
- New unit tests: `test_constant_time_eq` (equal, one-byte-off, length
  mismatches, empty), `test_allowed_key_matches` (first/last/no match, prefix,
  empty config), `test_auth_one_byte_off_rejected` and
  `test_auth_last_allowed_key_matches` (through the public `check_api_key_auth`).
- The pre-existing auth tests (valid/invalid/missing/custom-header/multiple-keys)
  still pass unchanged, confirming behavior is preserved.
- `cargo clippy` (no new warnings) and `cargo fmt --check` (no new drift).
