### PR TITLE
fix: wait for unambiguous bytes before classifying connection protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.9] - 2026-06-12
+
+### Fixed
+
+- Protocol detection no longer misclassifies connections whose first TCP
+  segment carries fewer bytes than the protocol signature needs. Detection
+  peeked the socket once and classified whatever had arrived: a fragmented
+  TLS ClientHello delivering only its first byte (`0x16`) was classified as
+  a Noise handshake, and a lone `P` was classified as HTTP/1.x even when it
+  began an HTTP/2 connection preface (`PRI `). Detection now waits for more
+  bytes whenever the peeked prefix is a proper prefix of more than one
+  signature, still bounded by the existing `protocol_detect_timeout_ms`
+  (clients that stall mid-prefix are closed at the timeout, as before).
+  Unambiguous prefixes are still classified immediately from the first
+  byte. (#75)
+
+### Documentation
+
+- README endpoint table: added `GET /version` and the `/health`,
+  `/v1/reranking`, and `/rerank` aliases.
+
 ## [1.10.8] - 2026-06-12
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.10.8"
+version = "1.10.9"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.10.8"
+version = "1.10.9"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -175,10 +175,11 @@ Use `__` (double underscore) for nested fields: `LLAMESH_CLUSTER__ENABLED=true`.
 | `POST /v1/chat/completions` | Chat completions (streaming supported) |
 | `POST /v1/completions` | Text completions (streaming supported) |
 | `POST /v1/embeddings` | Embeddings (requires `--embedding` profile) |
-| `POST /v1/rerank` | Reranking (requires `--reranking` profile) |
+| `POST /v1/rerank` | Reranking (requires `--reranking` profile; aliases: `/v1/reranking`, `/rerank`) |
 | `GET /v1/models` | List available models |
-| `GET /healthz` | Health check |
+| `GET /healthz` | Health check (alias: `/health`) |
 | `GET /readyz` | Readiness check |
+| `GET /version` | Proxy version |
 | `GET /metrics` | Prometheus metrics |
 | `GET /metrics/json` | JSON metrics snapshot |
 | `GET /cluster/nodes` | Cluster state |

--- a/src/protocol_detect.rs
+++ b/src/protocol_detect.rs
@@ -25,46 +25,74 @@ pub enum DetectedProtocol {
 /// Peek first bytes of stream to detect protocol without consuming them.
 ///
 /// Uses `TcpStream::peek()` which doesn't advance the read position.
+///
+/// A single peek sees only the bytes that have *arrived*, and the first TCP
+/// segment can legitimately carry fewer bytes than a signature needs — a
+/// fragmented TLS ClientHello delivering just `0x16` must not be classified
+/// as Noise, and a lone `P` cannot distinguish HTTP/1.x (`POST`) from the
+/// HTTP/2 preface (`PRI `). When the peeked prefix is still ambiguous, this
+/// waits for more bytes. The caller bounds the total wait with
+/// `protocol_detect_timeout_ms`, which also covers clients that send an
+/// ambiguous prefix and then stall.
 pub async fn detect(stream: &TcpStream) -> io::Result<DetectedProtocol> {
     let mut buf = [0u8; 4];
 
-    // Peek up to 4 bytes - enough to detect all protocols
-    let n = stream.peek(&mut buf).await?;
+    loop {
+        let n = stream.peek(&mut buf).await?;
 
-    if n == 0 {
-        // Empty peek - treat as noise (connection will fail anyway)
-        return Ok(DetectedProtocol::Noise);
-    }
-
-    // Check for TLS ClientHello: 0x16 (handshake) followed by version (0x03 0x0X)
-    if n >= 2 && buf[0] == 0x16 && buf[1] == 0x03 {
-        return Ok(DetectedProtocol::Tls);
-    }
-
-    // Check for HTTP/2 connection preface: "PRI " (0x50 0x52 0x49 0x20)
-    if n >= 4 && &buf[..4] == b"PRI " {
-        return Ok(DetectedProtocol::Http2);
-    }
-
-    // Check for HTTP/1.x methods by first byte
-    // GET, POST, PUT, DELETE, HEAD, OPTIONS, CONNECT, TRACE, PATCH
-    if n >= 1 {
-        match buf[0] {
-            b'G' | // GET
-            b'P' | // POST, PUT, PATCH
-            b'D' | // DELETE
-            b'H' | // HEAD
-            b'O' | // OPTIONS
-            b'C' | // CONNECT
-            b'T'   // TRACE
-                => return Ok(DetectedProtocol::Http),
-            _ => {}
+        if n == 0 {
+            // EOF before any data - treat as noise (connection will fail anyway)
+            return Ok(DetectedProtocol::Noise);
         }
-    }
 
-    // Default: assume Noise Protocol handshake
-    // Noise XX initiator sends 32-byte ephemeral public key (raw bytes)
-    Ok(DetectedProtocol::Noise)
+        if let Some(protocol) = classify(&buf[..n]) {
+            return Ok(protocol);
+        }
+
+        // Ambiguous prefix: more bytes are needed. peek() does not consume,
+        // so awaiting readiness again would return immediately with the same
+        // bytes; poll with a short sleep instead.
+        tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+    }
+}
+
+/// Classify a peeked prefix, or return `None` when the bytes seen so far are
+/// a proper prefix of more than one protocol signature and a decision needs
+/// more data.
+fn classify(buf: &[u8]) -> Option<DetectedProtocol> {
+    match buf[0] {
+        // TLS ClientHello: 0x16 (handshake) followed by version (0x03 0x0X)
+        0x16 => match buf.get(1) {
+            Some(0x03) => Some(DetectedProtocol::Tls),
+            Some(_) => Some(DetectedProtocol::Noise),
+            None => None,
+        },
+        // 'P' starts both HTTP/1.x methods (POST, PUT, PATCH) and the HTTP/2
+        // connection preface "PRI " (0x50 0x52 0x49 0x20). No HTTP/1.x method
+        // starts with "PR", so the second byte picks the branch; the full
+        // four bytes confirm the preface.
+        b'P' => match buf.get(1) {
+            Some(b'R') => {
+                if buf.len() >= 4 {
+                    if &buf[..4] == b"PRI " {
+                        Some(DetectedProtocol::Http2)
+                    } else {
+                        Some(DetectedProtocol::Http)
+                    }
+                } else {
+                    None
+                }
+            }
+            Some(_) => Some(DetectedProtocol::Http),
+            None => None,
+        },
+        // Remaining HTTP/1.x method initials are unambiguous on their own:
+        // GET, DELETE, HEAD, OPTIONS, CONNECT, TRACE
+        b'G' | b'D' | b'H' | b'O' | b'C' | b'T' => Some(DetectedProtocol::Http),
+        // Anything else: assume Noise Protocol handshake
+        // Noise XX initiator sends 32-byte ephemeral public key (raw bytes)
+        _ => Some(DetectedProtocol::Noise),
+    }
 }
 
 #[cfg(test)]
@@ -177,5 +205,78 @@ mod tests {
     async fn test_detect_http_patch() {
         let result = detect_bytes(b"PATCH /resource HTTP/1.1\r\n").await;
         assert_eq!(result, DetectedProtocol::Http);
+    }
+
+    /// Like `detect_bytes`, but delivers the payload in two fragments with a
+    /// delay in between, so detection initially peeks an incomplete prefix.
+    async fn detect_fragmented(first: &[u8], rest: &[u8]) -> DetectedProtocol {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let first_owned = first.to_vec();
+        let rest_owned = rest.to_vec();
+        let client = tokio::spawn(async move {
+            let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+            stream.set_nodelay(true).unwrap();
+            stream.write_all(&first_owned).await.unwrap();
+            stream.flush().await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            stream.write_all(&rest_owned).await.unwrap();
+            stream.flush().await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        });
+
+        let (stream, _) = listener.accept().await.unwrap();
+        let result = detect(&stream).await.unwrap();
+
+        client.abort();
+        result
+    }
+
+    #[tokio::test]
+    async fn test_detect_tls_fragmented_first_byte() {
+        // A TLS ClientHello whose first segment carries only the handshake
+        // byte must wait for the version byte, not fall through to Noise.
+        let result = detect_fragmented(&[0x16], &[0x03, 0x01, 0x00]).await;
+        assert_eq!(result, DetectedProtocol::Tls);
+    }
+
+    #[tokio::test]
+    async fn test_detect_http2_fragmented_p() {
+        // A lone 'P' is ambiguous between HTTP/1.x and the HTTP/2 preface.
+        let result = detect_fragmented(b"P", b"RI * HTTP/2.0\r\n\r\nSM\r\n\r\n").await;
+        assert_eq!(result, DetectedProtocol::Http2);
+    }
+
+    #[tokio::test]
+    async fn test_detect_http_post_fragmented_p() {
+        let result = detect_fragmented(b"P", b"OST /api HTTP/1.1\r\n").await;
+        assert_eq!(result, DetectedProtocol::Http);
+    }
+
+    #[tokio::test]
+    async fn test_detect_noise_tls_lookalike() {
+        // 0x16 followed by a non-TLS version byte is not a ClientHello.
+        let result = detect_bytes(&[0x16, 0x42, 0x00, 0x00]).await;
+        assert_eq!(result, DetectedProtocol::Noise);
+    }
+
+    #[test]
+    fn classify_waits_on_ambiguous_prefixes() {
+        assert_eq!(classify(&[0x16]), None);
+        assert_eq!(classify(b"P"), None);
+        assert_eq!(classify(b"PR"), None);
+        assert_eq!(classify(b"PRI"), None);
+    }
+
+    #[test]
+    fn classify_decides_unambiguous_prefixes_immediately() {
+        assert_eq!(classify(&[0x16, 0x03]), Some(DetectedProtocol::Tls));
+        assert_eq!(classify(&[0x16, 0x42]), Some(DetectedProtocol::Noise));
+        assert_eq!(classify(b"PO"), Some(DetectedProtocol::Http));
+        assert_eq!(classify(b"PRI "), Some(DetectedProtocol::Http2));
+        assert_eq!(classify(b"PRIx"), Some(DetectedProtocol::Http));
+        assert_eq!(classify(b"G"), Some(DetectedProtocol::Http));
+        assert_eq!(classify(&[0x00]), Some(DetectedProtocol::Noise));
     }
 }


### PR DESCRIPTION
Fixes #75

## Problem

`protocol_detect::detect` peeked the socket once and classified whatever bytes had arrived. The first TCP segment can legitimately carry fewer bytes than a signature needs: a fragmented TLS ClientHello delivering only its handshake byte (`0x16`) failed the two-byte TLS check and fell through to the Noise default (hard misroute — the TLS client is handed to the Noise handshake), and a lone `P` was classified as HTTP/1.x even when it began an HTTP/2 connection preface (`PRI `).

## Fix

Classification moves into a `classify` function that returns `None` when the peeked prefix is a proper prefix of more than one protocol signature, and `detect` loops — re-peeking after a 2ms sleep — until the prefix decides. The ambiguous prefixes are exactly `0x16` (needs the TLS version byte), and `P`/`PR`/`PRI` (HTTP/1.x methods vs the HTTP/2 preface; no HTTP/1.x method starts with `PR`, and the full four bytes confirm `PRI `). Everything else classifies immediately on the first byte, so the overwhelmingly common case is unchanged: one peek, one decision.

The wait is bounded by the caller, which already wraps detection in `protocol_detect_timeout_ms` and closes the connection on expiry — a client that sends an ambiguous prefix and stalls gets the same outcome as a client that sends nothing today. A sleep-poll is used rather than awaiting readiness because `peek` does not consume: the socket stays read-ready with the same bytes, so a readiness-based wait would spin.

## Changes

- `src/protocol_detect.rs`: classify-or-wait loop + `classify` helper; behavior table otherwise identical (including `0x16` + non-`0x03` → Noise, and non-`PRI ` `PR…` → HTTP/1.x).
- Tests: three fragmented-delivery tests through real sockets (TLS first byte alone, `P` + HTTP/2 preface remainder, `P` + POST remainder — the first two fail against the previous implementation), plus direct `classify` unit tests for ambiguous and unambiguous prefixes, and a `0x16`+non-TLS-version Noise case.
- README: endpoint table completed (`GET /version`, `/health`, `/v1/reranking`, `/rerank` aliases).
- Version 1.10.9, CHANGELOG updated.

## Testing

- 365 unit tests pass (6 new), 8 integration tests pass.
- `cargo fmt --check` and `cargo clippy`: clean.