### PR TITLE
feat: surface queue depth and queue drops as Prometheus metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-06-12
+
+### Added
+
+- Queue observability on the metrics surface. `proxy_queue_length` reports
+  the current number of requests waiting across all model queues (the same
+  value as `total_queue_length` in `/cluster/nodes`, previously not
+  scrapeable), refreshed at scrape time. `proxy_queue_drops_total{reason}`
+  counts requests dropped from queues by reason — `full` (per-model
+  `max_queue_size_per_model` reached), `timeout` (queue wait exceeded its
+  limit), and `global_limit` (node-wide `max_total_queue_entries` reached) —
+  mirroring the existing `queue_drop` log events, which previously were the
+  only record of client-visible queue rejections. The drop counters are
+  cumulative and persist across restarts; both metrics also appear in
+  `/metrics/json`. (#77)
+
 ## [1.10.9] - 2026-06-12
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.10.9"
+version = "1.11.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.10.9"
+version = "1.11.0"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/src/api.rs
+++ b/src/api.rs
@@ -40,6 +40,9 @@ async fn metrics_handler(
 ) -> Result<String, (StatusCode, Json<serde_json::Value>)> {
     check_auth(&state, &headers)?;
     let _ = state.calculate_resource_snapshot().await;
+    state
+        .metrics
+        .set_queue_length(state.total_queue_length().await);
     let llama_cpp_version = state.build_manager.get_version().await;
     Ok(metrics::render_prometheus_with_circuit_breaker(
         &state.metrics,
@@ -151,6 +154,9 @@ async fn metrics_json_handler(
 ) -> Result<Json<metrics::MetricsSnapshot>, (StatusCode, Json<serde_json::Value>)> {
     check_auth(&state, &headers)?;
     let _ = state.calculate_resource_snapshot().await;
+    state
+        .metrics
+        .set_queue_length(state.total_queue_length().await);
     let version = state.build_manager.get_version().await;
     let build_status = state.build_manager.build_status();
     Ok(Json(

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -75,6 +75,19 @@ impl HashMetrics {
     }
 }
 
+/// Why a request was dropped from a model queue. Mirrors the `reason` field
+/// of `queue_drop` log events and the `reason` label of
+/// `proxy_queue_drops_total`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueueDropReason {
+    /// The per-model queue reached its `max_queue_size_per_model`.
+    Full,
+    /// The request's queue wait exceeded its timeout.
+    Timeout,
+    /// The node-wide `max_total_queue_entries` limit was reached.
+    GlobalLimit,
+}
+
 #[derive(Debug, Default)]
 pub struct Metrics {
     pub requests_total: AtomicU64,
@@ -87,6 +100,20 @@ pub struct Metrics {
     pub queue_wait_total_ms: AtomicU64,
     /// Number of requests that waited in queue
     pub queue_wait_count: AtomicU64,
+    /// Current total queued requests across all model queues, matching
+    /// `total_queue_length` in `/cluster/nodes`. Runtime gauge, refreshed by
+    /// the scrape handlers; starts fresh on restart.
+    pub queue_length: AtomicU64,
+    /// Requests dropped from model queues because the per-model queue was
+    /// full. Cumulative; persisted across restarts.
+    pub queue_drops_full: AtomicU64,
+    /// Requests dropped from model queues because their queue wait timed
+    /// out. Cumulative; persisted across restarts.
+    pub queue_drops_timeout: AtomicU64,
+    /// Requests dropped because the node-wide queue entry limit
+    /// (`max_total_queue_entries`) was reached. Cumulative; persisted across
+    /// restarts.
+    pub queue_drops_global_limit: AtomicU64,
 
     // Per-hash metrics: args_hash -> HashMetrics
     pub hash_metrics: RwLock<HashMap<String, Arc<HashMetrics>>>,
@@ -128,6 +155,21 @@ pub struct MetricsSnapshot {
     pub requests_total: u64,
     pub errors_total: u64,
     pub current_requests: u64,
+    /// Current total queued requests across all model queues. Runtime gauge;
+    /// not restored on load. `#[serde(default)]` keeps snapshots written by
+    /// older versions loadable.
+    #[serde(default)]
+    pub queue_length: u64,
+    /// Requests dropped from model queues by drop reason. Cumulative
+    /// counters, restored on load like `requests_total`/`errors_total`.
+    /// `#[serde(default)]` keeps snapshots written by older versions loadable
+    /// (a missing field must not reset every other counter).
+    #[serde(default)]
+    pub queue_drops_full: u64,
+    #[serde(default)]
+    pub queue_drops_timeout: u64,
+    #[serde(default)]
+    pub queue_drops_global_limit: u64,
     pub hashes: HashMap<String, HashMetricsSnapshot>,
     pub updated_at: String,
     #[serde(default)]
@@ -239,6 +281,10 @@ impl Metrics {
             queue_pending_tokens: AtomicU64::new(0), // Not persisted, starts fresh
             queue_wait_total_ms: AtomicU64::new(0),  // Not persisted, starts fresh
             queue_wait_count: AtomicU64::new(0),     // Not persisted, starts fresh
+            queue_length: AtomicU64::new(0),         // Runtime gauge, starts fresh
+            queue_drops_full: AtomicU64::new(snapshot.queue_drops_full),
+            queue_drops_timeout: AtomicU64::new(snapshot.queue_drops_timeout),
+            queue_drops_global_limit: AtomicU64::new(snapshot.queue_drops_global_limit),
             hash_metrics: RwLock::new(map),
             node_llamesh_vram_mb: AtomicU64::new(0),
             node_llamesh_sysmem_mb: AtomicU64::new(0),
@@ -302,6 +348,21 @@ impl Metrics {
     pub fn observe_queue_wait(&self, ms: u64) {
         self.queue_wait_total_ms.fetch_add(ms, Ordering::Relaxed);
         self.queue_wait_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Refresh the current total queue depth gauge.
+    pub fn set_queue_length(&self, length: u64) {
+        self.queue_length.store(length, Ordering::Relaxed);
+    }
+
+    /// Record a request dropped from a model queue.
+    pub fn record_queue_drop(&self, reason: QueueDropReason) {
+        let counter = match reason {
+            QueueDropReason::Full => &self.queue_drops_full,
+            QueueDropReason::Timeout => &self.queue_drops_timeout,
+            QueueDropReason::GlobalLimit => &self.queue_drops_global_limit,
+        };
+        counter.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Get or create metrics for a given args_hash.
@@ -421,6 +482,10 @@ impl Metrics {
             requests_total: self.requests_total.load(Ordering::Relaxed),
             errors_total: self.errors_total.load(Ordering::Relaxed),
             current_requests: self.current_requests.load(Ordering::Relaxed),
+            queue_length: self.queue_length.load(Ordering::Relaxed),
+            queue_drops_full: self.queue_drops_full.load(Ordering::Relaxed),
+            queue_drops_timeout: self.queue_drops_timeout.load(Ordering::Relaxed),
+            queue_drops_global_limit: self.queue_drops_global_limit.load(Ordering::Relaxed),
             hashes,
             updated_at: chrono::Utc::now().to_rfc3339(),
             is_building: build_status
@@ -595,6 +660,26 @@ pub async fn render_prometheus_with_circuit_breaker(
     out.push_str(&format!(
         "proxy_queue_wait_count {}\n",
         metrics.queue_wait_count.load(Ordering::Relaxed)
+    ));
+    out.push_str("# HELP proxy_queue_length Current number of requests waiting in model queues.\n");
+    out.push_str("# TYPE proxy_queue_length gauge\n");
+    out.push_str(&format!(
+        "proxy_queue_length {}\n",
+        metrics.queue_length.load(Ordering::Relaxed)
+    ));
+    out.push_str("# HELP proxy_queue_drops_total Requests dropped from model queues, by reason.\n");
+    out.push_str("# TYPE proxy_queue_drops_total counter\n");
+    out.push_str(&format!(
+        "proxy_queue_drops_total{{reason=\"full\"}} {}\n",
+        metrics.queue_drops_full.load(Ordering::Relaxed)
+    ));
+    out.push_str(&format!(
+        "proxy_queue_drops_total{{reason=\"timeout\"}} {}\n",
+        metrics.queue_drops_timeout.load(Ordering::Relaxed)
+    ));
+    out.push_str(&format!(
+        "proxy_queue_drops_total{{reason=\"global_limit\"}} {}\n",
+        metrics.queue_drops_global_limit.load(Ordering::Relaxed)
     ));
     out.push_str("# HELP proxy_token_counting_disabled_total Times token counting was disabled.\n");
     out.push_str("# TYPE proxy_token_counting_disabled_total counter\n");
@@ -898,6 +983,48 @@ mod tests {
         assert_eq!(snapshot.node_resources.active_instances, 0);
         assert_eq!(snapshot.node_resources.max_vram_mb, 0);
         assert_eq!(snapshot.node_resources.max_sysmem_mb, 0);
+        // Queue metrics added in 1.11.0 default when absent.
+        assert_eq!(snapshot.queue_length, 0);
+        assert_eq!(snapshot.queue_drops_full, 0);
+        assert_eq!(snapshot.queue_drops_timeout, 0);
+        assert_eq!(snapshot.queue_drops_global_limit, 0);
+    }
+
+    #[tokio::test]
+    async fn queue_drop_counters_round_trip_through_snapshot() {
+        let metrics = Metrics::new();
+        metrics.record_queue_drop(QueueDropReason::Full);
+        metrics.record_queue_drop(QueueDropReason::Timeout);
+        metrics.record_queue_drop(QueueDropReason::Timeout);
+        metrics.record_queue_drop(QueueDropReason::GlobalLimit);
+        metrics.set_queue_length(7);
+
+        let snapshot = metrics.snapshot("n".into(), "v".into(), None).await;
+        assert_eq!(snapshot.queue_drops_full, 1);
+        assert_eq!(snapshot.queue_drops_timeout, 2);
+        assert_eq!(snapshot.queue_drops_global_limit, 1);
+        assert_eq!(snapshot.queue_length, 7);
+
+        // Drop counters are cumulative and survive a restart; the queue depth
+        // is a runtime gauge and starts fresh.
+        let restored = Metrics::from_snapshot(snapshot);
+        assert_eq!(restored.queue_drops_full.load(Ordering::Relaxed), 1);
+        assert_eq!(restored.queue_drops_timeout.load(Ordering::Relaxed), 2);
+        assert_eq!(restored.queue_drops_global_limit.load(Ordering::Relaxed), 1);
+        assert_eq!(restored.queue_length.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn render_includes_queue_length_and_drops() {
+        let metrics = Metrics::new();
+        metrics.set_queue_length(3);
+        metrics.record_queue_drop(QueueDropReason::Timeout);
+
+        let out = render_prometheus_with_circuit_breaker(&metrics, None, "test").await;
+        assert!(out.contains("proxy_queue_length 3\n"));
+        assert!(out.contains("proxy_queue_drops_total{reason=\"full\"} 0\n"));
+        assert!(out.contains("proxy_queue_drops_total{reason=\"timeout\"} 1\n"));
+        assert!(out.contains("proxy_queue_drops_total{reason=\"global_limit\"} 0\n"));
     }
 
     #[tokio::test]

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -1286,6 +1286,19 @@ impl NodeState {
                     if let Some(mut token) = my_token.take() {
                         token.release().await;
                     }
+                    // A waiter can be woken just before its deadline and hit
+                    // this check on the next iteration, before re-queueing.
+                    // If this request waited in a queue at any point, that is
+                    // a queue timeout exactly like the in-queue expiries
+                    // below — log and count it the same way. (Requests that
+                    // never queued and exhaust the deadline in retry loops
+                    // keep returning QueueTimeout without a queue_drop
+                    // event, as before.)
+                    if queue_start.is_some() {
+                        info!(event = "queue_drop", reason = "timeout", model = %model_name);
+                        self.metrics
+                            .record_queue_drop(crate::metrics::QueueDropReason::Timeout);
+                    }
                     return Err(NodeError::QueueTimeout);
                 }
             }

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -764,6 +764,14 @@ impl NodeState {
         (snapshot.effective_vram_mb, snapshot.effective_sysmem_mb)
     }
 
+    /// Current total queued requests across all model queues, matching
+    /// `total_queue_length` in `/cluster/nodes`.
+    pub async fn total_queue_length(&self) -> u64 {
+        // LOCK_ORDER: queues (2)
+        let queues = self.queues.read().await;
+        queues.values().map(|q| q.len() as u64).sum()
+    }
+
     async fn calculate_resource_snapshot_for_instances(
         &self,
         instances: &HashMap<String, Arc<RwLock<Instance>>>,
@@ -1317,6 +1325,8 @@ impl NodeState {
                         let total: usize = queues.values().map(|q| q.len()).sum();
                         if total >= self.config.max_total_queue_entries {
                             info!(event = "queue_drop", reason = "global_limit", model = %model_name, total = total);
+                            self.metrics
+                                .record_queue_drop(crate::metrics::QueueDropReason::GlobalLimit);
                             return Err(NodeError::QueueFull);
                         }
                     }
@@ -1334,6 +1344,8 @@ impl NodeState {
                     // 0 = unlimited queue size
                     if max_queue > 0 && queue.len() >= max_queue {
                         info!(event = "queue_drop", reason = "full", model = %model_name);
+                        self.metrics
+                            .record_queue_drop(crate::metrics::QueueDropReason::Full);
                         return Err(NodeError::QueueFull);
                     }
                     queue_token = self.pending_token_counter.fetch_add(1, Ordering::SeqCst);
@@ -1360,6 +1372,8 @@ impl NodeState {
                         let elapsed = loop_start.elapsed();
                         if elapsed >= timeout {
                             info!(event = "queue_drop", reason = "timeout", model = %model_name);
+                            self.metrics
+                                .record_queue_drop(crate::metrics::QueueDropReason::Timeout);
                             self.remove_queue_entry(&key, queue_token).await;
                             self.remove_pending_token(model_name, &profile.id, queue_token)
                                 .await;
@@ -1370,6 +1384,8 @@ impl NodeState {
                             Ok(result) => result,
                             Err(_) => {
                                 info!(event = "queue_drop", reason = "timeout", model = %model_name);
+                                self.metrics
+                                    .record_queue_drop(crate::metrics::QueueDropReason::Timeout);
                                 self.remove_queue_entry(&key, queue_token).await;
                                 self.remove_pending_token(model_name, &profile.id, queue_token)
                                     .await;
@@ -1585,6 +1601,9 @@ impl NodeState {
                                 let total: usize = queues.values().map(|q| q.len()).sum();
                                 if total >= self.config.max_total_queue_entries {
                                     info!(event = "queue_drop", reason = "global_limit", model = %model_name, total = total);
+                                    self.metrics.record_queue_drop(
+                                        crate::metrics::QueueDropReason::GlobalLimit,
+                                    );
                                     return Err(NodeError::QueueFull);
                                 }
                             }
@@ -1603,6 +1622,8 @@ impl NodeState {
                             // 0 = unlimited queue size
                             if max_queue > 0 && queue.len() >= max_queue {
                                 info!(event = "queue_drop", reason = "full", model = %model_name);
+                                self.metrics
+                                    .record_queue_drop(crate::metrics::QueueDropReason::Full);
                                 return Err(NodeError::QueueFull);
                             }
                             queue_token = self.pending_token_counter.fetch_add(1, Ordering::SeqCst);
@@ -1671,6 +1692,9 @@ impl NodeState {
                                 let elapsed = loop_start.elapsed();
                                 if elapsed >= timeout {
                                     info!(event = "queue_drop", reason = "timeout", model = %model_name);
+                                    self.metrics.record_queue_drop(
+                                        crate::metrics::QueueDropReason::Timeout,
+                                    );
                                     self.remove_queue_entry(&key, queue_token).await;
                                     self.remove_pending_token(model_name, &profile.id, queue_token)
                                         .await;
@@ -1681,6 +1705,9 @@ impl NodeState {
                                     Ok(result) => result,
                                     Err(_) => {
                                         info!(event = "queue_drop", reason = "timeout", model = %model_name);
+                                        self.metrics.record_queue_drop(
+                                            crate::metrics::QueueDropReason::Timeout,
+                                        );
                                         self.remove_queue_entry(&key, queue_token).await;
                                         self.remove_pending_token(
                                             model_name,


### PR DESCRIPTION
Fixes #77

## Summary

Adds queue observability to the metrics surface, following the same pattern as the earlier `proxy_node_active_instances` (#56) and guardrail-gauge (#58) additions — values that existed on the cluster surface or only in logs become scrapeable:

- **`proxy_queue_length`** (gauge): current total requests waiting across all model queues, matching `total_queue_length` in `/cluster/nodes`. Refreshed at scrape time by both `/metrics` and `/metrics/json` handlers via a new `NodeState::total_queue_length()` helper (queues read lock only, consistent with the documented lock order).
- **`proxy_queue_drops_total{reason}`** (counter): requests dropped from queues, recorded at all eight existing `queue_drop` log sites across both queueing paths. Reasons mirror the log events exactly: `full` (per-model `max_queue_size_per_model`), `timeout` (queue wait exceeded), `global_limit` (node-wide `max_total_queue_entries`).

Drop counters are cumulative and persist across restarts like `requests_total`; the new `MetricsSnapshot` fields carry `#[serde(default)]` so node-metrics.json files written by older versions remain loadable and an in-place upgrade does not reset persisted counters. The depth gauge is runtime-only and starts fresh. Both metrics also appear in `/metrics/json`.

## Testing

- 367 unit tests pass (new: drop-counter round-trip through snapshot/restore including the gauge-not-restored property; Prometheus render assertions for the new families; the existing older-snapshot-still-loads test extended to cover the new fields' defaults).
- 8 integration tests pass; `cargo fmt --check` and `clippy` clean.

Version 1.11.0 (minor — new observability feature), CHANGELOG updated.