### PR TITLE
fix: include exit status and output tail in llama.cpp build command failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (40 lines, long lines truncated) that is included in the error along with the
   exit status. Successful builds behave exactly as before. (#65)
 
+## [1.10.3] - 2026-05-31
+
 ### Fixed
 
 - mDNS peer removal no longer evicts the wrong peer. When a peer's mDNS service

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.10.3] - 2026-05-31
+## [1.10.4] - 2026-06-11
+
+### Fixed
+
+- Build command failures now include the failure reason. When a command in the
+  llama.cpp build pipeline failed (`git clone`/`fetch`/`checkout`, `cmake`
+  configure, `cmake --build`), the error logged with the `llama_build_failure`
+  event — and surfaced as `last_build_error` in the build status API — contained
+  only the command line, with no exit status and none of the process output. The
+  actual cause (for example a CMake configure error or a transient `git fetch`
+  network failure) was visible only in the parent process's raw stdout/stderr
+  stream, requiring manual correlation with supervisor logs to diagnose.
+  `run_command` now captures the child's stdout and stderr, streams each line
+  through to the parent's stdout/stderr as before, and retains a bounded tail
+  (40 lines, long lines truncated) that is included in the error along with the
+  exit status. Successful builds behave exactly as before. (#65)
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.10.3"
+version = "1.10.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.10.3"
+version = "1.10.4"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/src/build_manager.rs
+++ b/src/build_manager.rs
@@ -1,11 +1,14 @@
 use crate::config::LlamaCppConfig;
 use anyhow::{anyhow, Result};
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use serde::Serialize;
+use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
+use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
 use tokio::process::Command;
 use tracing::{info, warn};
 
@@ -550,10 +553,97 @@ impl BuildManager {
     }
 }
 
+/// Number of trailing output lines retained for error reporting.
+const COMMAND_OUTPUT_TAIL_LINES: usize = 40;
+/// Retained output lines longer than this are truncated, keeping error
+/// messages (and the `last_build_error` API field) bounded.
+const COMMAND_OUTPUT_MAX_LINE_LEN: usize = 400;
+
+/// Reads lines from a child process stream, echoing each to the parent's
+/// stdout/stderr (so build output keeps appearing in the supervisor log, as
+/// it did with inherited stdio) while retaining a bounded tail of recent
+/// lines for error reporting. Reads raw bytes rather than UTF-8 lines so a
+/// stray invalid byte can't stop the pump mid-stream.
+fn pump_output<R>(
+    reader: R,
+    to_stderr: bool,
+    tail: Arc<Mutex<VecDeque<String>>>,
+) -> tokio::task::JoinHandle<()>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+{
+    tokio::spawn(async move {
+        let mut reader = BufReader::new(reader);
+        let mut buf = Vec::new();
+        loop {
+            buf.clear();
+            match reader.read_until(b'\n', &mut buf).await {
+                Ok(0) | Err(_) => break,
+                Ok(_) => {}
+            }
+            let line = String::from_utf8_lossy(&buf);
+            let line = line.trim_end_matches(['\r', '\n']);
+            if to_stderr {
+                eprintln!("{line}");
+            } else {
+                println!("{line}");
+            }
+
+            let mut line = line.to_string();
+            if line.len() > COMMAND_OUTPUT_MAX_LINE_LEN {
+                let mut cut = COMMAND_OUTPUT_MAX_LINE_LEN;
+                while !line.is_char_boundary(cut) {
+                    cut -= 1;
+                }
+                line.truncate(cut);
+                line.push('…');
+            }
+            let mut tail = tail.lock();
+            if tail.len() == COMMAND_OUTPUT_TAIL_LINES {
+                tail.pop_front();
+            }
+            tail.push_back(line);
+        }
+    })
+}
+
 async fn run_command(cmd: &mut Command) -> Result<()> {
-    let status = cmd.status().await?;
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| anyhow!("Failed to spawn command: {cmd:?}: {e}"))?;
+
+    let tail = Arc::new(Mutex::new(VecDeque::new()));
+    let mut pumps = Vec::new();
+    if let Some(stdout) = child.stdout.take() {
+        pumps.push(pump_output(stdout, false, tail.clone()));
+    }
+    if let Some(stderr) = child.stderr.take() {
+        pumps.push(pump_output(stderr, true, tail.clone()));
+    }
+
+    let status = child.wait().await?;
+
+    // After the child exits the pumps drain to EOF almost immediately; the
+    // timeout guards against a grandchild process holding the pipes open.
+    for pump in pumps {
+        let _ = tokio::time::timeout(Duration::from_secs(5), pump).await;
+    }
+
     if !status.success() {
-        return Err(anyhow!("Command failed: {cmd:?}"));
+        let tail = tail.lock();
+        let output = if tail.is_empty() {
+            "no output captured".to_string()
+        } else {
+            format!(
+                "last output:\n{}",
+                tail.iter()
+                    .map(String::as_str)
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            )
+        };
+        return Err(anyhow!("Command failed ({status}): {cmd:?}; {output}"));
     }
     Ok(())
 }
