### PR TITLE
fix: skip binary swap signal when verified binary is already live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.6] - 2026-06-12
+
+### Fixed
+
+- A rebuild check that finds nothing to change no longer drains running
+  instances. When `update_and_build` verified an already-built binary for the
+  current commit, it unconditionally re-pointed the symlink and signaled a
+  binary swap — even when the symlink already pointed at exactly that binary.
+  Since every swap signal drains all running instances (they stop accepting
+  new requests and are recycled onto the "new" binary), the scheduled update
+  check evicted warm instances on every interval where upstream had no new
+  commits, forcing pointless model reloads. The swap (and its drain) is now
+  skipped when the live symlink already resolves to the verified binary.
+  Builds land in immutable per-commit directories, so an identical resolved
+  path means running instances already use exactly that binary; the
+  rebuild-after-failed-verification path is unaffected and still signals a
+  swap, since it replaces the binary content in place. (#69)
+
 ## [1.10.5] - 2026-06-12
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.10.5"
+version = "1.10.6"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.10.5"
+version = "1.10.6"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/SPEC.md
+++ b/SPEC.md
@@ -1075,6 +1075,10 @@ Each node is responsible for its local `llama.cpp`.
 When a new binary is ready:
 
 * The symlink swap signals `binary_swap_notify`, which triggers instance draining.
+* No-op checks are recognized: when the verified binary for the current commit
+  is already what the symlink resolves to, no swap is performed or signaled,
+  so running instances are not drained (per-commit build directories are
+  immutable, so an identical resolved path implies an identical binary).
 * **Version-aware drain**: All existing instances are marked as draining (they stop accepting new requests but continue serving in-flight requests).
 * New requests spawn fresh instances using the new binary.
 * Drained instances are terminated when their in-flight request count hits 0.

--- a/src/build_manager.rs
+++ b/src/build_manager.rs
@@ -300,6 +300,21 @@ impl BuildManager {
                 commit_hash
             );
             if self.verify_binary(&actual_binary_path).await.is_ok() {
+                // If the live symlink already points at this binary there is
+                // nothing to swap: signaling a swap anyway would drain every
+                // running instance for a binary change that never happened
+                // (the common case for the scheduled update check when
+                // upstream has no new commits, and for every restart).
+                // Builds land in immutable per-commit directories, so an
+                // identical resolved path means running instances already
+                // use exactly this binary. A rebuild into the same directory
+                // (the verification-failure path below) does not take this
+                // branch and still signals a swap.
+                if self.symlink_already_current(&actual_binary_path).await {
+                    info!("Existing binary verified and already live. Skipping binary swap.");
+                    self.record_running_version(&commit_hash);
+                    return Ok(());
+                }
                 info!("Existing binary verified. Switching symlink.");
                 self.update_symlink(&actual_binary_path).await?;
                 self.record_running_version(&commit_hash);
@@ -459,6 +474,22 @@ impl BuildManager {
                 Err(anyhow!("Binary verification failed to execute"))
             }
         }
+    }
+
+    /// Returns true when the configured binary path already resolves to the
+    /// same file as `target`. Any failure to resolve either side (missing
+    /// link, dangling target, non-symlink fallback installs) returns false,
+    /// in which case the caller proceeds with a normal swap — the check only
+    /// ever skips work, never a needed swap.
+    async fn symlink_already_current(&self, target: &Path) -> bool {
+        let link_path = Path::new(&self.config.binary_path);
+        let (Ok(resolved_link), Ok(resolved_target)) = (
+            tokio::fs::canonicalize(link_path).await,
+            tokio::fs::canonicalize(target).await,
+        ) else {
+            return false;
+        };
+        resolved_link == resolved_target
     }
 
     async fn update_symlink(&self, target: &Path) -> Result<()> {
@@ -837,8 +868,77 @@ fi
         assert!(status.last_build_error.is_none());
         assert!(status.last_build_at.is_some());
 
+        // 6. Re-run with the same commit: the verified binary is already
+        // live, so no new swap may be signaled — a swap would needlessly
+        // drain running instances. (This run takes the verify-existing fast
+        // path, so the mock cmake is not needed again.)
+        let gen_after_first = bm.binary_generation();
+        assert!(gen_after_first >= 1);
+        let result = bm.update_and_build().await;
+        assert!(result.is_ok());
+        assert_eq!(
+            bm.binary_generation(),
+            gen_after_first,
+            "same-commit no-op rebuild must not signal a binary swap"
+        );
+
+        // 7. If the symlink points somewhere else, the same situation must
+        // swap (and signal) again.
+        tokio::fs::remove_file(&binary_path).await.unwrap();
+        std::os::unix::fs::symlink(&cmake_path, &binary_path).unwrap();
+        let result = bm.update_and_build().await;
+        assert!(result.is_ok());
+        assert_eq!(
+            bm.binary_generation(),
+            gen_after_first + 1,
+            "stale symlink must be re-pointed and the swap signaled"
+        );
+        let resolved = tokio::fs::canonicalize(&binary_path).await.unwrap();
+        assert!(resolved.ends_with("bin/llama-server"));
+
         // Cleanup
         let _ = tokio::fs::remove_dir_all(temp_dir).await;
+    }
+
+    #[tokio::test]
+    async fn symlink_already_current_detects_live_and_stale_links() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "llamesh-symlink-test-{}",
+            ulid::Ulid::new().to_string()
+        ));
+        tokio::fs::create_dir_all(&temp_dir).await.unwrap();
+        let target = temp_dir.join("target-bin");
+        tokio::fs::write(&target, "x").await.unwrap();
+        let other = temp_dir.join("other-bin");
+        tokio::fs::write(&other, "y").await.unwrap();
+        let link = temp_dir.join("link");
+
+        let config = crate::config::LlamaCppConfig {
+            repo_url: "".into(),
+            repo_path: "".into(),
+            build_path: "".into(),
+            binary_path: link.to_string_lossy().to_string(),
+            branch: "".into(),
+            build_args: vec![],
+            build_command_args: vec![],
+            auto_update_interval_seconds: 0,
+            enabled: false,
+            keep_builds: 3,
+        };
+        let bm = BuildManager::new(config);
+
+        // No link exists yet.
+        assert!(!bm.symlink_already_current(&target).await);
+
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        assert!(bm.symlink_already_current(&target).await);
+        assert!(!bm.symlink_already_current(&other).await);
+
+        // Dangling link (target removed) must not count as current.
+        tokio::fs::remove_file(&target).await.unwrap();
+        assert!(!bm.symlink_already_current(&target).await);
+
+        let _ = tokio::fs::remove_dir_all(&temp_dir).await;
     }
 
     #[test]


