### PR TITLE
refactor: pass PeerRequest to attempt_peer_forward; clear fmt drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.8] - 2026-06-12
+
+### Changed
+
+- Cleared the codebase's standing static-analysis debt; `cargo fmt --check`
+  and `cargo clippy` now pass with no findings. `attempt_peer_forward` takes
+  the `PeerRequest` it previously assembled internally instead of nine loose
+  parameters (the repository's only clippy warning), and a stale formatting
+  drift in the connection module was reformatted. No behavior change. (#73)
+
 ## [1.10.7] - 2026-06-12
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.10.7"
+version = "1.10.8"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.10.7"
+version = "1.10.8"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -139,7 +139,10 @@ mod tests {
         )
         .await;
 
-        assert!(result.is_ok(), "poll_client_disconnect should have resolved");
+        assert!(
+            result.is_ok(),
+            "poll_client_disconnect should have resolved"
+        );
     }
 
     #[test]

--- a/src/router.rs
+++ b/src/router.rs
@@ -194,29 +194,11 @@ enum ForwardOutcome {
 /// pass-through to the client.
 async fn attempt_peer_forward(
     state: &NodeState,
-    peer_id: &str,
-    peer_address: &str,
-    method: &Method,
-    path_and_query: &str,
-    headers: HeaderMap,
-    body: Bytes,
-    timeout_ms: u64,
+    request: PeerRequest<'_>,
     response_streaming: bool,
 ) -> ForwardOutcome {
-    let resp = match send_peer_request(
-        state,
-        PeerRequest {
-            peer_id,
-            peer_address,
-            method: method.clone(),
-            path_and_query,
-            headers,
-            body,
-            timeout_ms,
-        },
-    )
-    .await
-    {
+    let peer_id = request.peer_id;
+    let resp = match send_peer_request(state, request).await {
         Ok(resp) => resp,
         Err(e) => return ForwardOutcome::Transport(e),
     };
@@ -674,13 +656,15 @@ pub async fn route_request(
 
                 let outcome = attempt_peer_forward(
                     &state,
-                    &peer.node_id,
-                    &peer.address,
-                    &parts.method,
-                    &path_and_query,
-                    forward_headers.clone(),
-                    forward_body.clone(),
-                    timeout_ms,
+                    PeerRequest {
+                        peer_id: &peer.node_id,
+                        peer_address: &peer.address,
+                        method: parts.method.clone(),
+                        path_and_query: &path_and_query,
+                        headers: forward_headers.clone(),
+                        body: forward_body.clone(),
+                        timeout_ms,
+                    },
                     response_streaming,
                 )
                 .await;
@@ -1212,13 +1196,15 @@ pub async fn route_request(
 
                 let outcome = attempt_peer_forward(
                     &state,
-                    &current_node.node_id,
-                    &current_node.address,
-                    &parts.method,
-                    &path_and_query,
-                    forward_headers.clone(),
-                    forward_body.clone(),
-                    timeout_ms,
+                    PeerRequest {
+                        peer_id: &current_node.node_id,
+                        peer_address: &current_node.address,
+                        method: parts.method.clone(),
+                        path_and_query: &path_and_query,
+                        headers: forward_headers.clone(),
+                        body: forward_body.clone(),
+                        timeout_ms,
+                    },
                     response_streaming,
                 )
                 .await;


### PR DESCRIPTION
Fixes #73

## Summary

Clears the codebase's two standing static-analysis findings so `cargo fmt --check` and `cargo clippy` pass with zero output, making them usable as clean gates.

- `attempt_peer_forward` took nine parameters and immediately packed seven of them into a `PeerRequest` for `send_peer_request`; it now accepts the `PeerRequest` directly plus `state` and `response_streaming`. Both call sites construct the struct themselves (the `Method` clone moves from callee to caller — same number of clones overall). The function body keeps a `peer_id` copy of the reference before the struct moves into `send_peer_request`, since it is needed afterwards for status recording and error messages.
- `connection.rs` had a long-standing formatting drift on a multi-line assert; reformatted by rustfmt.

No behavior change. Version 1.10.8, CHANGELOG under `Changed`.

## Testing

- 359 unit tests + 8 integration tests pass.
- `cargo fmt --check`: zero findings. `cargo clippy --bin llamesh`: zero warnings.