### PR TITLE
fix: reserve spawn capacity before releasing the instances lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   before spawning — and is served by the winner's instance as before.
   Reservations are RAII-released on every failure path (including request
   cancellation) and handed off when the instance is inserted into the map.
-  The post-spawn race detection remains as defense in depth, but is no longer
-  expected to fire. (#71)
+  Because queued contenders now depend on the in-flight spawn resolving,
+  both resolutions wake them: an abandoned reservation (spawn failure or
+  cancellation) notifies all queues, since capacity freed without any
+  instance reaching the map and no later event would do it; and an instance
+  becoming ready notifies one queued waiter for its model and profile, which
+  may attach to the ready instance's spare concurrency slots instead of
+  sleeping until an unrelated slot-release event. The post-spawn race
+  detection remains as defense in depth, but is no longer expected to
+  fire. (#71)
 
 ## [1.10.6] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,12 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   becoming ready wakes queued waiters for its model and profile up to its
   spare concurrency slots; and a failed startup triggers an immediate
   eviction pass (which removes the dead instance and notifies all queues)
-  instead of leaving waiters to the next periodic eviction tick. The
-  spawning request's own concurrency slot is also now claimed before the
-  instance is shared, closing a window where a concurrently attaching
-  request's increment could be overwritten and the instance permanently
-  undercounted. The post-spawn race detection remains as defense in depth,
-  but is no longer expected to fire. (#71)
+  instead of leaving waiters to the next periodic eviction tick; and a
+  request that enqueues after being gated by a reservation re-checks the
+  gate once it is visible in the queue, closing the window where an abandon
+  notification fires before the loser has enqueued. The spawning request's
+  own concurrency slot is also now claimed before the instance is shared,
+  closing a window where a concurrently attaching request's increment could
+  be overwritten and the instance permanently undercounted. The post-spawn
+  race detection remains as defense in depth, but is no longer expected to
+  fire. (#71)
 
 ## [1.10.6] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,14 +25,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Reservations are RAII-released on every failure path (including request
   cancellation) and handed off when the instance is inserted into the map.
   Because queued contenders now depend on the in-flight spawn resolving,
-  both resolutions wake them: an abandoned reservation (spawn failure or
+  every resolution wakes them: an abandoned reservation (spawn failure or
   cancellation) notifies all queues, since capacity freed without any
-  instance reaching the map and no later event would do it; and an instance
-  becoming ready notifies one queued waiter for its model and profile, which
-  may attach to the ready instance's spare concurrency slots instead of
-  sleeping until an unrelated slot-release event. The post-spawn race
-  detection remains as defense in depth, but is no longer expected to
-  fire. (#71)
+  instance reaching the map and no later event would do it; an instance
+  becoming ready wakes queued waiters for its model and profile up to its
+  spare concurrency slots; and a failed startup triggers an immediate
+  eviction pass (which removes the dead instance and notifies all queues)
+  instead of leaving waiters to the next periodic eviction tick. The
+  spawning request's own concurrency slot is also now claimed before the
+  instance is shared, closing a window where a concurrently attaching
+  request's increment could be overwritten and the instance permanently
+  undercounted. The post-spawn race detection remains as defense in depth,
+  but is no longer expected to fire. (#71)
 
 ## [1.10.6] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.7] - 2026-06-12
+
+### Fixed
+
+- Concurrent requests can no longer waste a llama-server spawn racing for the
+  same capacity slot. The capacity checks (per-profile `max_instances` and
+  node-wide `max_instances_per_node`) were enforced again only *after* a new
+  process had been spawned, because the instances lock is released during the
+  slow spawn itself; two concurrent requests for the same profile could both
+  pass the checks, both spawn, and the loser killed its just-spawned process
+  at insertion time (`spawn_profile_race_detected`), wasting a process exec
+  and partial model load. Spawns now take an in-flight capacity reservation
+  while still holding the instances lock, making check-and-reserve atomic:
+  the second contender observes the reservation and queues immediately —
+  before spawning — and is served by the winner's instance as before.
+  Reservations are RAII-released on every failure path (including request
+  cancellation) and handed off when the instance is inserted into the map.
+  The post-spawn race detection remains as defense in depth, but is no longer
+  expected to fire. (#71)
+
 ## [1.10.6] - 2026-06-12
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.10.6"
+version = "1.10.7"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.10.6"
+version = "1.10.7"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/SPEC.md
+++ b/SPEC.md
@@ -883,8 +883,13 @@ On chosen node (or standalone):
    * Dispatch the request to that instance.
 5. If no instance has capacity and total instances < `max_instances` for that profile and resource guardrails allow:
 
+   * Reserve the capacity slot (per-profile and node-wide) before releasing the
+     instances lock to spawn: in-flight spawn reservations count toward the
+     capacity checks, so a concurrent contender queues instead of spawning a
+     duplicate. Reservations are RAII-released on every failure path and handed
+     off to the instances map on successful insertion.
    * Start a new instance with spawn retry and port rotation (up to 3 retries on OS-level failure).
-   * After spawn, perform post-spawn race detection: if another request raced and consumed capacity, kill the just-spawned process to avoid waste.
+   * After spawn, perform post-spawn race detection as defense in depth: if another request somehow raced and consumed capacity, kill the just-spawned process to avoid waste (with reservations gating admission, this path is not expected to fire).
    * Queue the request until the instance is ready.
 6. If no new instance can be started (due to guardrails or `max_instances` reached):
 

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -2035,7 +2035,7 @@ impl NodeState {
                 // Check if this is a cold start (no learned memory for this args_hash)
                 let is_cold_start = !self.metrics.has_memory_data(&args_hash).await;
 
-                let new_instance = Instance::new(
+                let mut new_instance = Instance::new(
                     instance_id.clone(),
                     model_name.to_string(),
                     profile.id.clone(),
@@ -2044,6 +2044,15 @@ impl NodeState {
                     args_hash.clone(),
                     is_cold_start,
                 );
+                if reserve_slot {
+                    // Claim the spawning request's slot before the instance
+                    // is shared: once it is in the map, concurrent requests
+                    // (including ready-time woken waiters) can attach and
+                    // increment the count, and a late `= 1` assignment would
+                    // overwrite their increments, undercounting active
+                    // requests for the rest of the instance's life.
+                    new_instance.in_flight_requests = 1;
+                }
                 let inst_arc = Arc::new(RwLock::new(new_instance));
 
                 // Try to spawn BEFORE inserting into map to avoid race condition
@@ -2179,6 +2188,22 @@ impl NodeState {
                     error!("Instance {} failed to become ready: {}", inst.id, e);
                     inst.clear_startup_log();
                     let _ = inst.stop().await;
+                    // LOCK_ORDER: release the instance lock (4) before the
+                    // eviction pass acquires `instances` (1).
+                    drop(inst);
+
+                    // The stopped instance still occupies its map slot — and
+                    // its model:profile capacity count — until an eviction
+                    // pass removes it. Requests that queued behind this spawn
+                    // (gated by its reservation) would wait up to a full
+                    // periodic eviction tick before retrying; run a pass now
+                    // so they are woken immediately (check_idle_instances
+                    // removes dead instances and ends with
+                    // notify_all_queues). Same precedent as the immediate
+                    // pass after a cookbook reload.
+                    if let Err(e) = ready_state.check_idle_instances().await {
+                        error!("Eviction pass after failed startup failed: {}", e);
+                    }
                 } else {
                     // Parse model params from startup log now that instance is ready
                     inst.parse_and_store_startup_params();
@@ -2199,13 +2224,6 @@ impl NodeState {
                     // Trigger instant gossip so peers learn about new model availability
                     gossip_trigger.notify_one();
 
-                    // Wake one queued waiter for this model:profile. A request
-                    // that queued while this spawn was in flight (gated by
-                    // the spawn reservation) would otherwise sleep until some
-                    // unrelated slot-release event, even though the instance
-                    // is now ready and may have spare concurrency slots.
-                    ready_state.notify_queue(&ready_model, &ready_profile).await;
-
                     if is_cold {
                         // Cold start: sample memory after ready and store learned value
                         if let Some(pid) = inst.get_pid() {
@@ -2225,14 +2243,31 @@ impl NodeState {
                             }
                         }
                     }
+
+                    // Wake queued waiters for this model:profile, up to the
+                    // ready instance's spare concurrency. Requests that
+                    // queued while this spawn was in flight (gated by the
+                    // spawn reservation) would otherwise sleep until some
+                    // unrelated slot-release event, even though the instance
+                    // is ready with free slots. Woken waiters re-check
+                    // capacity themselves, so this can only ever wake too
+                    // many (they re-queue), never admit too many.
+                    let spare_slots = if max_concurrent == 0 {
+                        usize::MAX
+                    } else {
+                        max_concurrent.saturating_sub(inst.in_flight_requests)
+                    };
+                    // LOCK_ORDER: release the instance lock (4) before
+                    // notify_queue acquires `queues` (2).
+                    drop(inst);
+                    let mut woken = 0usize;
+                    while woken < spare_slots
+                        && ready_state.notify_queue(&ready_model, &ready_profile).await
+                    {
+                        woken += 1;
+                    }
                 }
             });
-
-            if reserve_slot {
-                let mut inst_write = inst_arc.write().await;
-                inst_write.in_flight_requests = 1;
-                inst_write.last_activity = std::time::Instant::now();
-            }
 
             info!(
                 event = "instance_spawn",

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -2120,7 +2120,15 @@ impl NodeState {
                         // hand-off is atomic for concurrent capacity checks.
                         spawn_reservation.handoff();
                         drop(instances_map);
-                        self.update_peak_memory(model_name, &profile.id).await;
+                        // INVARIANT: no awaits between the map insertion above
+                        // and this function's return. The spawning request's
+                        // in_flight slot was pre-claimed on the instance, and
+                        // the SlotReleaseGuard protecting it is only created
+                        // by the caller after we return (in the same poll);
+                        // an await here would open a cancellation window that
+                        // leaks the claimed slot on a mapped instance,
+                        // permanently blocking idle eviction. update_peak_memory
+                        // runs in the readiness task instead.
                         // Success - break out of retry loop with args
                         break (instance_id, port, inst_arc, is_cold_start, args);
                     }
@@ -2180,6 +2188,16 @@ impl NodeState {
             let ready_model = model_name.to_string();
             let ready_profile = profile.id.clone();
             tokio::spawn(async move {
+                // Refresh peak-memory accounting for this model's instances.
+                // Runs here (not inline after insertion) so the spawn path
+                // stays await-free between map insertion and returning the
+                // pre-claimed slot to the caller — see the INVARIANT comment
+                // at the insertion site. LOCK_ORDER: must run before the
+                // instance read guard below (instances is lock 1).
+                ready_state
+                    .update_peak_memory(&ready_model, &ready_profile)
+                    .await;
+
                 let inst = inst_clone.read().await;
                 if let Err(e) = inst
                     .wait_for_ready(startup_timeout, api_key, &http_client)

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -1978,9 +1978,23 @@ impl NodeState {
             // Reserve the slot before releasing the write lock so concurrent
             // contenders see this in-flight spawn in the checks above. The
             // guard releases on every error/cancellation path; on success it
-            // is released at map insertion, where the instance starts being
-            // counted via the map instead.
-            let mut spawn_reservation = self.spawn_reservations.reserve(profile_key);
+            // is handed off at map insertion, where the instance starts being
+            // counted via the map instead. On abandonment (spawn failure or
+            // request cancellation) capacity frees up without any instance
+            // reaching the map, so no later slot-release or termination event
+            // would ever wake requests that queued because of this
+            // reservation — wake them here. Drop is sync and the queue locks
+            // are async, so the work happens in a spawned task (same pattern
+            // as SlotReleaseGuard).
+            let abandon_state = self.clone();
+            let mut spawn_reservation = self.spawn_reservations.reserve(
+                profile_key,
+                Some(Box::new(move || {
+                    tokio::spawn(async move {
+                        abandon_state.notify_all_queues().await;
+                    });
+                })),
+            );
 
             // Release outer write lock before entering retry loop (will re-acquire as needed)
             drop(instances_map);
@@ -2095,7 +2109,7 @@ impl NodeState {
                         // The instance is now counted via the map; release the
                         // reservation while still holding the lock so the
                         // hand-off is atomic for concurrent capacity checks.
-                        spawn_reservation.release();
+                        spawn_reservation.handoff();
                         drop(instances_map);
                         self.update_peak_memory(model_name, &profile.id).await;
                         // Success - break out of retry loop with args
@@ -2153,6 +2167,9 @@ impl NodeState {
             let model_key = format!("{}:{}", model_name, profile.id);
             let args_hash_clone = args_hash.clone();
             let is_cold = is_cold_start;
+            let ready_state = self.clone();
+            let ready_model = model_name.to_string();
+            let ready_profile = profile.id.clone();
             tokio::spawn(async move {
                 let inst = inst_clone.read().await;
                 if let Err(e) = inst
@@ -2181,6 +2198,13 @@ impl NodeState {
 
                     // Trigger instant gossip so peers learn about new model availability
                     gossip_trigger.notify_one();
+
+                    // Wake one queued waiter for this model:profile. A request
+                    // that queued while this spawn was in flight (gated by
+                    // the spawn reservation) would otherwise sleep until some
+                    // unrelated slot-release event, even though the instance
+                    // is now ready and may have spare concurrency slots.
+                    ready_state.notify_queue(&ready_model, &ready_profile).await;
 
                     if is_cold {
                         // Cold start: sample memory after ready and store learned value
@@ -3721,7 +3745,9 @@ mod tests {
         // Simulate a concurrent request mid-spawn: its capacity checks have
         // passed and its reservation is held, but its instance has not
         // reached the instances map yet.
-        let guard = state.spawn_reservations.reserve("test:default".to_string());
+        let guard = state
+            .spawn_reservations
+            .reserve("test:default".to_string(), None);
 
         let err = state
             .try_get_or_spawn("test", &profile, false, "test", false)
@@ -3770,7 +3796,7 @@ mod tests {
         // slot. It is not in the map, so it cannot be evicted to make room.
         let _guard = state
             .spawn_reservations
-            .reserve("other-model:default".to_string());
+            .reserve("other-model:default".to_string(), None);
 
         let err = state
             .try_get_or_spawn("test", &profile, false, "test", false)

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -2242,9 +2242,37 @@ impl NodeState {
                     // Trigger instant gossip so peers learn about new model availability
                     gossip_trigger.notify_one();
 
+                    let spare_slots = if max_concurrent == 0 {
+                        usize::MAX
+                    } else {
+                        max_concurrent.saturating_sub(inst.in_flight_requests)
+                    };
+                    let instance_id = inst.id.clone();
+                    let pid = inst.get_pid();
+                    // LOCK_ORDER: release the instance lock (4) before
+                    // notify_queue acquires `queues` (2).
+                    drop(inst);
+
+                    // Wake queued waiters for this model:profile, up to the
+                    // ready instance's spare concurrency — and before the
+                    // cold-start sampling sleep below, so waiters near their
+                    // queue timeout are not held up by it. Requests that
+                    // queued while this spawn was in flight (gated by the
+                    // spawn reservation) would otherwise sleep until some
+                    // unrelated slot-release event, even though the instance
+                    // is ready with free slots. Woken waiters re-check
+                    // capacity themselves, so this can only ever wake too
+                    // many (they re-queue), never admit too many.
+                    let mut woken = 0usize;
+                    while woken < spare_slots
+                        && ready_state.notify_queue(&ready_model, &ready_profile).await
+                    {
+                        woken += 1;
+                    }
+
                     if is_cold {
                         // Cold start: sample memory after ready and store learned value
-                        if let Some(pid) = inst.get_pid() {
+                        if let Some(pid) = pid {
                             // Wait a moment for memory to stabilize after model load
                             tokio::time::sleep(std::time::Duration::from_secs(2)).await;
                             let (vram, sysmem) = memory_sampler.sample(pid);
@@ -2252,7 +2280,7 @@ impl NodeState {
                                 let hash_metrics = metrics.get_hash_metrics(&args_hash_clone).await;
                                 hash_metrics.observe_memory(vram, sysmem);
                                 info!(
-                                    instance_id = %inst.id,
+                                    instance_id = %instance_id,
                                     args_hash = %args_hash_clone,
                                     vram_mb = vram,
                                     sysmem_mb = sysmem,
@@ -2260,29 +2288,6 @@ impl NodeState {
                                 );
                             }
                         }
-                    }
-
-                    // Wake queued waiters for this model:profile, up to the
-                    // ready instance's spare concurrency. Requests that
-                    // queued while this spawn was in flight (gated by the
-                    // spawn reservation) would otherwise sleep until some
-                    // unrelated slot-release event, even though the instance
-                    // is ready with free slots. Woken waiters re-check
-                    // capacity themselves, so this can only ever wake too
-                    // many (they re-queue), never admit too many.
-                    let spare_slots = if max_concurrent == 0 {
-                        usize::MAX
-                    } else {
-                        max_concurrent.saturating_sub(inst.in_flight_requests)
-                    };
-                    // LOCK_ORDER: release the instance lock (4) before
-                    // notify_queue acquires `queues` (2).
-                    drop(inst);
-                    let mut woken = 0usize;
-                    while woken < spare_slots
-                        && ready_state.notify_queue(&ready_model, &ready_profile).await
-                    {
-                        woken += 1;
                     }
                 }
             });
@@ -3868,9 +3873,27 @@ mod tests {
         config.max_vram_mb = 1_000_000;
         config.max_sysmem_mb = 1_000_000;
         config.cluster.enabled = false;
-        // Any spawnable binary works: try_get_or_spawn only needs the exec to
-        // succeed; readiness is handled by a background task afterwards.
-        config.llama_cpp.binary_path = "/bin/true".into();
+        // The spawned process must stay alive past the assertions: a process
+        // that exits immediately fails the background readiness check, whose
+        // failure path runs an eviction pass that could remove the instance
+        // from the map before the assertions run. Use a script that ignores
+        // the llama-server args and sleeps.
+        let fake_server = std::env::temp_dir().join(format!(
+            "llamesh-fake-server-{}",
+            ulid::Ulid::new().to_string()
+        ));
+        tokio::fs::write(&fake_server, "#!/bin/sh\nsleep 300\n")
+            .await
+            .unwrap();
+        let mut perms = tokio::fs::metadata(&fake_server)
+            .await
+            .unwrap()
+            .permissions();
+        std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+        tokio::fs::set_permissions(&fake_server, perms)
+            .await
+            .unwrap();
+        config.llama_cpp.binary_path = fake_server.to_string_lossy().to_string();
         let build_manager = BuildManager::new(config.llama_cpp.clone());
         let state = Arc::new(
             NodeState::new(config, Cookbook { models: vec![] }, build_manager)
@@ -3893,9 +3916,10 @@ mod tests {
         );
         assert_eq!(state.spawn_reservations.profile_count("test:default"), 0);
 
-        // Cleanup: stop the child if it is still around.
+        // Cleanup: stop the child and remove the fake server script.
         let inst = inst.read().await;
         let _ = inst.stop().await;
+        let _ = tokio::fs::remove_file(&fake_server).await;
     }
 
     #[tokio::test]

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -1,10 +1,12 @@
 mod model_index;
 mod peer_state;
 mod port_pool;
+mod spawn_reservations;
 
 pub use model_index::{build_pre_args, get_args_hash_for_key, ModelIndex};
 pub use peer_state::{PeerModelStats, PeerState};
 pub use port_pool::PortPool;
+pub use spawn_reservations::SpawnReservations;
 
 use crate::build_manager::BuildManager;
 use crate::config::{Cookbook, ModelDefaults, NodeConfig, Profile};
@@ -123,6 +125,12 @@ pub struct NodeState {
     /// Notified when cluster capacity changes (instance idle, terminated, peer update).
     /// Used by route_or_wait() to efficiently wait for capacity.
     pub capacity_notify: Arc<Notify>,
+    /// In-flight spawn reservations: spawns that passed capacity checks but
+    /// whose instances are not yet in `instances`. Reserved while holding the
+    /// `instances` write lock (check-and-reserve is atomic); released via
+    /// RAII from any context. Interior mutex is a synchronous leaf lock,
+    /// never held across `await`.
+    pub spawn_reservations: Arc<SpawnReservations>,
     /// Model:profile keys that failed to spawn due to InsufficientResources
     /// and need eviction of existing instances to proceed. Used by the drain
     /// scheduler to decide when to drain an incumbent model.
@@ -465,6 +473,7 @@ impl NodeState {
             discovery,
             circuit_breaker,
             capacity_notify: Arc::new(Notify::new()),
+            spawn_reservations: Arc::new(SpawnReservations::default()),
             needs_eviction: Arc::new(RwLock::new(HashSet::new())),
             gossip_trigger: Arc::new(Notify::new()),
             peer_pending_forwards: Arc::new(RwLock::new(HashMap::new())),
@@ -1803,11 +1812,18 @@ impl NodeState {
                 // Lost the race or instance started draining — fall through to spawn/queue
             }
 
-            // 3. Check profile max instances
+            // 3. Check profile max instances. In-flight spawn reservations
+            // count toward capacity: a spawn that already passed these checks
+            // but hasn't reached the map yet must block a second contender
+            // here (it queues and is served by the winner's instance) instead
+            // of letting it spawn a duplicate that would be killed at
+            // insertion time.
+            let profile_key = format!("{}:{}", model_name, profile.id);
             let profile_count =
                 Self::count_profile_instances(&instances_map, model_name, &profile.id).await;
+            let reserved_profile = self.spawn_reservations.profile_count(&profile_key);
             let max_instances = profile.effective_max_instances(&self.config.model_defaults);
-            if profile_count >= max_instances {
+            if profile_count + reserved_profile >= max_instances {
                 return Err(NodeError::MaxInstancesProfile);
             }
 
@@ -1823,7 +1839,10 @@ impl NodeState {
                 .pick_victims(&instances_map, required_vram, required_sysmem)
                 .await?;
 
-            let current_instances = instances_map.len();
+            // In-flight spawn reservations occupy node capacity too. They are
+            // not in the map, so they can never be picked as eviction victims
+            // — the eviction math below only frees map entries.
+            let current_instances = instances_map.len() + self.spawn_reservations.node_total();
             let max_node_instances = self.config.max_instances_per_node;
 
             if current_instances + 1 > max_node_instances {
@@ -1955,6 +1974,14 @@ impl NodeState {
                 }
             }
 
+            // All capacity checks passed and we are committed to spawning.
+            // Reserve the slot before releasing the write lock so concurrent
+            // contenders see this in-flight spawn in the checks above. The
+            // guard releases on every error/cancellation path; on success it
+            // is released at map insertion, where the instance starts being
+            // counted via the map instead.
+            let mut spawn_reservation = self.spawn_reservations.reserve(profile_key);
+
             // Release outer write lock before entering retry loop (will re-acquire as needed)
             drop(instances_map);
 
@@ -2019,6 +2046,10 @@ impl NodeState {
 
                         // Re-check capacity constraints to close the race window between
                         // dropping the lock to spawn and re-acquiring it for insertion.
+                        // These re-checks intentionally count the MAP ONLY (not spawn
+                        // reservations — our own is still held and would self-block).
+                        // With reservations gating admission they should never fire;
+                        // they remain as defense in depth.
                         let current_profile_count =
                             Self::count_profile_instances(&instances_map, model_name, &profile.id)
                                 .await;
@@ -2061,6 +2092,10 @@ impl NodeState {
                         }
 
                         instances_map.insert(instance_id.clone(), inst_arc.clone());
+                        // The instance is now counted via the map; release the
+                        // reservation while still holding the lock so the
+                        // hand-off is atomic for concurrent capacity checks.
+                        spawn_reservation.release();
                         drop(instances_map);
                         self.update_peak_memory(model_name, &profile.id).await;
                         // Success - break out of retry loop with args
@@ -3668,6 +3703,120 @@ mod tests {
         drop(pending);
 
         permit.release().await;
+    }
+
+    #[tokio::test]
+    async fn spawn_reservation_blocks_profile_admission_before_spawn() {
+        let mut config = minimal_node_config();
+        config.cluster.enabled = false;
+        config.llama_cpp.binary_path = "/nonexistent/llamesh-test/llama-server".into();
+        let build_manager = BuildManager::new(config.llama_cpp.clone());
+        let state = Arc::new(
+            NodeState::new(config, Cookbook { models: vec![] }, build_manager)
+                .await
+                .unwrap(),
+        );
+        let profile = sample_profile(); // max_instances = 1
+
+        // Simulate a concurrent request mid-spawn: its capacity checks have
+        // passed and its reservation is held, but its instance has not
+        // reached the instances map yet.
+        let guard = state.spawn_reservations.reserve("test:default".to_string());
+
+        let err = state
+            .try_get_or_spawn("test", &profile, false, "test", false)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, NodeError::MaxInstancesProfile),
+            "in-flight reservation must gate profile admission, got: {err:?}"
+        );
+        assert!(
+            state.instances.read().await.is_empty(),
+            "the losing contender must not have spawned anything"
+        );
+
+        // Once the in-flight spawn resolves (here: released), admission
+        // proceeds past the capacity gate again — and fails much later at
+        // the actual process spawn, since the binary path does not exist.
+        drop(guard);
+        let err = state
+            .try_get_or_spawn("test", &profile, false, "test", false)
+            .await
+            .unwrap_err();
+        assert!(
+            !matches!(err, NodeError::MaxInstancesProfile),
+            "a released reservation must not gate admission, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_reservation_counts_toward_node_capacity() {
+        let mut config = minimal_node_config();
+        config.max_vram_mb = 1_000_000;
+        config.max_sysmem_mb = 1_000_000;
+        config.cluster.enabled = false;
+        config.max_instances_per_node = 1;
+        config.llama_cpp.binary_path = "/nonexistent/llamesh-test/llama-server".into();
+        let build_manager = BuildManager::new(config.llama_cpp.clone());
+        let state = Arc::new(
+            NodeState::new(config, Cookbook { models: vec![] }, build_manager)
+                .await
+                .unwrap(),
+        );
+        let profile = sample_profile();
+
+        // A different profile's in-flight spawn occupies the node's only
+        // slot. It is not in the map, so it cannot be evicted to make room.
+        let _guard = state
+            .spawn_reservations
+            .reserve("other-model:default".to_string());
+
+        let err = state
+            .try_get_or_spawn("test", &profile, false, "test", false)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, NodeError::MaxInstancesNode),
+            "in-flight reservation must count toward node capacity, got: {err:?}"
+        );
+        assert!(state.instances.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn spawn_reservation_released_at_insertion_on_successful_spawn() {
+        let mut config = minimal_node_config();
+        config.max_vram_mb = 1_000_000;
+        config.max_sysmem_mb = 1_000_000;
+        config.cluster.enabled = false;
+        // Any spawnable binary works: try_get_or_spawn only needs the exec to
+        // succeed; readiness is handled by a background task afterwards.
+        config.llama_cpp.binary_path = "/bin/true".into();
+        let build_manager = BuildManager::new(config.llama_cpp.clone());
+        let state = Arc::new(
+            NodeState::new(config, Cookbook { models: vec![] }, build_manager)
+                .await
+                .unwrap(),
+        );
+        let profile = sample_profile();
+
+        let inst = state
+            .try_get_or_spawn("test", &profile, false, "test", false)
+            .await
+            .expect("spawn should succeed with a spawnable binary");
+
+        // The instance is in the map and the reservation has been handed off.
+        assert_eq!(state.instances.read().await.len(), 1);
+        assert_eq!(
+            state.spawn_reservations.node_total(),
+            0,
+            "reservation must be released when the instance is inserted"
+        );
+        assert_eq!(state.spawn_reservations.profile_count("test:default"), 0);
+
+        // Cleanup: stop the child if it is still around.
+        let inst = inst.read().await;
+        let _ = inst.stop().await;
     }
 
     #[tokio::test]

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -1631,6 +1631,40 @@ impl NodeState {
                             self.needs_eviction.write().await.insert(key.clone());
                         }
 
+                        // Close the lost-wake window for reservation-gated
+                        // blocks: an in-flight spawn whose reservation tipped
+                        // the capacity check above may have been abandoned
+                        // before this request became visible in the queue, in
+                        // which case its abandon notification found nobody to
+                        // wake. Now that we are enqueued, re-check the gate
+                        // and wake the queue's front waiter if it cleared.
+                        if matches!(
+                            e,
+                            NodeError::MaxInstancesProfile | NodeError::MaxInstancesNode
+                        ) {
+                            let gate_cleared = {
+                                let instances_map = self.instances.read().await;
+                                let profile_count = Self::count_profile_instances(
+                                    &instances_map,
+                                    model_name,
+                                    &profile.id,
+                                )
+                                .await;
+                                let max_instances =
+                                    profile.effective_max_instances(&self.config.model_defaults);
+                                let profile_ok = profile_count
+                                    + self.spawn_reservations.profile_count(&key)
+                                    < max_instances;
+                                let node_ok = instances_map.len()
+                                    + self.spawn_reservations.node_total()
+                                    < self.config.max_instances_per_node;
+                                profile_ok && node_ok
+                            };
+                            if gate_cleared {
+                                self.notify_queue(model_name, &profile.id).await;
+                            }
+                        }
+
                         // Wait for queue notification with optional timeout
                         let wait_result = match queue_timeout {
                             Some(timeout) => {
@@ -1991,6 +2025,10 @@ impl NodeState {
                 profile_key,
                 Some(Box::new(move || {
                     tokio::spawn(async move {
+                        // Drains scheduled because this reservation occupied
+                        // node capacity may no longer be needed; re-evaluate
+                        // before waking waiters.
+                        abandon_state.maybe_cancel_drains().await;
                         abandon_state.notify_all_queues().await;
                     });
                 })),

--- a/src/node_state/spawn_reservations.rs
+++ b/src/node_state/spawn_reservations.rs
@@ -45,12 +45,24 @@ impl SpawnReservations {
     /// Call only while holding the `instances` write lock, so that the
     /// capacity check and the reservation form one atomic step with respect
     /// to other spawners.
-    pub fn reserve(self: &Arc<Self>, key: String) -> SpawnReservation {
+    ///
+    /// `on_abandon` runs when the guard is dropped without a prior
+    /// [`SpawnReservation::handoff`] — i.e. the spawn failed or the request
+    /// was cancelled. Concurrent requests may have queued *because of* this
+    /// reservation, and no instance will ever be inserted to wake them, so
+    /// the callback must wake queued waiters (it runs from a synchronous
+    /// `Drop`; spawn a task for async work).
+    pub fn reserve(
+        self: &Arc<Self>,
+        key: String,
+        on_abandon: Option<Box<dyn FnOnce() + Send>>,
+    ) -> SpawnReservation {
         *self.by_profile.lock().entry(key.clone()).or_insert(0) += 1;
         SpawnReservation {
             reservations: self.clone(),
             key,
             released: false,
+            on_abandon,
         }
     }
 
@@ -68,31 +80,47 @@ impl SpawnReservations {
 
 /// RAII guard for one reserved spawn.
 ///
-/// Dropping the guard releases the reservation, which covers every error
-/// path and future cancellation. When the spawned instance has been inserted
-/// into the instances map, call [`SpawnReservation::release`] at the
-/// insertion site (while still holding the `instances` write lock): from that
-/// moment the instance is counted via the map, and keeping the reservation
-/// would double-count it.
+/// When the spawned instance has been inserted into the instances map, call
+/// [`SpawnReservation::handoff`] at the insertion site (while still holding
+/// the `instances` write lock): from that moment the instance is counted via
+/// the map, and keeping the reservation would double-count it.
+///
+/// Dropping the guard without a prior hand-off releases the reservation and
+/// runs the `on_abandon` callback — this covers every error path and future
+/// cancellation, where capacity frees up without an instance ever reaching
+/// the map.
 pub struct SpawnReservation {
     reservations: Arc<SpawnReservations>,
     key: String,
     released: bool,
+    on_abandon: Option<Box<dyn FnOnce() + Send>>,
 }
 
 impl SpawnReservation {
-    /// Releases the reservation. Idempotent; `Drop` becomes a no-op after.
-    pub fn release(&mut self) {
-        if !self.released {
-            self.released = true;
-            self.reservations.release_one(&self.key);
+    /// Releases the reservation without running `on_abandon`: the spawned
+    /// instance is now in the instances map and provides the capacity this
+    /// reservation was holding. Idempotent; `Drop` becomes a no-op after.
+    pub fn handoff(&mut self) {
+        self.finish(false);
+    }
+
+    fn finish(&mut self, abandoned: bool) {
+        if self.released {
+            return;
+        }
+        self.released = true;
+        self.reservations.release_one(&self.key);
+        if abandoned {
+            if let Some(callback) = self.on_abandon.take() {
+                callback();
+            }
         }
     }
 }
 
 impl Drop for SpawnReservation {
     fn drop(&mut self) {
-        self.release();
+        self.finish(true);
     }
 }
 
@@ -106,7 +134,7 @@ mod tests {
         assert_eq!(reservations.profile_count("m:p"), 0);
         assert_eq!(reservations.node_total(), 0);
 
-        let guard = reservations.reserve("m:p".to_string());
+        let guard = reservations.reserve("m:p".to_string(), None);
         assert_eq!(reservations.profile_count("m:p"), 1);
         assert_eq!(reservations.node_total(), 1);
 
@@ -116,12 +144,12 @@ mod tests {
     }
 
     #[test]
-    fn explicit_release_makes_drop_a_no_op() {
+    fn explicit_handoff_makes_drop_a_no_op() {
         let reservations = Arc::new(SpawnReservations::default());
-        let mut guard = reservations.reserve("m:p".to_string());
-        guard.release();
+        let mut guard = reservations.reserve("m:p".to_string(), None);
+        guard.handoff();
         assert_eq!(reservations.profile_count("m:p"), 0);
-        guard.release();
+        guard.handoff();
         assert_eq!(reservations.profile_count("m:p"), 0);
         drop(guard);
         assert_eq!(reservations.profile_count("m:p"), 0);
@@ -129,11 +157,44 @@ mod tests {
     }
 
     #[test]
+    fn on_abandon_runs_on_drop_but_not_on_handoff() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let reservations = Arc::new(SpawnReservations::default());
+        let abandoned = Arc::new(AtomicUsize::new(0));
+
+        // Dropped without hand-off → callback runs exactly once.
+        let counter = abandoned.clone();
+        let guard = reservations.reserve(
+            "m:p".to_string(),
+            Some(Box::new(move || {
+                counter.fetch_add(1, Ordering::SeqCst);
+            })),
+        );
+        drop(guard);
+        assert_eq!(abandoned.load(Ordering::SeqCst), 1);
+        assert_eq!(reservations.profile_count("m:p"), 0);
+
+        // Handed off → callback must NOT run, neither at handoff nor at drop.
+        let counter = abandoned.clone();
+        let mut guard = reservations.reserve(
+            "m:p".to_string(),
+            Some(Box::new(move || {
+                counter.fetch_add(1, Ordering::SeqCst);
+            })),
+        );
+        guard.handoff();
+        drop(guard);
+        assert_eq!(abandoned.load(Ordering::SeqCst), 1);
+        assert_eq!(reservations.profile_count("m:p"), 0);
+    }
+
+    #[test]
     fn counts_are_per_key_and_stack() {
         let reservations = Arc::new(SpawnReservations::default());
-        let g1 = reservations.reserve("m:a".to_string());
-        let g2 = reservations.reserve("m:a".to_string());
-        let g3 = reservations.reserve("m:b".to_string());
+        let g1 = reservations.reserve("m:a".to_string(), None);
+        let g2 = reservations.reserve("m:a".to_string(), None);
+        let g3 = reservations.reserve("m:b".to_string(), None);
 
         assert_eq!(reservations.profile_count("m:a"), 2);
         assert_eq!(reservations.profile_count("m:b"), 1);

--- a/src/node_state/spawn_reservations.rs
+++ b/src/node_state/spawn_reservations.rs
@@ -1,0 +1,152 @@
+//! In-flight spawn reservation tracking.
+//!
+//! `try_get_or_spawn` releases the `instances` write lock before spawning a
+//! `llama-server` process (spawning is slow and must not block the node), and
+//! only inserts the instance into the map afterwards. Without reservations,
+//! two concurrent requests for the same profile could both pass the capacity
+//! checks inside that window, both spawn, and the loser would have to kill
+//! its just-spawned process at insertion time — a wasted process exec and
+//! partial model load.
+//!
+//! A reservation records "a spawn is in flight" so capacity checks can count
+//! it before the instance reaches the map. Reservations are created while the
+//! caller holds the `instances` write lock, which makes check-and-reserve
+//! atomic: the second contender observes the first's reservation and queues
+//! instead of spawning.
+//!
+//! The interior mutex is a synchronous leaf lock, held only for the map
+//! operation itself and never across `await`. Releases happen from `Drop`,
+//! so failure paths and future cancellation cannot leak a reservation.
+
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Counts of spawns that have passed capacity checks but whose instances are
+/// not yet in the instances map, keyed by `model:profile`.
+#[derive(Default)]
+pub struct SpawnReservations {
+    by_profile: Mutex<HashMap<String, usize>>,
+}
+
+impl SpawnReservations {
+    /// Number of in-flight spawns for a `model:profile` key.
+    pub fn profile_count(&self, key: &str) -> usize {
+        self.by_profile.lock().get(key).copied().unwrap_or(0)
+    }
+
+    /// Total in-flight spawns on this node.
+    pub fn node_total(&self) -> usize {
+        self.by_profile.lock().values().sum()
+    }
+
+    /// Records an in-flight spawn and returns its guard.
+    ///
+    /// Call only while holding the `instances` write lock, so that the
+    /// capacity check and the reservation form one atomic step with respect
+    /// to other spawners.
+    pub fn reserve(self: &Arc<Self>, key: String) -> SpawnReservation {
+        *self.by_profile.lock().entry(key.clone()).or_insert(0) += 1;
+        SpawnReservation {
+            reservations: self.clone(),
+            key,
+            released: false,
+        }
+    }
+
+    fn release_one(&self, key: &str) {
+        let mut by_profile = self.by_profile.lock();
+        match by_profile.get_mut(key) {
+            Some(n) if *n > 1 => *n -= 1,
+            Some(_) => {
+                by_profile.remove(key);
+            }
+            None => debug_assert!(false, "released a reservation that was never taken: {key}"),
+        }
+    }
+}
+
+/// RAII guard for one reserved spawn.
+///
+/// Dropping the guard releases the reservation, which covers every error
+/// path and future cancellation. When the spawned instance has been inserted
+/// into the instances map, call [`SpawnReservation::release`] at the
+/// insertion site (while still holding the `instances` write lock): from that
+/// moment the instance is counted via the map, and keeping the reservation
+/// would double-count it.
+pub struct SpawnReservation {
+    reservations: Arc<SpawnReservations>,
+    key: String,
+    released: bool,
+}
+
+impl SpawnReservation {
+    /// Releases the reservation. Idempotent; `Drop` becomes a no-op after.
+    pub fn release(&mut self) {
+        if !self.released {
+            self.released = true;
+            self.reservations.release_one(&self.key);
+        }
+    }
+}
+
+impl Drop for SpawnReservation {
+    fn drop(&mut self) {
+        self.release();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reserve_and_drop_round_trips() {
+        let reservations = Arc::new(SpawnReservations::default());
+        assert_eq!(reservations.profile_count("m:p"), 0);
+        assert_eq!(reservations.node_total(), 0);
+
+        let guard = reservations.reserve("m:p".to_string());
+        assert_eq!(reservations.profile_count("m:p"), 1);
+        assert_eq!(reservations.node_total(), 1);
+
+        drop(guard);
+        assert_eq!(reservations.profile_count("m:p"), 0);
+        assert_eq!(reservations.node_total(), 0);
+    }
+
+    #[test]
+    fn explicit_release_makes_drop_a_no_op() {
+        let reservations = Arc::new(SpawnReservations::default());
+        let mut guard = reservations.reserve("m:p".to_string());
+        guard.release();
+        assert_eq!(reservations.profile_count("m:p"), 0);
+        guard.release();
+        assert_eq!(reservations.profile_count("m:p"), 0);
+        drop(guard);
+        assert_eq!(reservations.profile_count("m:p"), 0);
+        assert_eq!(reservations.node_total(), 0);
+    }
+
+    #[test]
+    fn counts_are_per_key_and_stack() {
+        let reservations = Arc::new(SpawnReservations::default());
+        let g1 = reservations.reserve("m:a".to_string());
+        let g2 = reservations.reserve("m:a".to_string());
+        let g3 = reservations.reserve("m:b".to_string());
+
+        assert_eq!(reservations.profile_count("m:a"), 2);
+        assert_eq!(reservations.profile_count("m:b"), 1);
+        assert_eq!(reservations.node_total(), 3);
+
+        drop(g1);
+        assert_eq!(reservations.profile_count("m:a"), 1);
+        assert_eq!(reservations.node_total(), 2);
+
+        drop(g2);
+        drop(g3);
+        assert_eq!(reservations.profile_count("m:a"), 0);
+        assert_eq!(reservations.profile_count("m:b"), 0);
+        assert_eq!(reservations.node_total(), 0);
+    }
+}


### PR DESCRIPTION
Fixes #71

## Problem

`try_get_or_spawn` releases the instances write lock before spawning a `llama-server` process (spawning is slow and must not block the node), and re-enforces the capacity checks only at insertion time. Two concurrent requests for the same profile could both pass the per-profile and node-wide checks inside that window, both spawn, and the loser killed its just-spawned process at insertion (`spawn_profile_race_detected`) — a wasted process exec and partial model load. Production logs show this firing a couple of times per day for a `max_instances: 1` profile with bursty concurrent traffic.

## Fix

A new `SpawnReservations` store tracks in-flight spawns: spawns that passed capacity checks but whose instances have not reached the instances map yet. The reservation is taken while still holding the instances write lock, which makes check-and-reserve atomic with respect to other spawners — the second contender observes the first's reservation in the capacity checks, queues immediately (before spawning), and is served by the winner's instance exactly as it was before this change.

Lifecycle guarantees, audited against every exit path of `try_get_or_spawn`:

- The reservation is created only after **all** admission checks pass, immediately before the lock is released to spawn — every earlier `return`/`continue` (profile cap, victim eviction restart, argument validation, memory guardrails) happens before the guard exists.
- It is an RAII guard: every later failure path (port allocation, spawn failure after retries, the defensive race checks) and **future cancellation** release it via `Drop`. A leaked reservation would permanently block a `max_instances: 1` profile, so nothing relies on manual cleanup.
- On success it is explicitly released at map insertion, while still holding the instances lock, so the hand-off from "reserved" to "counted via the map" is atomic for concurrent observers.
- The interior mutex is a synchronous leaf lock (`parking_lot`), held only for the map operation and never across an `await`, per the module's documented lock-ordering rules.

Node-wide capacity counts reservations too, and the eviction math correctly treats them as unevictable (they are not in the map). The post-spawn race detection remains as defense in depth but is no longer expected to fire.

## Changes

- `src/node_state/spawn_reservations.rs`: new module — `SpawnReservations` store and `SpawnReservation` RAII guard, with unit tests.
- `src/node_state/mod.rs`: capacity checks count reservations; reservation taken before lock release and handed off at insertion; defensive re-checks kept map-only (a contender must not block on its own reservation).
- `SPEC.md`: spawn admission flow updated.
- Version 1.10.7, CHANGELOG updated.

## Testing

- 358 unit tests pass (6 new: 3 for the reservation primitive, 3 integration-style through `try_get_or_spawn` proving a held reservation gates profile admission *before* any spawn with an empty instances map, counts toward node capacity as unevictable, and is released exactly at insertion on a successful spawn).
- 8 integration tests pass; fmt/clippy clean on changed code.