### PR DESCRIPTION
Fixes #69

## Problem

Every successful `update_and_build()` ended by re-pointing the binary symlink and signaling a binary swap — including the early path where the binary for the current commit already exists, verifies, and is already exactly what the symlink resolves to. Since each swap signal drains all running instances, the scheduled update check (commonly daily) evicted every warm llama-server instance on each interval where upstream had no new commits, forcing pointless model reloads.

## Fix

In the verify-existing-binary path, the swap and its drain signal are now skipped when the live symlink already resolves to the verified binary (new `symlink_already_current` helper using canonicalized comparison). The reasoning relies on per-commit build directories being immutable: an identical resolved path implies running instances already execute exactly that binary.

Two paths deliberately keep today's behavior:

- **Rebuild after failed verification** writes new binary content into the *same* per-commit path; it does not take the skip branch and still swaps and signals, so instances running the old bits are drained.
- **Any resolution failure** (missing link, dangling target, the non-symlink copy fallback) returns "not current" and falls through to the normal swap — the check can only ever skip redundant work, never a needed swap.

Interaction with the v1.10.5 initial-build retry was audited: the retry loop's cancellation marker is the binary generation, which a skipped no-op swap no longer bumps — but in that case a redundant retry attempt now also resolves as a no-op (no swap, no drain), so the property the marker protects (no needless drain) holds either way.

## Changes

- `src/build_manager.rs`: skip branch in the verify-existing path + `symlink_already_current` helper.
- Tests: `test_build_manager_flow` extended with two more `update_and_build` runs asserting the generation is unchanged on a same-commit no-op and bumps again when the symlink was re-pointed elsewhere; new focused unit test for `symlink_already_current` (live, stale, missing, dangling).
- `SPEC.md`: documented the no-op recognition in the binary-swap section.
- Version 1.10.6, CHANGELOG updated.

## Testing

- 352 unit tests pass, 8 integration tests pass.
- `cargo fmt` and `clippy` clean on changed code.