@@ -907,5 +997,64 @@ fi
         let status = bm.build_status();
         assert!(status.last_build_error.is_none());
         assert!(status.last_build_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_run_command_success() {
+        run_command(&mut Command::new("true")).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_run_command_failure_includes_status_and_output() {
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c")
+            .arg("echo configuring; echo 'CMake Error: CUDA Toolkit not found' >&2; exit 3");
+        let err = run_command(&mut cmd).await.unwrap_err().to_string();
+        assert!(err.contains("exit status: 3"), "missing status: {err}");
+        assert!(
+            err.contains("CMake Error: CUDA Toolkit not found"),
+            "missing stderr line: {err}"
+        );
+        assert!(err.contains("configuring"), "missing stdout line: {err}");
+    }
+
+    #[tokio::test]
+    async fn test_run_command_failure_without_output() {
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg("exit 7");
+        let err = run_command(&mut cmd).await.unwrap_err().to_string();
+        assert!(err.contains("exit status: 7"), "missing status: {err}");
+        assert!(err.contains("no output captured"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn test_run_command_failure_output_tail_is_bounded() {
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c")
+            .arg("i=1; while [ $i -le 200 ]; do echo line-$i; i=$((i+1)); done; exit 1");
+        let err = run_command(&mut cmd).await.unwrap_err().to_string();
+        // Only the last COMMAND_OUTPUT_TAIL_LINES (40) lines are kept: 161..=200
+        assert!(err.contains("line-200"), "{err}");
+        assert!(err.contains("line-161\n"), "{err}");
+        assert!(!err.contains("line-160\n"), "{err}");
+        assert!(!err.contains("line-1\n"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn test_run_command_failure_truncates_long_lines() {
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c")
+            .arg("printf 'x%.0s' $(seq 1 1000); echo; exit 1");
+        let err = run_command(&mut cmd).await.unwrap_err().to_string();
+        let long_line = err
+            .lines()
+            .find(|l| l.starts_with('x'))
+            .expect("truncated output line present");
+        assert!(
+            long_line.chars().filter(|&c| c == 'x').count() == COMMAND_OUTPUT_MAX_LINE_LEN,
+            "line not truncated to limit: {} chars",
+            long_line.len()
+        );
+        assert!(long_line.ends_with('…'), "missing truncation marker");
     }
 }

--- a/src/build_manager.rs
+++ b/src/build_manager.rs
@@ -8,7 +8,7 @@ use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 use tracing::{info, warn};
 
@@ -558,12 +558,46 @@ const COMMAND_OUTPUT_TAIL_LINES: usize = 40;
 /// Retained output lines longer than this are truncated, keeping error
 /// messages (and the `last_build_error` API field) bounded.
 const COMMAND_OUTPUT_MAX_LINE_LEN: usize = 400;
+/// Hard cap on bytes buffered for a single output line. Bytes beyond this
+/// (up to the next newline) are consumed and discarded, so a child emitting
+/// an enormous newline-free line cannot grow the buffer without bound.
+const COMMAND_OUTPUT_MAX_LINE_BYTES: usize = 8192;
+
+/// Reads up to and including the next `\n` from `reader`, appending at most
+/// `cap` bytes to `buf`. The remainder of an over-long line is consumed and
+/// discarded, bounding memory regardless of what the child writes. Returns
+/// `Ok(false)` on EOF with nothing read.
+async fn read_line_capped<R>(reader: &mut R, buf: &mut Vec<u8>, cap: usize) -> std::io::Result<bool>
+where
+    R: tokio::io::AsyncBufRead + Unpin,
+{
+    let mut read_any = false;
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            return Ok(read_any);
+        }
+        read_any = true;
+        let (chunk_len, found_newline) = match available.iter().position(|&b| b == b'\n') {
+            Some(i) => (i + 1, true),
+            None => (available.len(), false),
+        };
+        let take = chunk_len.min(cap.saturating_sub(buf.len()));
+        buf.extend_from_slice(&available[..take]);
+        reader.consume(chunk_len);
+        if found_newline {
+            return Ok(true);
+        }
+    }
+}
 
 /// Reads lines from a child process stream, echoing each to the parent's
 /// stdout/stderr (so build output keeps appearing in the supervisor log, as
 /// it did with inherited stdio) while retaining a bounded tail of recent
 /// lines for error reporting. Reads raw bytes rather than UTF-8 lines so a
-/// stray invalid byte can't stop the pump mid-stream.
+/// stray invalid byte can't stop the pump mid-stream, and echoes through
+/// tokio's async stdout/stderr so a stalled log sink cannot block runtime
+/// worker threads.
 fn pump_output<R>(
     reader: R,
     to_stderr: bool,
@@ -575,21 +609,34 @@ where
     tokio::spawn(async move {
         let mut reader = BufReader::new(reader);
         let mut buf = Vec::new();
+        let mut out = tokio::io::stdout();
+        let mut err = tokio::io::stderr();
+        let mut echo_ok = true;
         loop {
             buf.clear();
-            match reader.read_until(b'\n', &mut buf).await {
-                Ok(0) | Err(_) => break,
-                Ok(_) => {}
-            }
-            let line = String::from_utf8_lossy(&buf);
-            let line = line.trim_end_matches(['\r', '\n']);
-            if to_stderr {
-                eprintln!("{line}");
-            } else {
-                println!("{line}");
+            match read_line_capped(&mut reader, &mut buf, COMMAND_OUTPUT_MAX_LINE_BYTES).await {
+                Ok(true) => {}
+                // EOF or read error: stop pumping
+                Ok(false) | Err(_) => break,
             }
 
-            let mut line = line.to_string();
+            // Echo with newline framing preserved even for truncated lines.
+            if echo_ok {
+                if !buf.ends_with(b"\n") {
+                    buf.push(b'\n');
+                }
+                let res = if to_stderr {
+                    err.write_all(&buf).await
+                } else {
+                    out.write_all(&buf).await
+                };
+                // If the parent's stdio is gone, keep draining the pipe so
+                // the child doesn't block, but stop attempting to echo.
+                echo_ok = res.is_ok();
+            }
+
+            let line = String::from_utf8_lossy(&buf);
+            let mut line = line.trim_end_matches(['\r', '\n']).to_string();
             if line.len() > COMMAND_OUTPUT_MAX_LINE_LEN {
                 let mut cut = COMMAND_OUTPUT_MAX_LINE_LEN;
                 while !line.is_char_boundary(cut) {
@@ -603,6 +650,13 @@ where
                 tail.pop_front();
             }
             tail.push_back(line);
+        }
+        if echo_ok {
+            let _ = if to_stderr {
+                err.flush().await
+            } else {
+                out.flush().await
+            };
         }
     })
 }
@@ -625,9 +679,16 @@ async fn run_command(cmd: &mut Command) -> Result<()> {
     let status = child.wait().await?;
 
     // After the child exits the pumps drain to EOF almost immediately; the
-    // timeout guards against a grandchild process holding the pipes open.
-    for pump in pumps {
-        let _ = tokio::time::timeout(Duration::from_secs(5), pump).await;
+    // timeout guards against a grandchild process holding the pipes open. On
+    // timeout the pump is aborted so it can't linger and echo a grandchild's
+    // output into the supervisor log long after the build step finished.
+    for mut pump in pumps {
+        if tokio::time::timeout(Duration::from_secs(5), &mut pump)
+            .await
+            .is_err()
+        {
+            pump.abort();
+        }
     }
 
     if !status.success() {
@@ -1056,5 +1117,49 @@ fi
             long_line.len()
         );
         assert!(long_line.ends_with('…'), "missing truncation marker");
+    }
+
+    #[tokio::test]
+    async fn test_run_command_bounds_newline_free_output() {
+        // A child emitting a huge line with no newline must not grow the
+        // capture buffer without bound; the tail entry is still truncated.
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c")
+            .arg("head -c 1000000 /dev/zero | tr '\\0' 'y'; exit 1");
+        let err = run_command(&mut cmd).await.unwrap_err().to_string();
+        let long_line = err
+            .lines()
+            .find(|l| l.starts_with('y'))
+            .expect("captured line present");
+        assert!(
+            long_line.chars().filter(|&c| c == 'y').count() == COMMAND_OUTPUT_MAX_LINE_LEN,
+            "line not truncated to limit"
+        );
+        assert!(long_line.ends_with('…'), "missing truncation marker");
+    }
+
+    #[tokio::test]
+    async fn test_read_line_capped() {
+        let data: Vec<u8> = [b"short\n".to_vec(), vec![b'z'; 20000], b"\nnext\n".to_vec()].concat();
+        let mut reader = BufReader::new(data.as_slice());
+        let cap = COMMAND_OUTPUT_MAX_LINE_BYTES;
+
+        let mut buf = Vec::new();
+        assert!(read_line_capped(&mut reader, &mut buf, cap).await.unwrap());
+        assert_eq!(buf, b"short\n");
+
+        // Over-long line: capped at `cap` bytes, remainder discarded
+        buf.clear();
+        assert!(read_line_capped(&mut reader, &mut buf, cap).await.unwrap());
+        assert_eq!(buf.len(), cap);
+        assert!(buf.iter().all(|&b| b == b'z'));
+
+        // The next line is read intact — the overflow didn't bleed into it
+        buf.clear();
+        assert!(read_line_capped(&mut reader, &mut buf, cap).await.unwrap());
+        assert_eq!(buf, b"next\n");
+
+        buf.clear();
+        assert!(!read_line_capped(&mut reader, &mut buf, cap).await.unwrap());
     }
 }


### PR DESCRIPTION
Fixes #65

## Problem

`run_command` in `src/build_manager.rs` runs every command in the llama.cpp build pipeline (`git clone`/`fetch`/`checkout`/`reset`, `cmake` configure, `cmake --build`) with inherited stdio and reports failures as `Command failed: {cmd:?}` — just the command line. The exit status and all process output are discarded, so the `llama_build_failure` log event and the `last_build_error` field in the build status API never contain the actual cause of the failure (for example a CMake configure error, or a transient `git fetch` network failure). Diagnosing a failed build requires manually correlating timestamps against the supervisor's raw stdout/stderr capture.

## Change

`run_command` now spawns the child with piped stdout/stderr and pumps both streams line-by-line:

- Each line is echoed to the parent's stdout/stderr as it arrives, preserving the previous inherited-stdio behavior of build output appearing live in the supervisor log.
- A bounded tail of recent lines is retained (last 40 lines across both streams, individual lines truncated at 400 bytes on a char boundary), keeping the error message and `last_build_error` bounded even for very long builds.
- On failure, the returned error includes the exit status (or terminating signal) and the retained output tail. On success, nothing changes.

The stream pumps read raw bytes with lossy UTF-8 conversion rather than UTF-8 lines, so a stray invalid byte can't stop a pump mid-stream (which would otherwise risk a pipe-full deadlock). Pumps are drained concurrently with `wait()`, and joined with a short timeout after exit to guard against a grandchild holding the pipes open.

## Testing

- 5 new unit tests covering: success path, failure error containing exit status + stdout + stderr lines, failure with no output, tail bounding (only the last 40 of 200 lines retained), and long-line truncation with marker.
- Full suite: 344 bin tests + 8 integration tests pass.