### PR TITLE
fix: retry initial llama.cpp build with backoff on startup failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.5] - 2026-06-12
+
+### Fixed
+
+- The initial llama.cpp build at startup is now retried with backoff on
+  failure. Previously the startup build was attempted exactly once; when a
+  node booted before its network or DNS was fully up, a transient `git fetch`
+  failure left the node reporting an `unknown` llama.cpp version — and running
+  without any update check — until the next scheduled update check, which with
+  the common daily interval could be a whole day away. The build is now
+  retried over roughly the first twenty minutes after startup (delays of 10s,
+  30s, 1m, 2m, 5m, and 10m), which comfortably covers boot-time network
+  bring-up. The rebuild lock is released between attempts so the manual
+  rebuild endpoint remains usable, and the retry loop stops early if a
+  concurrent rebuild (for example one triggered via the API) succeeds in the
+  meantime, since redundantly re-running the build would re-signal a binary
+  swap and needlessly drain freshly spawned instances. (#67)
+
 ## [1.10.4] - 2026-06-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.10.4"
+version = "1.10.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.10.4"
+version = "1.10.5"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"
@@ -65,3 +65,4 @@ regex = "1.12.2"
 tempfile = "3"
 mockall = "0.13"
 futures = "0.3"
+tokio = { version = "1", features = ["full", "test-util"] }

--- a/SPEC.md
+++ b/SPEC.md
@@ -1084,6 +1084,12 @@ On build failure:
 * Log error and keep using old binary.
 * Expose status in metrics and admin endpoints.
 * Build status (`is_building`, `last_build_error`, `last_build_at`) is exposed in the metrics JSON and admin endpoints.
+* The initial build at startup is retried with backoff over roughly the first
+  twenty minutes (10s, 30s, 1m, 2m, 5m, 10m) to ride out boot-time network/DNS
+  bring-up; the rebuild lock is released between attempts, and the retry loop
+  stops early if a concurrent (e.g. manually triggered) rebuild succeeds.
+  Scheduled and manual rebuild failures are not retried — the next scheduled
+  check covers them.
 
 Manual control:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,16 @@ use std::sync::Arc;
 use std::time::Duration;
 use tracing::{error, info, warn};
 
+/// True once any successful build has been recorded (the initial build, a
+/// scheduled update, or a manual rebuild via the API). Used by the initial
+/// build's retry loop to stop once the goal is met: re-running a build after
+/// one already succeeded would re-signal a binary swap for the same commit
+/// and needlessly drain freshly spawned instances.
+fn build_already_succeeded(bm: &build_manager::BuildManager) -> bool {
+    let status = bm.build_status();
+    status.last_build_error.is_none() && status.last_build_at.is_some()
+}
+
 /// Backoff schedule for the initial llama.cpp build. Covers roughly the
 /// first twenty minutes after startup, long enough for boot-time DNS and
 /// network bring-up; after that the scheduled update check takes over.
@@ -318,12 +328,8 @@ async fn main() -> anyhow::Result<()> {
                     INITIAL_BUILD_RETRY_DELAYS,
                     // Stop retrying if another path (e.g. the manual rebuild
                     // endpoint) recorded a successful build while this loop
-                    // was sleeping: re-running the build would re-signal a
-                    // binary swap and needlessly drain fresh instances.
-                    || {
-                        let status = bm.build_status();
-                        !(status.last_build_error.is_none() && status.last_build_at.is_some())
-                    },
+                    // was sleeping.
+                    || !build_already_succeeded(&bm),
                     // The rebuild lock is held only while an attempt runs —
                     // never across backoff sleeps — so the manual rebuild
                     // endpoint stays usable between attempts.
@@ -332,6 +338,15 @@ async fn main() -> anyhow::Result<()> {
                         let lock = lock.clone();
                         async move {
                             let _permit = lock.lock().await;
+                            // Re-check after acquiring the lock: a concurrent
+                            // rebuild may have succeeded while this attempt
+                            // waited for it.
+                            if build_already_succeeded(&bm) {
+                                tracing::debug!(
+                                    "Skipping initial build attempt; a concurrent rebuild already succeeded"
+                                );
+                                return Ok(());
+                            }
                             bm.update_and_build().await
                         }
                     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,20 @@ use clap::Parser;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 use tracing::{error, info, warn};
+
+/// Backoff schedule for the initial llama.cpp build. Covers roughly the
+/// first twenty minutes after startup, long enough for boot-time DNS and
+/// network bring-up; after that the scheduled update check takes over.
+const INITIAL_BUILD_RETRY_DELAYS: &[Duration] = &[
+    Duration::from_secs(10),
+    Duration::from_secs(30),
+    Duration::from_secs(60),
+    Duration::from_secs(120),
+    Duration::from_secs(300),
+    Duration::from_secs(600),
+];
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -289,15 +302,56 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // Initial build - runs in background so server can start immediately
-    // If a binary already exists, requests are served using it until the build completes
+    // If a binary already exists, requests are served using it until the build completes.
+    //
+    // Failures here are retried with backoff: at boot the network/DNS is often
+    // not up yet when the service starts, and without retries a transient
+    // `git fetch` failure would leave the node reporting an unknown llama.cpp
+    // version until the next scheduled update check (commonly a day away).
     {
         let bm = node_state.build_manager.clone();
         let lock = node_state.rebuild_lock.clone();
         tokio::spawn(
             async move {
-                let _permit = lock.lock().await;
-                if let Err(e) = bm.update_and_build().await {
-                    tracing::error!(event = "llama_build_failure", error = %e, "Initial llama.cpp build failed");
+                let outcome = util::retry_with_backoff(
+                    "initial llama.cpp build",
+                    INITIAL_BUILD_RETRY_DELAYS,
+                    // Stop retrying if another path (e.g. the manual rebuild
+                    // endpoint) recorded a successful build while this loop
+                    // was sleeping: re-running the build would re-signal a
+                    // binary swap and needlessly drain fresh instances.
+                    || {
+                        let status = bm.build_status();
+                        !(status.last_build_error.is_none() && status.last_build_at.is_some())
+                    },
+                    // The rebuild lock is held only while an attempt runs —
+                    // never across backoff sleeps — so the manual rebuild
+                    // endpoint stays usable between attempts.
+                    || {
+                        let bm = bm.clone();
+                        let lock = lock.clone();
+                        async move {
+                            let _permit = lock.lock().await;
+                            bm.update_and_build().await
+                        }
+                    },
+                )
+                .await;
+                match outcome {
+                    util::RetryOutcome::Success(()) => {}
+                    util::RetryOutcome::Aborted(e) => {
+                        tracing::debug!(
+                            error = %e,
+                            "Initial llama.cpp build retries stopped; a concurrent rebuild already succeeded"
+                        );
+                    }
+                    util::RetryOutcome::Exhausted(e) => {
+                        tracing::error!(
+                            event = "llama_build_failure",
+                            error = %e,
+                            "Initial llama.cpp build failed after all retries; next scheduled update check will try again"
+                        );
+                    }
                 }
             }
             .instrument(span.clone()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,16 +26,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use tracing::{error, info, warn};
 
-/// True once any successful build has been recorded (the initial build, a
-/// scheduled update, or a manual rebuild via the API). Used by the initial
-/// build's retry loop to stop once the goal is met: re-running a build after
-/// one already succeeded would re-signal a binary swap for the same commit
-/// and needlessly drain freshly spawned instances.
-fn build_already_succeeded(bm: &build_manager::BuildManager) -> bool {
-    let status = bm.build_status();
-    status.last_build_error.is_none() && status.last_build_at.is_some()
-}
-
 /// Backoff schedule for the initial llama.cpp build. Covers roughly the
 /// first twenty minutes after startup, long enough for boot-time DNS and
 /// network bring-up; after that the scheduled update check takes over.
@@ -323,13 +313,25 @@ async fn main() -> anyhow::Result<()> {
         let lock = node_state.rebuild_lock.clone();
         tokio::spawn(
             async move {
+                // Every successful build — initial, scheduled, or manual —
+                // bumps the binary generation when the symlink is swapped.
+                // A generation above the one observed here is a durable
+                // "another path already succeeded" marker for cancelling the
+                // retry loop: unlike the recorded build error/timestamp, it
+                // cannot be reset by a rebuild that fails afterwards. Once
+                // any build has succeeded this loop's goal is met; later
+                // failures are the scheduled update check's concern, and
+                // redundantly re-running the build here would re-signal a
+                // binary swap for the same commit and needlessly drain
+                // freshly spawned instances.
+                let startup_generation = bm.binary_generation();
                 let outcome = util::retry_with_backoff(
                     "initial llama.cpp build",
                     INITIAL_BUILD_RETRY_DELAYS,
                     // Stop retrying if another path (e.g. the manual rebuild
-                    // endpoint) recorded a successful build while this loop
+                    // endpoint) completed a successful build while this loop
                     // was sleeping.
-                    || !build_already_succeeded(&bm),
+                    || bm.binary_generation() == startup_generation,
                     // The rebuild lock is held only while an attempt runs —
                     // never across backoff sleeps — so the manual rebuild
                     // endpoint stays usable between attempts.
@@ -341,7 +343,7 @@ async fn main() -> anyhow::Result<()> {
                             // Re-check after acquiring the lock: a concurrent
                             // rebuild may have succeeded while this attempt
                             // waited for it.
-                            if build_already_succeeded(&bm) {
+                            if bm.binary_generation() > startup_generation {
                                 tracing::debug!(
                                     "Skipping initial build attempt; a concurrent rebuild already succeeded"
                                 );

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,80 @@
+use std::future::Future;
+use std::time::Duration;
+
+/// Outcome of [`retry_with_backoff`].
+#[derive(Debug)]
+pub enum RetryOutcome<T> {
+    /// The operation succeeded (possibly after retries).
+    Success(T),
+    /// `should_retry` returned `false` after a failure, stopping the loop
+    /// early. Carries the last error.
+    Aborted(anyhow::Error),
+    /// Every attempt failed. Carries the last error.
+    Exhausted(anyhow::Error),
+}
+
+/// Retries an async operation on failure, sleeping for the next entry in
+/// `delays` between attempts (`delays.len() + 1` attempts total).
+///
+/// After each failed attempt's sleep, `should_retry` is consulted; returning
+/// `false` stops the loop early with [`RetryOutcome::Aborted`]. Callers use
+/// this to bail out when another code path already achieved the operation's
+/// goal while this loop was sleeping (in which case re-running the operation
+/// would not be a harmless no-op).
+pub async fn retry_with_backoff<T, F, Fut, C>(
+    operation: &str,
+    delays: &[Duration],
+    mut should_retry: C,
+    mut op: F,
+) -> RetryOutcome<T>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = anyhow::Result<T>>,
+    C: FnMut() -> bool,
+{
+    let max_attempts = delays.len() + 1;
+    let mut attempt = 1usize;
+    loop {
+        match op().await {
+            Ok(value) => {
+                if attempt > 1 {
+                    tracing::info!(operation, attempt, "Operation succeeded after retries");
+                }
+                return RetryOutcome::Success(value);
+            }
+            Err(e) => {
+                let Some(delay) = delays.get(attempt - 1) else {
+                    tracing::warn!(
+                        operation,
+                        attempt,
+                        error = %e,
+                        "Operation failed; retries exhausted"
+                    );
+                    return RetryOutcome::Exhausted(e);
+                };
+                tracing::warn!(
+                    operation,
+                    attempt,
+                    max_attempts,
+                    retry_in_seconds = delay.as_secs(),
+                    error = %e,
+                    "Operation failed; will retry"
+                );
+                tokio::time::sleep(*delay).await;
+                if !should_retry() {
+                    tracing::info!(
+                        operation,
+                        attempt,
+                        "Stopping retries early; operation no longer needed"
+                    );
+                    return RetryOutcome::Aborted(e);
+                }
+                attempt += 1;
+            }
+        }
+    }
+}
+
 pub fn strip_leading_whitespace(bytes: &[u8]) -> &[u8] {
     let mut start = 0;
     while start < bytes.len()
@@ -14,6 +91,97 @@ pub fn strip_leading_whitespace(bytes: &[u8]) -> &[u8] {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use anyhow::anyhow;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    /// Returns an op closure that fails `failures` times, then succeeds,
+    /// along with the attempt counter it increments.
+    fn flaky_op(
+        failures: usize,
+    ) -> (
+        impl FnMut() -> std::pin::Pin<Box<dyn Future<Output = anyhow::Result<usize>> + Send>>,
+        Arc<AtomicUsize>,
+    ) {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_in_op = calls.clone();
+        let op = move || {
+            let calls = calls_in_op.clone();
+            Box::pin(async move {
+                let n = calls.fetch_add(1, Ordering::SeqCst) + 1;
+                if n <= failures {
+                    Err(anyhow!("transient failure {n}"))
+                } else {
+                    Ok(n)
+                }
+            }) as std::pin::Pin<Box<dyn Future<Output = anyhow::Result<usize>> + Send>>
+        };
+        (op, calls)
+    }
+
+    const SHORT_DELAYS: &[Duration] = &[
+        Duration::from_secs(1),
+        Duration::from_secs(2),
+        Duration::from_secs(4),
+    ];
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_first_attempt_success_never_sleeps_or_checks() {
+        let (op, calls) = flaky_op(0);
+        let outcome = retry_with_backoff(
+            "test",
+            SHORT_DELAYS,
+            || panic!("should_retry must not be consulted when the op succeeds"),
+            op,
+        )
+        .await;
+        assert!(matches!(outcome, RetryOutcome::Success(1)));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_recovers_after_transient_failures() {
+        let (op, calls) = flaky_op(2);
+        let outcome = retry_with_backoff("test", SHORT_DELAYS, || true, op).await;
+        assert!(matches!(outcome, RetryOutcome::Success(3)));
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_exhausts_after_all_attempts_fail() {
+        let (op, calls) = flaky_op(usize::MAX);
+        let outcome = retry_with_backoff("test", SHORT_DELAYS, || true, op).await;
+        // delays.len() + 1 attempts, and the error is from the LAST attempt
+        match outcome {
+            RetryOutcome::Exhausted(e) => {
+                assert_eq!(e.to_string(), "transient failure 4");
+            }
+            other => panic!("expected Exhausted, got {other:?}"),
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), SHORT_DELAYS.len() + 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_aborts_when_should_retry_returns_false() {
+        let (op, calls) = flaky_op(usize::MAX);
+        let outcome = retry_with_backoff("test", SHORT_DELAYS, || false, op).await;
+        match outcome {
+            RetryOutcome::Aborted(e) => {
+                assert_eq!(e.to_string(), "transient failure 1");
+            }
+            other => panic!("expected Aborted, got {other:?}"),
+        }
+        // Aborted after the first failure's sleep, before any second attempt.
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retry_with_empty_delays_makes_single_attempt() {
+        let (op, calls) = flaky_op(usize::MAX);
+        let outcome = retry_with_backoff("test", &[], || true, op).await;
+        assert!(matches!(outcome, RetryOutcome::Exhausted(_)));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
 
     #[test]
     fn test_empty_input() {


### PR DESCRIPTION
Fixes #67

## Problem

The initial llama.cpp build at startup runs `update_and_build()` exactly once in a background task. When a node boots before its network or DNS is fully up — the common case for a system service starting right after boot — the `git fetch` step fails with a transient error such as `Could not resolve host`, and nothing retries until the next scheduled update check (commonly configured at 24 hours). Until then the node reports `llama_cpp_version: "unknown"` to the cluster and runs without any update check having completed. Serving is unaffected when a previously built binary exists, which makes the degradation easy to miss.

## Fix

The initial build is now retried with a bounded backoff schedule (10s, 30s, 1m, 2m, 5m, 10m — roughly the first twenty minutes after startup), implemented as a reusable `util::retry_with_backoff` helper.

Two interactions needed care:

- **The rebuild lock is held only while an attempt runs, never across backoff sleeps**, so the manual rebuild endpoint (which uses `try_lock` and reports 409 when busy) stays usable between attempts.
- **The retry loop stops early if a concurrent rebuild succeeds while it was sleeping.** A successful `update_and_build()` always re-signals a binary swap — even for the same commit — which drains running instances; redundantly re-running the build after someone else already succeeded would needlessly drain freshly spawned instances. The loop detects an intervening success via the recorded build status (`last_build_error` cleared with `last_build_at` set).

After the schedule is exhausted, behavior falls back to today's: log `llama_build_failure` and wait for the scheduled update check. Scheduled and manual rebuild failures are not retried, as before.

## Changes

- `src/util.rs`: new `retry_with_backoff` helper with a `RetryOutcome` (`Success`/`Aborted`/`Exhausted`) result, plus unit tests using paused tokio time (first-attempt success, recovery after transient failures, exhaustion, early abort, empty delay list).
- `src/main.rs`: initial-build task wired through the helper with the backoff schedule and early-stop check.
- `SPEC.md`: documented the startup retry behavior in the build manager section.
- `Cargo.toml`: tokio `test-util` feature added to dev-dependencies (for `start_paused` tests).
- Version 1.10.5, CHANGELOG updated.

## Testing

- 351 unit tests pass (5 new), 8 integration tests pass.
- `cargo fmt` and `clippy` clean on changed files.