### PR TITLE
fix: drive circuit breaker recovery from the production request path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.1] - 2026-06-12
+
+### Fixed
+
+- The circuit breaker now recovers — and keeps blocking — through the code
+  paths production actually exercises. Its recovery transitions lived only in
+  an async entry point that no request path calls; the real gate is the
+  synchronous peer-candidate check, which never transitions state. As a
+  result an opened circuit stopped blocking permanently once its first
+  backoff window elapsed (failures while open never restarted the window or
+  escalated the backoff, so a still-down peer was retried by every request),
+  and never closed again either (successes while open were discarded, leaving
+  the circuit reported as open in metrics indefinitely and the backoff
+  escalation counter never reset). "Open with backoff elapsed" is now treated
+  as the recovery probe phase: the synchronous gate admits at most one probe
+  per `cluster.circuit_breaker.half_open_probe_interval_ms` (default 1000ms,
+  0 disables gating — this also implements the previously unenforced
+  "limited probes" half-open contract), a success recorded in that phase
+  advances the circuit toward half-open/closed, and a failure restarts the
+  block window with escalated backoff. Results arriving while the backoff is
+  still running are stale responses from requests sent before the circuit
+  opened and leave the state unchanged. (#79)
+
 ## [1.11.0] - 2026-06-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and never closed again either (successes while open were discarded, leaving
   the circuit reported as open in metrics indefinitely and the backoff
   escalation counter never reset). "Open with backoff elapsed" is now treated
-  as the recovery probe phase: the synchronous gate admits at most one probe
-  per `cluster.circuit_breaker.half_open_probe_interval_ms` (default 1000ms,
-  0 disables gating — this also implements the previously unenforced
-  "limited probes" half-open contract), a success recorded in that phase
-  advances the circuit toward half-open/closed, and a failure restarts the
-  block window with escalated backoff. Results arriving while the backoff is
-  still running are stale responses from requests sent before the circuit
-  opened and leave the state unchanged. (#79)
+  as the recovery probe phase: candidate filtering stays a read-only
+  eligibility check, the probe slot is claimed at the dispatch commit point
+  (at most one probe per `cluster.circuit_breaker.half_open_probe_interval_ms`,
+  default 1000ms, 0 admits every dispatch — this also implements the
+  previously unenforced "limited probes" half-open contract, without letting
+  candidate scans burn the probe slot of peers they never dispatch to), and
+  only results attributed to a claimed probe drive recovery: a probe success
+  advances the circuit toward half-open/closed and a probe failure restarts
+  the block window with escalated backoff, while late responses from
+  requests sent before the circuit opened leave the state unchanged whether
+  they arrive during or after the backoff window. Gossip claims the probe
+  slot when available, so an idle cluster recovers a returned peer within a
+  gossip round even with no client traffic, and recovery transitions wake
+  routing waiters parked on capacity notifications so already-queued
+  requests retry immediately. (#79)
 
 ## [1.11.0] - 2026-06-12
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.11.0"
+version = "1.11.1"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/SPEC.md
+++ b/SPEC.md
@@ -206,6 +206,7 @@ cluster:
     success_threshold: 2                 # Successes needed to close circuit
     open_duration_base_ms: 5000          # Base backoff (doubles each time circuit opens)
     open_duration_max_ms: 60000          # Maximum backoff cap
+    half_open_probe_interval_ms: 1000    # Min interval between recovery probes (0 = no gating)
 
   # Action when peer llama.cpp version differs (default: "warn")
   version_mismatch_action: "warn"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -181,6 +181,10 @@ cluster:
     open_duration_base_ms: 5000
     # Max backoff duration in ms with exponential backoff (default: 60000)
     open_duration_max_ms: 60000
+    # Minimum interval in ms between recovery probes once an open circuit's
+    # backoff has elapsed; limits traffic to a recovering peer until the
+    # circuit closes. 0 disables probe gating. (default: 1000)
+    half_open_probe_interval_ms: 1000
 
 # -----------------------------------------------------------------------------
 # HTTP Server Settings

--- a/src/circuit_breaker.rs
+++ b/src/circuit_breaker.rs
@@ -11,6 +11,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
@@ -35,6 +36,12 @@ pub struct PeerCircuit {
     pub last_failure: Option<Instant>,
     pub last_state_change: Instant,
     pub consecutive_opens: u32,
+    /// Creation instant; epoch for `last_probe_ms`.
+    created: Instant,
+    /// Milliseconds since `created` of the most recently admitted probe
+    /// (0 = never). Atomic so the read-lock-only sync gate can claim probes
+    /// without taking the circuits write lock.
+    last_probe_ms: AtomicU64,
 }
 
 impl Default for PeerCircuit {
@@ -46,7 +53,37 @@ impl Default for PeerCircuit {
             last_failure: None,
             last_state_change: Instant::now(),
             consecutive_opens: 0,
+            created: Instant::now(),
+            last_probe_ms: AtomicU64::new(0),
         }
+    }
+}
+
+impl PeerCircuit {
+    /// Try to claim a recovery probe slot. At most one probe is admitted per
+    /// `interval_ms`, so a recovering peer sees a trickle of probes instead
+    /// of the full queued backlog. An interval of 0 disables gating (every
+    /// request is admitted, the pre-gating behavior).
+    fn try_claim_probe(&self, interval_ms: u64) -> bool {
+        if interval_ms == 0 {
+            return true;
+        }
+        // `max(1)` keeps a probe claimed in the first millisecond
+        // distinguishable from "never probed".
+        let now_ms = (self.created.elapsed().as_millis() as u64).max(1);
+        let last = self.last_probe_ms.load(Ordering::Relaxed);
+        if last != 0 && now_ms.saturating_sub(last) < interval_ms {
+            return false;
+        }
+        // CAS so concurrent claimants admit exactly one probe.
+        self.last_probe_ms
+            .compare_exchange(last, now_ms, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+    }
+
+    /// Forget probe history (on state transitions that reset counters).
+    fn reset_probe(&self) {
+        self.last_probe_ms.store(0, Ordering::Relaxed);
     }
 }
 
@@ -69,6 +106,13 @@ pub struct CircuitBreakerConfig {
     #[serde(default = "default_open_duration_max_ms")]
     pub open_duration_max_ms: u64,
 
+    /// Minimum interval in ms between recovery probes once an open circuit's
+    /// backoff has elapsed (default: 1000). Limits how much traffic a
+    /// recovering peer sees before the circuit closes. 0 disables gating —
+    /// every request is admitted once the backoff has elapsed.
+    #[serde(default = "default_half_open_probe_interval_ms")]
+    pub half_open_probe_interval_ms: u64,
+
     /// Enable circuit breaker (default: true)
     #[serde(default = "default_enabled")]
     pub enabled: bool,
@@ -89,6 +133,9 @@ fn default_open_duration_max_ms() -> u64 {
 fn default_enabled() -> bool {
     true
 }
+fn default_half_open_probe_interval_ms() -> u64 {
+    1000
+}
 
 impl Default for CircuitBreakerConfig {
     fn default() -> Self {
@@ -97,6 +144,7 @@ impl Default for CircuitBreakerConfig {
             success_threshold: default_success_threshold(),
             open_duration_base_ms: default_open_duration_base_ms(),
             open_duration_max_ms: default_open_duration_max_ms(),
+            half_open_probe_interval_ms: default_half_open_probe_interval_ms(),
             enabled: default_enabled(),
         }
     }
@@ -137,18 +185,20 @@ impl CircuitBreaker {
                     circuit.state = CircuitState::HalfOpen;
                     circuit.last_state_change = Instant::now();
                     circuit.success_count = 0;
+                    circuit.reset_probe();
                     tracing::info!(
                         peer_id = %peer_id,
                         "Circuit breaker transitioning to half-open"
                     );
-                    true
+                    // Claim the first recovery probe.
+                    circuit.try_claim_probe(self.config.half_open_probe_interval_ms)
                 } else {
                     false
                 }
             }
             CircuitState::HalfOpen => {
-                // Allow limited probes in half-open
-                true
+                // Admit one recovery probe per configured interval.
+                circuit.try_claim_probe(self.config.half_open_probe_interval_ms)
             }
         }
     }
@@ -180,11 +230,20 @@ impl CircuitBreaker {
 
         match circuit.state {
             CircuitState::Closed => true,
-            CircuitState::HalfOpen => true,
+            // Half-open (explicit, or implicit as an open circuit whose
+            // backoff has elapsed): admit one recovery probe per configured
+            // interval so the recovering peer is not herded by the whole
+            // queued backlog. The probe stamp is an atomic, so this works
+            // under the read lock.
+            CircuitState::HalfOpen => {
+                circuit.try_claim_probe(self.config.half_open_probe_interval_ms)
+            }
             CircuitState::Open => {
-                // Check if backoff has elapsed (state transition happens in async should_allow)
                 let backoff = self.calculate_backoff(circuit.consecutive_opens);
-                circuit.last_state_change.elapsed() >= backoff
+                if circuit.last_state_change.elapsed() < backoff {
+                    return false;
+                }
+                circuit.try_claim_probe(self.config.half_open_probe_interval_ms)
             }
         }
     }
@@ -207,6 +266,7 @@ impl CircuitBreaker {
                     circuit.last_state_change = Instant::now();
                     circuit.failure_count = 0;
                     circuit.consecutive_opens = 0;
+                    circuit.reset_probe();
                     tracing::info!(
                         peer_id = %peer_id,
                         "Circuit breaker closed after successful recovery"
@@ -218,7 +278,34 @@ impl CircuitBreaker {
                 circuit.failure_count = 0;
             }
             CircuitState::Open => {
-                // Shouldn't happen - requests blocked in open state
+                // The production gate (`should_allow_sync`) admits probes
+                // once the backoff has elapsed but cannot transition state
+                // under its read lock — a success arriving here is a
+                // successful recovery probe, so drive the transition now.
+                // (A success while the backoff is still running is a stale
+                // response from a request sent before the circuit opened;
+                // ignore it, as before.)
+                let backoff = self.calculate_backoff(circuit.consecutive_opens);
+                if circuit.last_state_change.elapsed() >= backoff {
+                    circuit.last_state_change = Instant::now();
+                    circuit.success_count = 1;
+                    if circuit.success_count >= self.config.success_threshold {
+                        circuit.state = CircuitState::Closed;
+                        circuit.failure_count = 0;
+                        circuit.consecutive_opens = 0;
+                        circuit.reset_probe();
+                        tracing::info!(
+                            peer_id = %peer_id,
+                            "Circuit breaker closed after successful recovery"
+                        );
+                    } else {
+                        circuit.state = CircuitState::HalfOpen;
+                        tracing::info!(
+                            peer_id = %peer_id,
+                            "Circuit breaker transitioning to half-open"
+                        );
+                    }
+                }
             }
         }
     }
@@ -254,13 +341,33 @@ impl CircuitBreaker {
                 circuit.state = CircuitState::Open;
                 circuit.last_state_change = Instant::now();
                 circuit.consecutive_opens += 1;
+                circuit.success_count = 0;
+                circuit.reset_probe();
                 tracing::warn!(
                     peer_id = %peer_id,
                     "Circuit breaker reopened after failure in half-open state"
                 );
             }
             CircuitState::Open => {
-                // Already open
+                // A failure after the backoff elapsed is a failed recovery
+                // probe admitted by the sync gate: restart the block window
+                // with escalated backoff. Without this, the first backoff
+                // expiry permanently un-gates a still-failing peer, since
+                // nothing ever moves `last_state_change` forward again.
+                // (Failures inside the window are stale responses from
+                // requests sent before the circuit opened; keep waiting.)
+                let backoff = self.calculate_backoff(circuit.consecutive_opens);
+                if circuit.last_state_change.elapsed() >= backoff {
+                    circuit.last_state_change = Instant::now();
+                    circuit.consecutive_opens += 1;
+                    circuit.success_count = 0;
+                    circuit.reset_probe();
+                    tracing::warn!(
+                        peer_id = %peer_id,
+                        consecutive_opens = circuit.consecutive_opens,
+                        "Circuit breaker reopened after failed recovery probe"
+                    );
+                }
             }
         }
     }
@@ -464,6 +571,106 @@ mod tests {
         let states = cb.get_all_states().await;
         assert_eq!(states.get("peer-1"), Some(&CircuitState::Closed));
         assert_eq!(states.get("peer-2"), Some(&CircuitState::Open));
+    }
+
+    #[tokio::test]
+    async fn sync_gate_drives_recovery_through_record_paths() {
+        // The production path is should_allow_sync (read lock, no state
+        // transitions) plus record_success/record_failure — recovery must
+        // work through those alone.
+        let config = CircuitBreakerConfig {
+            failure_threshold: 2,
+            success_threshold: 2,
+            open_duration_base_ms: 1,
+            half_open_probe_interval_ms: 0, // gating off; tested separately
+            ..Default::default()
+        };
+        let cb = CircuitBreaker::new(config);
+
+        cb.record_failure("p").await;
+        cb.record_failure("p").await;
+        assert_eq!(cb.get_state("p").await, CircuitState::Open);
+        assert!(!cb.should_allow_sync("p"));
+
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        assert!(cb.should_allow_sync("p")); // probe admitted after backoff
+
+        cb.record_success("p").await; // successful probe → half-open
+        assert_eq!(cb.get_state("p").await, CircuitState::HalfOpen);
+        cb.record_success("p").await; // second success → closed
+        assert_eq!(cb.get_state("p").await, CircuitState::Closed);
+    }
+
+    #[tokio::test]
+    async fn failed_probe_reopens_with_escalated_backoff() {
+        let config = CircuitBreakerConfig {
+            failure_threshold: 1,
+            open_duration_base_ms: 40,
+            open_duration_max_ms: 10_000,
+            half_open_probe_interval_ms: 0,
+            ..Default::default()
+        };
+        let cb = CircuitBreaker::new(config);
+
+        cb.record_failure("p").await; // open; backoff 40ms
+        assert!(!cb.should_allow_sync("p"));
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(cb.should_allow_sync("p")); // probe admitted
+
+        // Failed probe must restart the block window with doubled backoff;
+        // without it, the first expiry permanently un-gates the peer.
+        cb.record_failure("p").await;
+        assert_eq!(cb.get_state("p").await, CircuitState::Open);
+        assert!(!cb.should_allow_sync("p"));
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(!cb.should_allow_sync("p")); // still inside the 80ms backoff
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(cb.should_allow_sync("p")); // escalated backoff elapsed
+    }
+
+    #[tokio::test]
+    async fn stale_results_inside_backoff_window_do_not_change_state() {
+        let config = CircuitBreakerConfig {
+            failure_threshold: 1,
+            open_duration_base_ms: 60_000,
+            ..Default::default()
+        };
+        let cb = CircuitBreaker::new(config);
+        cb.record_failure("p").await;
+        assert_eq!(cb.get_state("p").await, CircuitState::Open);
+
+        // Late results from requests sent before the circuit opened must
+        // neither recover nor escalate the circuit.
+        cb.record_success("p").await;
+        assert_eq!(cb.get_state("p").await, CircuitState::Open);
+        cb.record_failure("p").await;
+        assert_eq!(cb.get_state("p").await, CircuitState::Open);
+        assert!(!cb.should_allow_sync("p"));
+    }
+
+    #[tokio::test]
+    async fn probe_gating_limits_admissions_per_interval() {
+        let config = CircuitBreakerConfig {
+            failure_threshold: 1,
+            success_threshold: 2,
+            open_duration_base_ms: 1,
+            half_open_probe_interval_ms: 60_000,
+            ..Default::default()
+        };
+        let cb = CircuitBreaker::new(config);
+        cb.record_failure("p").await;
+        tokio::time::sleep(Duration::from_millis(5)).await;
+
+        assert!(cb.should_allow_sync("p")); // first probe admitted
+        assert!(!cb.should_allow_sync("p")); // backlog herd denied
+        assert!(!cb.should_allow_sync("p"));
+
+        // Recovery through probe successes reopens unrestricted traffic.
+        cb.record_success("p").await;
+        cb.record_success("p").await;
+        assert_eq!(cb.get_state("p").await, CircuitState::Closed);
+        assert!(cb.should_allow_sync("p"));
+        assert!(cb.should_allow_sync("p"));
     }
 
     #[tokio::test]

--- a/src/circuit_breaker.rs
+++ b/src/circuit_breaker.rs
@@ -27,6 +27,21 @@ pub enum CircuitState {
     HalfOpen,
 }
 
+/// Outcome of a dispatch admission check against a peer's circuit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DispatchDecision {
+    /// Send the request. `probe_ticket` is true when this dispatch is a
+    /// recovery probe for an open/half-open circuit: the caller must pass it
+    /// to `record_success`/`record_failure` so the result is attributed to
+    /// this specific dispatch. Results without a ticket never drive
+    /// recovery, which keeps late responses from requests sent before the
+    /// circuit opened from recovering (or re-blocking) a peer.
+    Admit { probe_ticket: bool },
+    /// Do not send: the circuit is blocking, or the recovery probe slot for
+    /// this interval is already taken.
+    Deny,
+}
+
 /// Per-peer circuit state
 #[derive(Debug)]
 pub struct PeerCircuit {
@@ -42,14 +57,6 @@ pub struct PeerCircuit {
     /// (0 = never). Paces probe admission. Atomic so the read-lock-only sync
     /// gate can claim probes without taking the circuits write lock.
     last_probe_ms: AtomicU64,
-    /// Number of claimed probes whose results are outstanding. Attribution
-    /// tickets: only results that consume one count as probe outcomes, so
-    /// late responses from pre-open requests (or unadmitted gossip sends)
-    /// cannot drive recovery. A count (not a flag) because a probe can
-    /// outlive the probe interval and overlap the next admitted probe; each
-    /// then carries its own ticket. Kept separate from `last_probe_ms` so
-    /// consuming a ticket does not reset probe pacing.
-    pending_probes: AtomicU64,
 }
 
 impl Default for PeerCircuit {
@@ -63,7 +70,6 @@ impl Default for PeerCircuit {
             consecutive_opens: 0,
             created: Instant::now(),
             last_probe_ms: AtomicU64::new(0),
-            pending_probes: AtomicU64::new(0),
         }
     }
 }
@@ -78,11 +84,8 @@ impl PeerCircuit {
         // distinguishable from "never probed".
         let now_ms = (self.created.elapsed().as_millis() as u64).max(1);
         if interval_ms == 0 {
-            // Gating disabled: every dispatch is admitted — but the
-            // attribution ticket is still issued, since classifying results
-            // (probe vs stale pre-open response) depends on it.
+            // Gating disabled: every dispatch is admitted as a probe.
             self.last_probe_ms.store(now_ms, Ordering::Relaxed);
-            self.pending_probes.fetch_add(1, Ordering::Relaxed);
             return true;
         }
         let last = self.last_probe_ms.load(Ordering::Relaxed);
@@ -90,30 +93,14 @@ impl PeerCircuit {
             return false;
         }
         // CAS so concurrent claimants admit exactly one probe per interval.
-        if self
-            .last_probe_ms
+        self.last_probe_ms
             .compare_exchange(last, now_ms, Ordering::Relaxed, Ordering::Relaxed)
             .is_ok()
-        {
-            self.pending_probes.fetch_add(1, Ordering::Relaxed);
-            true
-        } else {
-            false
-        }
     }
 
-    /// Consume one outstanding probe ticket, if any. Pacing is unaffected:
-    /// the next probe still waits for the interval from the last admission.
-    fn consume_probe_claim(&self) -> bool {
-        self.pending_probes
-            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| n.checked_sub(1))
-            .is_ok()
-    }
-
-    /// Forget probe history (on state transitions that reset counters).
+    /// Forget probe pacing (on state transitions that reset counters).
     fn reset_probe(&self) {
         self.last_probe_ms.store(0, Ordering::Relaxed);
-        self.pending_probes.store(0, Ordering::Relaxed);
     }
 }
 
@@ -277,34 +264,55 @@ impl CircuitBreaker {
     /// point of committing to send (not while filtering candidates, which
     /// would burn the probe slot on peers that are never dispatched to).
     ///
-    /// Closed circuits always admit. Circuits in the recovery phase —
-    /// half-open, or open with backoff elapsed — admit at most one probe per
-    /// `half_open_probe_interval_ms`, so a recovering peer sees a trickle of
-    /// probes instead of the queued backlog. Like `should_allow_sync`, this
-    /// is synchronous and conservatively admits when the lock is contended.
-    pub fn try_claim_dispatch_sync(&self, peer_id: &str) -> bool {
+    /// Closed circuits always admit (without a probe ticket). Circuits in
+    /// the recovery phase — half-open, or open with backoff elapsed — admit
+    /// at most one probe per `half_open_probe_interval_ms` and hand the
+    /// caller the probe ticket for result attribution, so a recovering peer
+    /// sees a trickle of probes instead of the queued backlog. Like
+    /// `should_allow_sync`, this is synchronous and conservatively admits
+    /// when the lock is contended.
+    pub fn try_claim_dispatch_sync(&self, peer_id: &str) -> DispatchDecision {
         if !self.config.enabled {
-            return true;
+            return DispatchDecision::Admit {
+                probe_ticket: false,
+            };
         }
 
         let circuits = match self.circuits.try_read() {
             Ok(guard) => guard,
-            Err(_) => return true,
+            Err(_) => {
+                return DispatchDecision::Admit {
+                    probe_ticket: false,
+                }
+            }
         };
 
         let Some(circuit) = circuits.get(peer_id) else {
-            return true;
+            return DispatchDecision::Admit {
+                probe_ticket: false,
+            };
         };
 
         match circuit.state {
-            CircuitState::Closed => true,
+            CircuitState::Closed => DispatchDecision::Admit {
+                probe_ticket: false,
+            },
             CircuitState::HalfOpen => {
-                circuit.try_claim_probe(self.config.half_open_probe_interval_ms)
+                if circuit.try_claim_probe(self.config.half_open_probe_interval_ms) {
+                    DispatchDecision::Admit { probe_ticket: true }
+                } else {
+                    DispatchDecision::Deny
+                }
             }
             CircuitState::Open => {
                 let backoff = self.calculate_backoff(circuit.consecutive_opens);
-                circuit.last_state_change.elapsed() >= backoff
+                if circuit.last_state_change.elapsed() >= backoff
                     && circuit.try_claim_probe(self.config.half_open_probe_interval_ms)
+                {
+                    DispatchDecision::Admit { probe_ticket: true }
+                } else {
+                    DispatchDecision::Deny
+                }
             }
         }
     }
@@ -315,7 +323,7 @@ impl CircuitBreaker {
     /// (open → half-open, or → closed): callers should wake routing waiters
     /// parked on capacity notifications, which may have filtered this peer
     /// out before it recovered.
-    pub async fn record_success(&self, peer_id: &str) -> bool {
+    pub async fn record_success(&self, peer_id: &str, probe_ticket: bool) -> bool {
         if !self.config.enabled {
             return false;
         }
@@ -325,9 +333,9 @@ impl CircuitBreaker {
 
         match circuit.state {
             CircuitState::HalfOpen => {
-                // Only results from claimed probes count toward recovery;
-                // stale pre-open responses carry no ticket.
-                if !circuit.consume_probe_claim() {
+                // Only results from this dispatch's claimed probe count
+                // toward recovery; stale pre-open responses carry no ticket.
+                if !probe_ticket {
                     return false;
                 }
                 circuit.success_count += 1;
@@ -355,13 +363,12 @@ impl CircuitBreaker {
                 // The production gate cannot transition state under its read
                 // lock, so a success from a dispatched recovery probe arrives
                 // here while the circuit is still Open — drive the transition
-                // now. Attribute the result to a probe only when one was
-                // actually claimed (the swap consumes the claim): with
+                // now. The caller-carried ticket is the attribution: with
                 // unlimited request durations, a slow response from a request
-                // sent before the circuit opened can arrive after the backoff
-                // elapsed, and must not recover a peer nobody has re-probed.
-                let backoff = self.calculate_backoff(circuit.consecutive_opens);
-                if circuit.last_state_change.elapsed() >= backoff && circuit.consume_probe_claim() {
+                // sent before the circuit opened can arrive at any time, and
+                // carries no ticket, so it cannot recover a peer nobody has
+                // re-probed.
+                if probe_ticket {
                     circuit.last_state_change = Instant::now();
                     circuit.success_count = 1;
                     if circuit.success_count >= self.config.success_threshold {
@@ -390,8 +397,9 @@ impl CircuitBreaker {
         }
     }
 
-    /// Record a failed request to a peer
-    pub async fn record_failure(&self, peer_id: &str) {
+    /// Record a failed request to a peer. `probe_ticket` carries this
+    /// dispatch's probe attribution, as in `record_success`.
+    pub async fn record_failure(&self, peer_id: &str, probe_ticket: bool) {
         if !self.config.enabled {
             return;
         }
@@ -419,10 +427,10 @@ impl CircuitBreaker {
                 }
             }
             CircuitState::HalfOpen => {
-                // Only a claimed probe's failure reopens the circuit; a slow
-                // failure from a request sent before the circuit opened must
-                // not re-block a recovering peer.
-                if circuit.consume_probe_claim() {
+                // Only a ticketed probe's failure reopens the circuit; a
+                // slow failure from a request sent before the circuit opened
+                // must not re-block a recovering peer.
+                if probe_ticket {
                     circuit.state = CircuitState::Open;
                     circuit.last_state_change = Instant::now();
                     circuit.consecutive_opens += 1;
@@ -435,15 +443,14 @@ impl CircuitBreaker {
                 }
             }
             CircuitState::Open => {
-                // A failure from a claimed recovery probe restarts the block
+                // A failure from a ticketed recovery probe restarts the block
                 // window with escalated backoff. Without this, the first
                 // backoff expiry permanently un-gates a still-failing peer,
                 // since nothing ever moves `last_state_change` forward again.
-                // The claim requirement (the swap consumes it) keeps stale
-                // failures — slow requests sent before the circuit opened —
-                // from escalating a window nobody has re-probed.
-                let backoff = self.calculate_backoff(circuit.consecutive_opens);
-                if circuit.last_state_change.elapsed() >= backoff && circuit.consume_probe_claim() {
+                // The ticket requirement keeps stale failures — slow
+                // requests sent before the circuit opened — from escalating
+                // a window nobody has re-probed.
+                if probe_ticket {
                     circuit.last_state_change = Instant::now();
                     circuit.consecutive_opens += 1;
                     circuit.success_count = 0;
@@ -512,11 +519,11 @@ mod tests {
         };
         let cb = CircuitBreaker::new(config);
 
-        cb.record_failure("peer-1").await;
-        cb.record_failure("peer-1").await;
+        cb.record_failure("peer-1", false).await;
+        cb.record_failure("peer-1", false).await;
         assert!(cb.should_allow("peer-1").await); // Still closed
 
-        cb.record_failure("peer-1").await;
+        cb.record_failure("peer-1", false).await;
         assert_eq!(cb.get_state("peer-1").await, CircuitState::Open);
         assert!(!cb.should_allow("peer-1").await); // Now blocked
     }
@@ -529,12 +536,12 @@ mod tests {
         };
         let cb = CircuitBreaker::new(config);
 
-        cb.record_failure("peer-1").await;
-        cb.record_failure("peer-1").await;
-        cb.record_success("peer-1").await; // Reset
+        cb.record_failure("peer-1", false).await;
+        cb.record_failure("peer-1", false).await;
+        cb.record_success("peer-1", false).await; // Reset
 
-        cb.record_failure("peer-1").await;
-        cb.record_failure("peer-1").await;
+        cb.record_failure("peer-1", false).await;
+        cb.record_failure("peer-1", false).await;
         assert!(cb.should_allow("peer-1").await); // Still closed (only 2 failures)
     }
 
@@ -547,9 +554,9 @@ mod tests {
         };
         let cb = CircuitBreaker::new(config);
 
-        cb.record_failure("peer-1").await;
-        cb.record_failure("peer-1").await;
-        cb.record_failure("peer-1").await;
+        cb.record_failure("peer-1", false).await;
+        cb.record_failure("peer-1", false).await;
+        cb.record_failure("peer-1", false).await;
 
         // Should still allow even after many failures
         assert!(cb.should_allow("peer-1").await);
@@ -583,8 +590,8 @@ mod tests {
         let cb = CircuitBreaker::new(config);
 
         // Open the circuit
-        cb.record_failure("peer-1").await;
-        cb.record_failure("peer-1").await;
+        cb.record_failure("peer-1", false).await;
+        cb.record_failure("peer-1", false).await;
         assert_eq!(cb.get_state("peer-1").await, CircuitState::Open);
 
         // Wait for backoff and trigger half-open
@@ -592,11 +599,11 @@ mod tests {
         assert!(cb.should_allow("peer-1").await); // Transitions to HalfOpen, claims probe
         assert_eq!(cb.get_state("peer-1").await, CircuitState::HalfOpen);
 
-        // Claimed-probe successes in half-open close the circuit
-        cb.record_success("peer-1").await;
+        // Ticketed probe successes in half-open close the circuit
+        cb.record_success("peer-1", true).await;
         assert_eq!(cb.get_state("peer-1").await, CircuitState::HalfOpen);
-        assert!(cb.should_allow("peer-1").await); // claim the next probe
-        cb.record_success("peer-1").await;
+        assert!(cb.should_allow("peer-1").await); // admit the next probe
+        cb.record_success("peer-1", true).await;
         assert_eq!(cb.get_state("peer-1").await, CircuitState::Closed);
     }
 
@@ -611,8 +618,8 @@ mod tests {
         let cb = CircuitBreaker::new(config);
 
         // Open the circuit
-        cb.record_failure("peer-1").await;
-        cb.record_failure("peer-1").await;
+        cb.record_failure("peer-1", false).await;
+        cb.record_failure("peer-1", false).await;
         assert_eq!(cb.get_state("peer-1").await, CircuitState::Open);
 
         // Wait and transition to half-open
@@ -620,8 +627,8 @@ mod tests {
         cb.should_allow("peer-1").await;
         assert_eq!(cb.get_state("peer-1").await, CircuitState::HalfOpen);
 
-        // Failure in half-open reopens circuit
-        cb.record_failure("peer-1").await;
+        // Ticketed probe failure in half-open reopens circuit
+        cb.record_failure("peer-1", true).await;
         assert_eq!(cb.get_state("peer-1").await, CircuitState::Open);
     }
 
@@ -634,8 +641,8 @@ mod tests {
         let cb = CircuitBreaker::new(config);
 
         // Open the circuit
-        cb.record_failure("peer-1").await;
-        cb.record_failure("peer-1").await;
+        cb.record_failure("peer-1", false).await;
+        cb.record_failure("peer-1", false).await;
         assert_eq!(cb.get_state("peer-1").await, CircuitState::Open);
 
         // Reset should clear state
@@ -654,7 +661,7 @@ mod tests {
 
         // Create circuits for multiple peers
         cb.should_allow("peer-1").await; // Creates closed circuit
-        cb.record_failure("peer-2").await; // Opens circuit
+        cb.record_failure("peer-2", false).await; // Opens circuit
 
         let states = cb.get_all_states().await;
         assert_eq!(states.get("peer-1"), Some(&CircuitState::Closed));
@@ -675,19 +682,25 @@ mod tests {
         };
         let cb = CircuitBreaker::new(config);
 
-        cb.record_failure("p").await;
-        cb.record_failure("p").await;
+        cb.record_failure("p", false).await;
+        cb.record_failure("p", false).await;
         assert_eq!(cb.get_state("p").await, CircuitState::Open);
         assert!(!cb.should_allow_sync("p"));
 
         tokio::time::sleep(Duration::from_millis(5)).await;
         assert!(cb.should_allow_sync("p")); // eligible after backoff
-        assert!(cb.try_claim_dispatch_sync("p")); // probe claimed at dispatch
+        assert!(matches!(
+            cb.try_claim_dispatch_sync("p"),
+            DispatchDecision::Admit { probe_ticket: true }
+        )); // probe claimed at dispatch
 
-        assert!(cb.record_success("p").await); // successful probe → half-open
+        assert!(cb.record_success("p", true).await); // successful probe → half-open
         assert_eq!(cb.get_state("p").await, CircuitState::HalfOpen);
-        assert!(cb.try_claim_dispatch_sync("p")); // next probe claimed
-        assert!(cb.record_success("p").await); // second success → closed
+        assert!(matches!(
+            cb.try_claim_dispatch_sync("p"),
+            DispatchDecision::Admit { probe_ticket: true }
+        )); // next probe claimed
+        assert!(cb.record_success("p", true).await); // second success → closed
         assert_eq!(cb.get_state("p").await, CircuitState::Closed);
     }
 
@@ -702,16 +715,22 @@ mod tests {
         };
         let cb = CircuitBreaker::new(config);
 
-        cb.record_failure("p").await; // open; backoff 40ms
+        cb.record_failure("p", false).await; // open; backoff 40ms
         assert!(!cb.should_allow_sync("p"));
-        assert!(!cb.try_claim_dispatch_sync("p")); // dispatch denied too
+        assert!(matches!(
+            cb.try_claim_dispatch_sync("p"),
+            DispatchDecision::Deny
+        )); // dispatch denied too
         tokio::time::sleep(Duration::from_millis(50)).await;
         assert!(cb.should_allow_sync("p")); // eligible
-        assert!(cb.try_claim_dispatch_sync("p")); // probe claimed
+        assert!(matches!(
+            cb.try_claim_dispatch_sync("p"),
+            DispatchDecision::Admit { probe_ticket: true }
+        )); // probe claimed
 
         // Failed probe must restart the block window with doubled backoff;
         // without it, the first expiry permanently un-gates the peer.
-        cb.record_failure("p").await;
+        cb.record_failure("p", true).await;
         assert_eq!(cb.get_state("p").await, CircuitState::Open);
         assert!(!cb.should_allow_sync("p"));
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -728,14 +747,14 @@ mod tests {
             ..Default::default()
         };
         let cb = CircuitBreaker::new(config);
-        cb.record_failure("p").await;
+        cb.record_failure("p", false).await;
         assert_eq!(cb.get_state("p").await, CircuitState::Open);
 
         // Late results from requests sent before the circuit opened must
         // neither recover nor escalate the circuit.
-        cb.record_success("p").await;
+        cb.record_success("p", false).await;
         assert_eq!(cb.get_state("p").await, CircuitState::Open);
-        cb.record_failure("p").await;
+        cb.record_failure("p", false).await;
         assert_eq!(cb.get_state("p").await, CircuitState::Open);
         assert!(!cb.should_allow_sync("p"));
     }
@@ -750,7 +769,7 @@ mod tests {
             ..Default::default()
         };
         let cb = CircuitBreaker::new(config);
-        cb.record_failure("p").await;
+        cb.record_failure("p", false).await;
         tokio::time::sleep(Duration::from_millis(5)).await;
 
         // Eligibility checks (candidate filtering) are read-only and never
@@ -758,16 +777,35 @@ mod tests {
         assert!(cb.should_allow_sync("p"));
         assert!(cb.should_allow_sync("p"));
 
-        assert!(cb.try_claim_dispatch_sync("p")); // first dispatch claims the probe
-        assert!(!cb.try_claim_dispatch_sync("p")); // backlog herd denied
-        assert!(!cb.try_claim_dispatch_sync("p"));
+        assert!(matches!(
+            cb.try_claim_dispatch_sync("p"),
+            DispatchDecision::Admit { probe_ticket: true }
+        )); // first dispatch claims the probe
+        assert!(matches!(
+            cb.try_claim_dispatch_sync("p"),
+            DispatchDecision::Deny
+        )); // backlog herd denied
+        assert!(matches!(
+            cb.try_claim_dispatch_sync("p"),
+            DispatchDecision::Deny
+        ));
 
         // The probe's success closes the circuit and reopens unrestricted
-        // traffic.
-        assert!(cb.record_success("p").await);
+        // traffic (closed-circuit admissions carry no probe ticket).
+        assert!(cb.record_success("p", true).await);
         assert_eq!(cb.get_state("p").await, CircuitState::Closed);
-        assert!(cb.try_claim_dispatch_sync("p"));
-        assert!(cb.try_claim_dispatch_sync("p"));
+        assert!(matches!(
+            cb.try_claim_dispatch_sync("p"),
+            DispatchDecision::Admit {
+                probe_ticket: false
+            }
+        ));
+        assert!(matches!(
+            cb.try_claim_dispatch_sync("p"),
+            DispatchDecision::Admit {
+                probe_ticket: false
+            }
+        ));
     }
 
     #[tokio::test]
@@ -780,22 +818,28 @@ mod tests {
             ..Default::default()
         };
         let cb = CircuitBreaker::new(config);
-        cb.record_failure("p").await;
+        cb.record_failure("p", false).await;
         tokio::time::sleep(Duration::from_millis(5)).await;
 
-        assert!(cb.try_claim_dispatch_sync("p"));
-        assert!(cb.record_success("p").await); // probe success → half-open
+        assert!(matches!(
+            cb.try_claim_dispatch_sync("p"),
+            DispatchDecision::Admit { probe_ticket: true }
+        ));
+        assert!(cb.record_success("p", true).await); // probe success → half-open
         assert_eq!(cb.get_state("p").await, CircuitState::HalfOpen);
 
         // The interval still paces half-open probes after the transition: a
         // woken backlog cannot immediately claim the next probe.
-        assert!(!cb.try_claim_dispatch_sync("p"));
+        assert!(matches!(
+            cb.try_claim_dispatch_sync("p"),
+            DispatchDecision::Deny
+        ));
 
         // And stale results without a claimed probe neither advance recovery
         // nor re-block the recovering peer in half-open.
-        assert!(!cb.record_success("p").await);
+        assert!(!cb.record_success("p", false).await);
         assert_eq!(cb.get_state("p").await, CircuitState::HalfOpen);
-        cb.record_failure("p").await;
+        cb.record_failure("p", false).await;
         assert_eq!(cb.get_state("p").await, CircuitState::HalfOpen);
     }
 
@@ -811,20 +855,23 @@ mod tests {
             ..Default::default()
         };
         let cb = CircuitBreaker::new(config);
-        cb.record_failure("p").await;
+        cb.record_failure("p", false).await;
         tokio::time::sleep(Duration::from_millis(5)).await;
 
-        assert!(!cb.record_success("p").await); // stale success: no recovery
+        assert!(!cb.record_success("p", false).await); // stale success: no recovery
         assert_eq!(cb.get_state("p").await, CircuitState::Open);
 
-        cb.record_failure("p").await; // stale failure: no escalation
+        cb.record_failure("p", false).await; // stale failure: no escalation
         assert_eq!(cb.get_state("p").await, CircuitState::Open);
         // Backoff window unchanged (1ms, long elapsed): peer still eligible.
         assert!(cb.should_allow_sync("p"));
 
-        // A claimed probe's success, by contrast, recovers the circuit.
-        assert!(cb.try_claim_dispatch_sync("p"));
-        assert!(cb.record_success("p").await);
+        // A ticketed probe's success, by contrast, recovers the circuit.
+        assert!(matches!(
+            cb.try_claim_dispatch_sync("p"),
+            DispatchDecision::Admit { probe_ticket: true }
+        ));
+        assert!(cb.record_success("p", true).await);
         assert_eq!(cb.get_state("p").await, CircuitState::HalfOpen);
     }
 
@@ -844,7 +891,7 @@ mod tests {
         };
         let cb = CircuitBreaker::new(config);
 
-        cb.record_failure("peer-1").await;
+        cb.record_failure("peer-1", false).await;
         assert!(!cb.should_allow_sync("peer-1")); // Blocked
     }
 

--- a/src/circuit_breaker.rs
+++ b/src/circuit_breaker.rs
@@ -39,9 +39,15 @@ pub struct PeerCircuit {
     /// Creation instant; epoch for `last_probe_ms`.
     created: Instant,
     /// Milliseconds since `created` of the most recently admitted probe
-    /// (0 = never). Atomic so the read-lock-only sync gate can claim probes
-    /// without taking the circuits write lock.
+    /// (0 = never). Paces probe admission. Atomic so the read-lock-only sync
+    /// gate can claim probes without taking the circuits write lock.
     last_probe_ms: AtomicU64,
+    /// True while a claimed probe's result is outstanding. Attribution
+    /// ticket: only results that consume it count as probe outcomes, so
+    /// late responses from pre-open requests (or unadmitted gossip sends)
+    /// cannot drive recovery. Kept separate from `last_probe_ms` so
+    /// consuming the ticket does not reset probe pacing.
+    probe_pending: std::sync::atomic::AtomicBool,
 }
 
 impl Default for PeerCircuit {
@@ -55,6 +61,7 @@ impl Default for PeerCircuit {
             consecutive_opens: 0,
             created: Instant::now(),
             last_probe_ms: AtomicU64::new(0),
+            probe_pending: std::sync::atomic::AtomicBool::new(false),
         }
     }
 }
@@ -69,25 +76,40 @@ impl PeerCircuit {
         // distinguishable from "never probed".
         let now_ms = (self.created.elapsed().as_millis() as u64).max(1);
         if interval_ms == 0 {
-            // Gating disabled: every dispatch is admitted — but the claim is
-            // still stamped, since result attribution (probe vs stale
-            // pre-open response) depends on it.
+            // Gating disabled: every dispatch is admitted — but the
+            // attribution ticket is still issued, since classifying results
+            // (probe vs stale pre-open response) depends on it.
             self.last_probe_ms.store(now_ms, Ordering::Relaxed);
+            self.probe_pending.store(true, Ordering::Relaxed);
             return true;
         }
         let last = self.last_probe_ms.load(Ordering::Relaxed);
         if last != 0 && now_ms.saturating_sub(last) < interval_ms {
             return false;
         }
-        // CAS so concurrent claimants admit exactly one probe.
-        self.last_probe_ms
+        // CAS so concurrent claimants admit exactly one probe per interval.
+        if self
+            .last_probe_ms
             .compare_exchange(last, now_ms, Ordering::Relaxed, Ordering::Relaxed)
             .is_ok()
+        {
+            self.probe_pending.store(true, Ordering::Relaxed);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Consume the outstanding probe ticket, if any. Pacing is unaffected:
+    /// the next probe still waits for the interval from the last admission.
+    fn consume_probe_claim(&self) -> bool {
+        self.probe_pending.swap(false, Ordering::Relaxed)
     }
 
     /// Forget probe history (on state transitions that reset counters).
     fn reset_probe(&self) {
         self.last_probe_ms.store(0, Ordering::Relaxed);
+        self.probe_pending.store(false, Ordering::Relaxed);
     }
 }
 
@@ -299,6 +321,11 @@ impl CircuitBreaker {
 
         match circuit.state {
             CircuitState::HalfOpen => {
+                // Only results from claimed probes count toward recovery;
+                // stale pre-open responses carry no ticket.
+                if !circuit.consume_probe_claim() {
+                    return false;
+                }
                 circuit.success_count += 1;
                 if circuit.success_count >= self.config.success_threshold {
                     // Transition to closed
@@ -330,20 +357,22 @@ impl CircuitBreaker {
                 // sent before the circuit opened can arrive after the backoff
                 // elapsed, and must not recover a peer nobody has re-probed.
                 let backoff = self.calculate_backoff(circuit.consecutive_opens);
-                if circuit.last_state_change.elapsed() >= backoff
-                    && circuit.last_probe_ms.swap(0, Ordering::Relaxed) != 0
-                {
+                if circuit.last_state_change.elapsed() >= backoff && circuit.consume_probe_claim() {
                     circuit.last_state_change = Instant::now();
                     circuit.success_count = 1;
                     if circuit.success_count >= self.config.success_threshold {
                         circuit.state = CircuitState::Closed;
                         circuit.failure_count = 0;
                         circuit.consecutive_opens = 0;
+                        circuit.reset_probe();
                         tracing::info!(
                             peer_id = %peer_id,
                             "Circuit breaker closed after successful recovery"
                         );
                     } else {
+                        // Probe pacing (last_probe_ms) deliberately persists
+                        // through this transition: the next half-open probe
+                        // still waits out the configured interval.
                         circuit.state = CircuitState::HalfOpen;
                         tracing::info!(
                             peer_id = %peer_id,
@@ -406,12 +435,11 @@ impl CircuitBreaker {
                 // failures — slow requests sent before the circuit opened —
                 // from escalating a window nobody has re-probed.
                 let backoff = self.calculate_backoff(circuit.consecutive_opens);
-                if circuit.last_state_change.elapsed() >= backoff
-                    && circuit.last_probe_ms.swap(0, Ordering::Relaxed) != 0
-                {
+                if circuit.last_state_change.elapsed() >= backoff && circuit.consume_probe_claim() {
                     circuit.last_state_change = Instant::now();
                     circuit.consecutive_opens += 1;
                     circuit.success_count = 0;
+                    circuit.reset_probe();
                     tracing::warn!(
                         peer_id = %peer_id,
                         consecutive_opens = circuit.consecutive_opens,
@@ -540,7 +568,8 @@ mod tests {
         let config = CircuitBreakerConfig {
             failure_threshold: 2,
             success_threshold: 2,
-            open_duration_base_ms: 1, // 1ms for fast test
+            open_duration_base_ms: 1,       // 1ms for fast test
+            half_open_probe_interval_ms: 0, // every probe admitted
             ..Default::default()
         };
         let cb = CircuitBreaker::new(config);
@@ -552,12 +581,13 @@ mod tests {
 
         // Wait for backoff and trigger half-open
         tokio::time::sleep(Duration::from_millis(5)).await;
-        assert!(cb.should_allow("peer-1").await); // Transitions to HalfOpen
+        assert!(cb.should_allow("peer-1").await); // Transitions to HalfOpen, claims probe
         assert_eq!(cb.get_state("peer-1").await, CircuitState::HalfOpen);
 
-        // Successes in half-open close the circuit
+        // Claimed-probe successes in half-open close the circuit
         cb.record_success("peer-1").await;
         assert_eq!(cb.get_state("peer-1").await, CircuitState::HalfOpen);
+        assert!(cb.should_allow("peer-1").await); // claim the next probe
         cb.record_success("peer-1").await;
         assert_eq!(cb.get_state("peer-1").await, CircuitState::Closed);
     }
@@ -648,6 +678,7 @@ mod tests {
 
         assert!(cb.record_success("p").await); // successful probe → half-open
         assert_eq!(cb.get_state("p").await, CircuitState::HalfOpen);
+        assert!(cb.try_claim_dispatch_sync("p")); // next probe claimed
         assert!(cb.record_success("p").await); // second success → closed
         assert_eq!(cb.get_state("p").await, CircuitState::Closed);
     }
@@ -705,7 +736,7 @@ mod tests {
     async fn probe_gating_limits_dispatch_claims_per_interval() {
         let config = CircuitBreakerConfig {
             failure_threshold: 1,
-            success_threshold: 2,
+            success_threshold: 1,
             open_duration_base_ms: 1,
             half_open_probe_interval_ms: 60_000,
             ..Default::default()
@@ -723,12 +754,39 @@ mod tests {
         assert!(!cb.try_claim_dispatch_sync("p")); // backlog herd denied
         assert!(!cb.try_claim_dispatch_sync("p"));
 
-        // Recovery through probe successes reopens unrestricted traffic.
-        assert!(cb.record_success("p").await);
+        // The probe's success closes the circuit and reopens unrestricted
+        // traffic.
         assert!(cb.record_success("p").await);
         assert_eq!(cb.get_state("p").await, CircuitState::Closed);
         assert!(cb.try_claim_dispatch_sync("p"));
         assert!(cb.try_claim_dispatch_sync("p"));
+    }
+
+    #[tokio::test]
+    async fn probe_pacing_persists_across_half_open_transition() {
+        let config = CircuitBreakerConfig {
+            failure_threshold: 1,
+            success_threshold: 2,
+            open_duration_base_ms: 1,
+            half_open_probe_interval_ms: 60_000,
+            ..Default::default()
+        };
+        let cb = CircuitBreaker::new(config);
+        cb.record_failure("p").await;
+        tokio::time::sleep(Duration::from_millis(5)).await;
+
+        assert!(cb.try_claim_dispatch_sync("p"));
+        assert!(cb.record_success("p").await); // probe success → half-open
+        assert_eq!(cb.get_state("p").await, CircuitState::HalfOpen);
+
+        // The interval still paces half-open probes after the transition: a
+        // woken backlog cannot immediately claim the next probe.
+        assert!(!cb.try_claim_dispatch_sync("p"));
+
+        // And a stale success without a claimed probe does not advance
+        // recovery in half-open either.
+        assert!(!cb.record_success("p").await);
+        assert_eq!(cb.get_state("p").await, CircuitState::HalfOpen);
     }
 
     #[tokio::test]

--- a/src/circuit_breaker.rs
+++ b/src/circuit_breaker.rs
@@ -65,12 +65,16 @@ impl PeerCircuit {
     /// of the full queued backlog. An interval of 0 disables gating (every
     /// request is admitted, the pre-gating behavior).
     fn try_claim_probe(&self, interval_ms: u64) -> bool {
-        if interval_ms == 0 {
-            return true;
-        }
         // `max(1)` keeps a probe claimed in the first millisecond
         // distinguishable from "never probed".
         let now_ms = (self.created.elapsed().as_millis() as u64).max(1);
+        if interval_ms == 0 {
+            // Gating disabled: every dispatch is admitted — but the claim is
+            // still stamped, since result attribution (probe vs stale
+            // pre-open response) depends on it.
+            self.last_probe_ms.store(now_ms, Ordering::Relaxed);
+            return true;
+        }
         let last = self.last_probe_ms.load(Ordering::Relaxed);
         if last != 0 && now_ms.saturating_sub(last) < interval_ms {
             return false;
@@ -230,28 +234,64 @@ impl CircuitBreaker {
 
         match circuit.state {
             CircuitState::Closed => true,
-            // Half-open (explicit, or implicit as an open circuit whose
-            // backoff has elapsed): admit one recovery probe per configured
-            // interval so the recovering peer is not herded by the whole
-            // queued backlog. The probe stamp is an atomic, so this works
-            // under the read lock.
+            CircuitState::HalfOpen => true,
+            CircuitState::Open => {
+                // Eligible for recovery probes once the backoff has elapsed.
+                // This check is read-only on purpose: it runs while routing
+                // filters peer candidates, and most filtered candidates are
+                // never dispatched to. The probe slot is claimed at the point
+                // of committing to send, via `try_claim_dispatch_sync`.
+                let backoff = self.calculate_backoff(circuit.consecutive_opens);
+                circuit.last_state_change.elapsed() >= backoff
+            }
+        }
+    }
+
+    /// Claim the right to dispatch one request to this peer; call at the
+    /// point of committing to send (not while filtering candidates, which
+    /// would burn the probe slot on peers that are never dispatched to).
+    ///
+    /// Closed circuits always admit. Circuits in the recovery phase —
+    /// half-open, or open with backoff elapsed — admit at most one probe per
+    /// `half_open_probe_interval_ms`, so a recovering peer sees a trickle of
+    /// probes instead of the queued backlog. Like `should_allow_sync`, this
+    /// is synchronous and conservatively admits when the lock is contended.
+    pub fn try_claim_dispatch_sync(&self, peer_id: &str) -> bool {
+        if !self.config.enabled {
+            return true;
+        }
+
+        let circuits = match self.circuits.try_read() {
+            Ok(guard) => guard,
+            Err(_) => return true,
+        };
+
+        let Some(circuit) = circuits.get(peer_id) else {
+            return true;
+        };
+
+        match circuit.state {
+            CircuitState::Closed => true,
             CircuitState::HalfOpen => {
                 circuit.try_claim_probe(self.config.half_open_probe_interval_ms)
             }
             CircuitState::Open => {
                 let backoff = self.calculate_backoff(circuit.consecutive_opens);
-                if circuit.last_state_change.elapsed() < backoff {
-                    return false;
-                }
-                circuit.try_claim_probe(self.config.half_open_probe_interval_ms)
+                circuit.last_state_change.elapsed() >= backoff
+                    && circuit.try_claim_probe(self.config.half_open_probe_interval_ms)
             }
         }
     }
 
-    /// Record a successful request to a peer
-    pub async fn record_success(&self, peer_id: &str) {
+    /// Record a successful request to a peer.
+    ///
+    /// Returns `true` when the success advanced a recovery transition
+    /// (open → half-open, or → closed): callers should wake routing waiters
+    /// parked on capacity notifications, which may have filtered this peer
+    /// out before it recovered.
+    pub async fn record_success(&self, peer_id: &str) -> bool {
         if !self.config.enabled {
-            return;
+            return false;
         }
 
         let mut circuits = self.circuits.write().await;
@@ -271,29 +311,34 @@ impl CircuitBreaker {
                         peer_id = %peer_id,
                         "Circuit breaker closed after successful recovery"
                     );
+                    return true;
                 }
+                false
             }
             CircuitState::Closed => {
                 // Reset failure count on success
                 circuit.failure_count = 0;
+                false
             }
             CircuitState::Open => {
-                // The production gate (`should_allow_sync`) admits probes
-                // once the backoff has elapsed but cannot transition state
-                // under its read lock — a success arriving here is a
-                // successful recovery probe, so drive the transition now.
-                // (A success while the backoff is still running is a stale
-                // response from a request sent before the circuit opened;
-                // ignore it, as before.)
+                // The production gate cannot transition state under its read
+                // lock, so a success from a dispatched recovery probe arrives
+                // here while the circuit is still Open — drive the transition
+                // now. Attribute the result to a probe only when one was
+                // actually claimed (the swap consumes the claim): with
+                // unlimited request durations, a slow response from a request
+                // sent before the circuit opened can arrive after the backoff
+                // elapsed, and must not recover a peer nobody has re-probed.
                 let backoff = self.calculate_backoff(circuit.consecutive_opens);
-                if circuit.last_state_change.elapsed() >= backoff {
+                if circuit.last_state_change.elapsed() >= backoff
+                    && circuit.last_probe_ms.swap(0, Ordering::Relaxed) != 0
+                {
                     circuit.last_state_change = Instant::now();
                     circuit.success_count = 1;
                     if circuit.success_count >= self.config.success_threshold {
                         circuit.state = CircuitState::Closed;
                         circuit.failure_count = 0;
                         circuit.consecutive_opens = 0;
-                        circuit.reset_probe();
                         tracing::info!(
                             peer_id = %peer_id,
                             "Circuit breaker closed after successful recovery"
@@ -305,7 +350,9 @@ impl CircuitBreaker {
                             "Circuit breaker transitioning to half-open"
                         );
                     }
+                    return true;
                 }
+                false
             }
         }
     }
@@ -329,6 +376,8 @@ impl CircuitBreaker {
                     circuit.state = CircuitState::Open;
                     circuit.last_state_change = Instant::now();
                     circuit.consecutive_opens += 1;
+                    circuit.success_count = 0;
+                    circuit.reset_probe();
                     tracing::warn!(
                         peer_id = %peer_id,
                         failures = circuit.failure_count,
@@ -349,19 +398,20 @@ impl CircuitBreaker {
                 );
             }
             CircuitState::Open => {
-                // A failure after the backoff elapsed is a failed recovery
-                // probe admitted by the sync gate: restart the block window
-                // with escalated backoff. Without this, the first backoff
-                // expiry permanently un-gates a still-failing peer, since
-                // nothing ever moves `last_state_change` forward again.
-                // (Failures inside the window are stale responses from
-                // requests sent before the circuit opened; keep waiting.)
+                // A failure from a claimed recovery probe restarts the block
+                // window with escalated backoff. Without this, the first
+                // backoff expiry permanently un-gates a still-failing peer,
+                // since nothing ever moves `last_state_change` forward again.
+                // The claim requirement (the swap consumes it) keeps stale
+                // failures — slow requests sent before the circuit opened —
+                // from escalating a window nobody has re-probed.
                 let backoff = self.calculate_backoff(circuit.consecutive_opens);
-                if circuit.last_state_change.elapsed() >= backoff {
+                if circuit.last_state_change.elapsed() >= backoff
+                    && circuit.last_probe_ms.swap(0, Ordering::Relaxed) != 0
+                {
                     circuit.last_state_change = Instant::now();
                     circuit.consecutive_opens += 1;
                     circuit.success_count = 0;
-                    circuit.reset_probe();
                     tracing::warn!(
                         peer_id = %peer_id,
                         consecutive_opens = circuit.consecutive_opens,
@@ -593,11 +643,12 @@ mod tests {
         assert!(!cb.should_allow_sync("p"));
 
         tokio::time::sleep(Duration::from_millis(5)).await;
-        assert!(cb.should_allow_sync("p")); // probe admitted after backoff
+        assert!(cb.should_allow_sync("p")); // eligible after backoff
+        assert!(cb.try_claim_dispatch_sync("p")); // probe claimed at dispatch
 
-        cb.record_success("p").await; // successful probe → half-open
+        assert!(cb.record_success("p").await); // successful probe → half-open
         assert_eq!(cb.get_state("p").await, CircuitState::HalfOpen);
-        cb.record_success("p").await; // second success → closed
+        assert!(cb.record_success("p").await); // second success → closed
         assert_eq!(cb.get_state("p").await, CircuitState::Closed);
     }
 
@@ -614,8 +665,10 @@ mod tests {
 
         cb.record_failure("p").await; // open; backoff 40ms
         assert!(!cb.should_allow_sync("p"));
+        assert!(!cb.try_claim_dispatch_sync("p")); // dispatch denied too
         tokio::time::sleep(Duration::from_millis(50)).await;
-        assert!(cb.should_allow_sync("p")); // probe admitted
+        assert!(cb.should_allow_sync("p")); // eligible
+        assert!(cb.try_claim_dispatch_sync("p")); // probe claimed
 
         // Failed probe must restart the block window with doubled backoff;
         // without it, the first expiry permanently un-gates the peer.
@@ -649,7 +702,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn probe_gating_limits_admissions_per_interval() {
+    async fn probe_gating_limits_dispatch_claims_per_interval() {
         let config = CircuitBreakerConfig {
             failure_threshold: 1,
             success_threshold: 2,
@@ -661,16 +714,50 @@ mod tests {
         cb.record_failure("p").await;
         tokio::time::sleep(Duration::from_millis(5)).await;
 
-        assert!(cb.should_allow_sync("p")); // first probe admitted
-        assert!(!cb.should_allow_sync("p")); // backlog herd denied
-        assert!(!cb.should_allow_sync("p"));
+        // Eligibility checks (candidate filtering) are read-only and never
+        // consume the probe slot, no matter how many scans run.
+        assert!(cb.should_allow_sync("p"));
+        assert!(cb.should_allow_sync("p"));
+
+        assert!(cb.try_claim_dispatch_sync("p")); // first dispatch claims the probe
+        assert!(!cb.try_claim_dispatch_sync("p")); // backlog herd denied
+        assert!(!cb.try_claim_dispatch_sync("p"));
 
         // Recovery through probe successes reopens unrestricted traffic.
-        cb.record_success("p").await;
-        cb.record_success("p").await;
+        assert!(cb.record_success("p").await);
+        assert!(cb.record_success("p").await);
         assert_eq!(cb.get_state("p").await, CircuitState::Closed);
+        assert!(cb.try_claim_dispatch_sync("p"));
+        assert!(cb.try_claim_dispatch_sync("p"));
+    }
+
+    #[tokio::test]
+    async fn unclaimed_results_after_backoff_do_not_change_state() {
+        // With unlimited request durations, a slow response from a request
+        // sent before the circuit opened can arrive after the backoff has
+        // elapsed. Without a claimed probe it must neither recover the
+        // circuit nor escalate the backoff.
+        let config = CircuitBreakerConfig {
+            failure_threshold: 1,
+            open_duration_base_ms: 1,
+            ..Default::default()
+        };
+        let cb = CircuitBreaker::new(config);
+        cb.record_failure("p").await;
+        tokio::time::sleep(Duration::from_millis(5)).await;
+
+        assert!(!cb.record_success("p").await); // stale success: no recovery
+        assert_eq!(cb.get_state("p").await, CircuitState::Open);
+
+        cb.record_failure("p").await; // stale failure: no escalation
+        assert_eq!(cb.get_state("p").await, CircuitState::Open);
+        // Backoff window unchanged (1ms, long elapsed): peer still eligible.
         assert!(cb.should_allow_sync("p"));
-        assert!(cb.should_allow_sync("p"));
+
+        // A claimed probe's success, by contrast, recovers the circuit.
+        assert!(cb.try_claim_dispatch_sync("p"));
+        assert!(cb.record_success("p").await);
+        assert_eq!(cb.get_state("p").await, CircuitState::HalfOpen);
     }
 
     #[tokio::test]

--- a/src/circuit_breaker.rs
+++ b/src/circuit_breaker.rs
@@ -42,12 +42,14 @@ pub struct PeerCircuit {
     /// (0 = never). Paces probe admission. Atomic so the read-lock-only sync
     /// gate can claim probes without taking the circuits write lock.
     last_probe_ms: AtomicU64,
-    /// True while a claimed probe's result is outstanding. Attribution
-    /// ticket: only results that consume it count as probe outcomes, so
+    /// Number of claimed probes whose results are outstanding. Attribution
+    /// tickets: only results that consume one count as probe outcomes, so
     /// late responses from pre-open requests (or unadmitted gossip sends)
-    /// cannot drive recovery. Kept separate from `last_probe_ms` so
-    /// consuming the ticket does not reset probe pacing.
-    probe_pending: std::sync::atomic::AtomicBool,
+    /// cannot drive recovery. A count (not a flag) because a probe can
+    /// outlive the probe interval and overlap the next admitted probe; each
+    /// then carries its own ticket. Kept separate from `last_probe_ms` so
+    /// consuming a ticket does not reset probe pacing.
+    pending_probes: AtomicU64,
 }
 
 impl Default for PeerCircuit {
@@ -61,7 +63,7 @@ impl Default for PeerCircuit {
             consecutive_opens: 0,
             created: Instant::now(),
             last_probe_ms: AtomicU64::new(0),
-            probe_pending: std::sync::atomic::AtomicBool::new(false),
+            pending_probes: AtomicU64::new(0),
         }
     }
 }
@@ -80,7 +82,7 @@ impl PeerCircuit {
             // attribution ticket is still issued, since classifying results
             // (probe vs stale pre-open response) depends on it.
             self.last_probe_ms.store(now_ms, Ordering::Relaxed);
-            self.probe_pending.store(true, Ordering::Relaxed);
+            self.pending_probes.fetch_add(1, Ordering::Relaxed);
             return true;
         }
         let last = self.last_probe_ms.load(Ordering::Relaxed);
@@ -93,23 +95,25 @@ impl PeerCircuit {
             .compare_exchange(last, now_ms, Ordering::Relaxed, Ordering::Relaxed)
             .is_ok()
         {
-            self.probe_pending.store(true, Ordering::Relaxed);
+            self.pending_probes.fetch_add(1, Ordering::Relaxed);
             true
         } else {
             false
         }
     }
 
-    /// Consume the outstanding probe ticket, if any. Pacing is unaffected:
+    /// Consume one outstanding probe ticket, if any. Pacing is unaffected:
     /// the next probe still waits for the interval from the last admission.
     fn consume_probe_claim(&self) -> bool {
-        self.probe_pending.swap(false, Ordering::Relaxed)
+        self.pending_probes
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| n.checked_sub(1))
+            .is_ok()
     }
 
     /// Forget probe history (on state transitions that reset counters).
     fn reset_probe(&self) {
         self.last_probe_ms.store(0, Ordering::Relaxed);
-        self.probe_pending.store(false, Ordering::Relaxed);
+        self.pending_probes.store(0, Ordering::Relaxed);
     }
 }
 
@@ -415,16 +419,20 @@ impl CircuitBreaker {
                 }
             }
             CircuitState::HalfOpen => {
-                // Any failure in half-open goes back to open
-                circuit.state = CircuitState::Open;
-                circuit.last_state_change = Instant::now();
-                circuit.consecutive_opens += 1;
-                circuit.success_count = 0;
-                circuit.reset_probe();
-                tracing::warn!(
-                    peer_id = %peer_id,
-                    "Circuit breaker reopened after failure in half-open state"
-                );
+                // Only a claimed probe's failure reopens the circuit; a slow
+                // failure from a request sent before the circuit opened must
+                // not re-block a recovering peer.
+                if circuit.consume_probe_claim() {
+                    circuit.state = CircuitState::Open;
+                    circuit.last_state_change = Instant::now();
+                    circuit.consecutive_opens += 1;
+                    circuit.success_count = 0;
+                    circuit.reset_probe();
+                    tracing::warn!(
+                        peer_id = %peer_id,
+                        "Circuit breaker reopened after failure in half-open state"
+                    );
+                }
             }
             CircuitState::Open => {
                 // A failure from a claimed recovery probe restarts the block
@@ -783,9 +791,11 @@ mod tests {
         // woken backlog cannot immediately claim the next probe.
         assert!(!cb.try_claim_dispatch_sync("p"));
 
-        // And a stale success without a claimed probe does not advance
-        // recovery in half-open either.
+        // And stale results without a claimed probe neither advance recovery
+        // nor re-block the recovering peer in half-open.
         assert!(!cb.record_success("p").await);
+        assert_eq!(cb.get_state("p").await, CircuitState::HalfOpen);
+        cb.record_failure("p").await;
         assert_eq!(cb.get_state("p").await, CircuitState::HalfOpen);
     }
 

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -135,8 +135,11 @@ pub async fn start_gossip_loop(state: Arc<NodeState>) {
             // cluster's standing health probe. Claim the recovery probe slot
             // when one is available so a gossip success while the circuit is
             // open is attributed as a recovery probe result; without traffic,
-            // this is what closes the circuit after a peer comes back.
-            let _ = circuit_breaker.try_claim_dispatch_sync(&cb_key);
+            // this is what closes the circuit after a peer comes back. When
+            // the claim is denied (a routed request's probe is in flight),
+            // this round's result is NOT recorded — recording it would
+            // consume the in-flight probe's attribution ticket.
+            let gossip_probe_claimed = circuit_breaker.try_claim_dispatch_sync(&cb_key);
 
             // Spawn each gossip request to avoid head-of-line blocking in the loop
             tokio::spawn(async move {
@@ -176,11 +179,15 @@ pub async fn start_gossip_loop(state: Arc<NodeState>) {
                                         }
                                     }
                                     if (200..300).contains(&status) {
-                                        if circuit_breaker.record_success(&cb_key).await {
+                                        if gossip_probe_claimed
+                                            && circuit_breaker.record_success(&cb_key).await
+                                        {
                                             capacity_notify.notify_waiters();
                                         }
                                     } else {
-                                        circuit_breaker.record_failure(&cb_key).await;
+                                        if gossip_probe_claimed {
+                                            circuit_breaker.record_failure(&cb_key).await;
+                                        }
                                         debug!(
                                             "Failed to gossip to {} over Noise: HTTP {}",
                                             peer_url, status
@@ -188,13 +195,17 @@ pub async fn start_gossip_loop(state: Arc<NodeState>) {
                                     }
                                 }
                                 Err(e) => {
-                                    circuit_breaker.record_failure(&cb_key).await;
+                                    if gossip_probe_claimed {
+                                        circuit_breaker.record_failure(&cb_key).await;
+                                    }
                                     debug!("Failed to gossip to {} over Noise: {}", peer_url, e);
                                 }
                             }
                         }
                         Err(e) => {
-                            circuit_breaker.record_failure(&cb_key).await;
+                            if gossip_probe_claimed {
+                                circuit_breaker.record_failure(&cb_key).await;
+                            }
                             debug!("Failed to serialize gossip for {}: {}", peer_url, e);
                         }
                     }
@@ -208,12 +219,16 @@ pub async fn start_gossip_loop(state: Arc<NodeState>) {
                             }
                         }
                         Ok(resp) => {
-                            circuit_breaker.record_failure(&cb_key).await;
+                            if gossip_probe_claimed {
+                                circuit_breaker.record_failure(&cb_key).await;
+                            }
                             debug!("Failed to gossip to {}: HTTP {}", url, resp.status());
                         }
                         Err(e) => {
                             // Record failure - circuit breaker handles escalation and logging
-                            circuit_breaker.record_failure(&cb_key).await;
+                            if gossip_probe_claimed {
+                                circuit_breaker.record_failure(&cb_key).await;
+                            }
                             debug!("Failed to gossip to {}: {}", url, e);
                         }
                     }

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -130,6 +130,13 @@ pub async fn start_gossip_loop(state: Arc<NodeState>) {
                 .unwrap_or_else(|| peer_url.clone());
             let expected_node_id = url_to_node_id.get(&peer_url).cloned();
             let circuit_breaker = state.circuit_breaker.clone();
+            let capacity_notify = state.capacity_notify.clone();
+            // Gossip always sends regardless of circuit state — it is the
+            // cluster's standing health probe. Claim the recovery probe slot
+            // when one is available so a gossip success while the circuit is
+            // open is attributed as a recovery probe result; without traffic,
+            // this is what closes the circuit after a peer comes back.
+            let _ = circuit_breaker.try_claim_dispatch_sync(&cb_key);
 
             // Spawn each gossip request to avoid head-of-line blocking in the loop
             tokio::spawn(async move {
@@ -169,7 +176,9 @@ pub async fn start_gossip_loop(state: Arc<NodeState>) {
                                         }
                                     }
                                     if (200..300).contains(&status) {
-                                        circuit_breaker.record_success(&cb_key).await;
+                                        if circuit_breaker.record_success(&cb_key).await {
+                                            capacity_notify.notify_waiters();
+                                        }
                                     } else {
                                         circuit_breaker.record_failure(&cb_key).await;
                                         debug!(
@@ -192,8 +201,11 @@ pub async fn start_gossip_loop(state: Arc<NodeState>) {
                 } else {
                     match client.post(&url).json(&message).send().await {
                         Ok(resp) if resp.status().is_success() => {
-                            // Record success - resets failure count and closes circuit if half-open
-                            circuit_breaker.record_success(&cb_key).await;
+                            // Record success - resets failure count, and on a
+                            // recovery transition wakes parked routing waiters.
+                            if circuit_breaker.record_success(&cb_key).await {
+                                capacity_notify.notify_waiters();
+                            }
                         }
                         Ok(resp) => {
                             circuit_breaker.record_failure(&cb_key).await;

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -214,7 +214,8 @@ pub async fn start_gossip_loop(state: Arc<NodeState>) {
                         Ok(resp) if resp.status().is_success() => {
                             // Record success - resets failure count, and on a
                             // recovery transition wakes parked routing waiters.
-                            if circuit_breaker.record_success(&cb_key).await {
+                            if gossip_probe_claimed && circuit_breaker.record_success(&cb_key).await
+                            {
                                 capacity_notify.notify_waiters();
                             }
                         }

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -137,9 +137,12 @@ pub async fn start_gossip_loop(state: Arc<NodeState>) {
             // open is attributed as a recovery probe result; without traffic,
             // this is what closes the circuit after a peer comes back. When
             // the claim is denied (a routed request's probe is in flight),
-            // this round's result is NOT recorded — recording it would
-            // consume the in-flight probe's attribution ticket.
-            let gossip_probe_claimed = circuit_breaker.try_claim_dispatch_sync(&cb_key);
+            // this round's result carries no ticket and cannot drive
+            // recovery, but closed-circuit failure counting still works.
+            let gossip_probe_ticket = matches!(
+                circuit_breaker.try_claim_dispatch_sync(&cb_key),
+                crate::circuit_breaker::DispatchDecision::Admit { probe_ticket: true }
+            );
 
             // Spawn each gossip request to avoid head-of-line blocking in the loop
             tokio::spawn(async move {
@@ -179,15 +182,16 @@ pub async fn start_gossip_loop(state: Arc<NodeState>) {
                                         }
                                     }
                                     if (200..300).contains(&status) {
-                                        if gossip_probe_claimed
-                                            && circuit_breaker.record_success(&cb_key).await
+                                        if circuit_breaker
+                                            .record_success(&cb_key, gossip_probe_ticket)
+                                            .await
                                         {
                                             capacity_notify.notify_waiters();
                                         }
                                     } else {
-                                        if gossip_probe_claimed {
-                                            circuit_breaker.record_failure(&cb_key).await;
-                                        }
+                                        circuit_breaker
+                                            .record_failure(&cb_key, gossip_probe_ticket)
+                                            .await;
                                         debug!(
                                             "Failed to gossip to {} over Noise: HTTP {}",
                                             peer_url, status
@@ -195,17 +199,17 @@ pub async fn start_gossip_loop(state: Arc<NodeState>) {
                                     }
                                 }
                                 Err(e) => {
-                                    if gossip_probe_claimed {
-                                        circuit_breaker.record_failure(&cb_key).await;
-                                    }
+                                    circuit_breaker
+                                        .record_failure(&cb_key, gossip_probe_ticket)
+                                        .await;
                                     debug!("Failed to gossip to {} over Noise: {}", peer_url, e);
                                 }
                             }
                         }
                         Err(e) => {
-                            if gossip_probe_claimed {
-                                circuit_breaker.record_failure(&cb_key).await;
-                            }
+                            circuit_breaker
+                                .record_failure(&cb_key, gossip_probe_ticket)
+                                .await;
                             debug!("Failed to serialize gossip for {}: {}", peer_url, e);
                         }
                     }
@@ -214,22 +218,24 @@ pub async fn start_gossip_loop(state: Arc<NodeState>) {
                         Ok(resp) if resp.status().is_success() => {
                             // Record success - resets failure count, and on a
                             // recovery transition wakes parked routing waiters.
-                            if gossip_probe_claimed && circuit_breaker.record_success(&cb_key).await
+                            if circuit_breaker
+                                .record_success(&cb_key, gossip_probe_ticket)
+                                .await
                             {
                                 capacity_notify.notify_waiters();
                             }
                         }
                         Ok(resp) => {
-                            if gossip_probe_claimed {
-                                circuit_breaker.record_failure(&cb_key).await;
-                            }
+                            circuit_breaker
+                                .record_failure(&cb_key, gossip_probe_ticket)
+                                .await;
                             debug!("Failed to gossip to {}: HTTP {}", url, resp.status());
                         }
                         Err(e) => {
                             // Record failure - circuit breaker handles escalation and logging
-                            if gossip_probe_claimed {
-                                circuit_breaker.record_failure(&cb_key).await;
-                            }
+                            circuit_breaker
+                                .record_failure(&cb_key, gossip_probe_ticket)
+                                .await;
                             debug!("Failed to gossip to {}: {}", url, e);
                         }
                     }

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -643,7 +643,11 @@ impl NodeState {
     /// Find a peer that supports a model (case-insensitive).
     /// Used when local cookbook doesn't have the model but a peer might.
     /// Returns the PeerState of the best candidate peer, if any.
-    pub async fn find_peer_for_model(&self, model_name: &str) -> Option<PeerState> {
+    pub async fn find_peer_for_model(
+        &self,
+        model_name: &str,
+        exclude_peer: Option<&str>,
+    ) -> Option<PeerState> {
         let peers = self.peers.read().await;
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -675,6 +679,11 @@ impl NodeState {
             }
             // Skip peers with open circuit breaker
             if !self.circuit_breaker.should_allow_sync(&peer.node_id) {
+                continue;
+            }
+            // Skip a peer the caller just failed to claim a recovery probe
+            // for, so the retry can reach a different healthy peer.
+            if exclude_peer == Some(peer.node_id.as_str()) {
                 continue;
             }
             // Check if peer supports this model (case-insensitive)
@@ -2633,6 +2642,7 @@ impl NodeState {
         model_name: &str,
         profile: &Profile,
         prefer_local: bool,
+        exclude_peer: Option<&str>,
     ) -> Option<PeerState> {
         let mut candidates = Vec::new();
         let requested_profile = profile.id.clone();
@@ -2691,6 +2701,11 @@ impl NodeState {
                     peer_id = %peer.node_id,
                     "Skipping peer due to open circuit breaker"
                 );
+                continue;
+            }
+            // Skip a peer the caller just failed to claim a recovery probe
+            // for, so the retry can reach a different healthy peer.
+            if exclude_peer == Some(peer.node_id.as_str()) {
                 continue;
             }
 
@@ -3688,7 +3703,7 @@ mod tests {
         // 1. Initially no peers, and local cookbook is empty.
         let profile = sample_profile();
         let result = state
-            .select_best_node("remote-model", &profile, false)
+            .select_best_node("remote-model", &profile, false, None)
             .await;
         // Should be None because we don't support it and we have no peers.
         assert!(result.is_none());
@@ -3732,7 +3747,7 @@ mod tests {
 
         // 3. Now select_best_node should find the peer
         let result = state
-            .select_best_node("remote-model", &profile, false)
+            .select_best_node("remote-model", &profile, false, None)
             .await;
         assert!(result.is_some());
         let picked = result.unwrap();

--- a/src/router.rs
+++ b/src/router.rs
@@ -129,10 +129,22 @@ fn peer_status_is_failure(status: StatusCode) -> bool {
         || status == StatusCode::FORBIDDEN
 }
 
-async fn record_peer_status(state: &NodeState, peer_id: &str, status: StatusCode) {
+async fn record_peer_status(
+    state: &NodeState,
+    peer_id: &str,
+    status: StatusCode,
+    probe_ticket: bool,
+) {
     if peer_status_is_failure(status) {
-        state.circuit_breaker.record_failure(peer_id).await;
-    } else if state.circuit_breaker.record_success(peer_id).await {
+        state
+            .circuit_breaker
+            .record_failure(peer_id, probe_ticket)
+            .await;
+    } else if state
+        .circuit_breaker
+        .record_success(peer_id, probe_ticket)
+        .await
+    {
         // The circuit just advanced toward recovery. Wake routing loops that
         // parked on capacity_notify after filtering this peer out, so they
         // retry (or send the next recovery probe) immediately instead of
@@ -208,25 +220,38 @@ async fn attempt_peer_forward(
     let peer_id = request.peer_id;
     // Circuit-breaker admission happens here, at the commit point, rather
     // than during candidate filtering: filtering scans peers that are never
-    // dispatched to, and must not burn a recovering peer's probe slot.
-    if !state.circuit_breaker.try_claim_dispatch_sync(peer_id) {
-        return ForwardOutcome::ProbeDenied;
-    }
+    // dispatched to, and must not burn a recovering peer's probe slot. The
+    // returned probe ticket attributes THIS dispatch's result; every
+    // success/failure recording below carries it, and the dispatch loops do
+    // not record outcomes themselves.
+    let probe_ticket = match state.circuit_breaker.try_claim_dispatch_sync(peer_id) {
+        crate::circuit_breaker::DispatchDecision::Admit { probe_ticket } => probe_ticket,
+        crate::circuit_breaker::DispatchDecision::Deny => return ForwardOutcome::ProbeDenied,
+    };
     let resp = match send_peer_request(state, request).await {
         Ok(resp) => resp,
-        Err(e) => return ForwardOutcome::Transport(e),
+        Err(e) => {
+            state
+                .circuit_breaker
+                .record_failure(peer_id, probe_ticket)
+                .await;
+            return ForwardOutcome::Transport(e);
+        }
     };
 
     let status = match &resp {
         PeerResponse::Http(r) => r.status(),
         PeerResponse::Noise { status, .. } => *status,
     };
-    record_peer_status(state, peer_id, status).await;
 
     // Pass through streaming successful responses without buffering. A 5xx
     // never opens a stream because the peer commits to its response shape
     // before opening one — error responses are always non-streaming JSON.
+    // The status is recorded at stream handoff; for non-streaming responses
+    // recording waits until the body is buffered, so a body-read failure is
+    // recorded as the probe's failure rather than a premature success.
     if response_streaming && status.is_success() {
+        record_peer_status(state, peer_id, status, probe_ticket).await;
         return ForwardOutcome::StreamingSurface(resp);
     }
 
@@ -238,6 +263,10 @@ async fn attempt_peer_forward(
             let bytes = match r.bytes().await {
                 Ok(b) => b,
                 Err(e) => {
+                    state
+                        .circuit_breaker
+                        .record_failure(peer_id, probe_ticket)
+                        .await;
                     return ForwardOutcome::Transport(AppError::new(
                         StatusCode::BAD_GATEWAY,
                         format!("Failed to read peer response body from {peer_id}: {e}"),
@@ -263,6 +292,10 @@ async fn attempt_peer_forward(
             {
                 Ok(b) => Bytes::from(b),
                 Err(e) => {
+                    state
+                        .circuit_breaker
+                        .record_failure(peer_id, probe_ticket)
+                        .await;
                     return ForwardOutcome::Transport(AppError::new(
                         StatusCode::BAD_GATEWAY,
                         format!("Failed to read Noise peer response body from {peer_id}: {e}"),
@@ -273,6 +306,8 @@ async fn attempt_peer_forward(
             (status, headers, bytes)
         }
     };
+
+    record_peer_status(state, peer_id, status, probe_ticket).await;
 
     if status.is_server_error() && is_healable_error_body(&body_bytes) {
         let reason = serde_json::from_slice::<Value>(&body_bytes)
@@ -621,8 +656,18 @@ pub async fn route_request(
                 build_forward_headers(&parts.headers, current_hops, &request_id);
             let timeout_ms = state.config.model_defaults.max_request_duration_ms;
 
+            // Set when a dispatch was probe-denied: the immediate retry
+            // excludes that peer so a healthy alternative is reached without
+            // waiting out the probe interval. Consumed by the next selection.
+            let mut exclude_peer: Option<String> = None;
+            let mut last_probe_denied: Option<String> = None;
+
             loop {
-                let Some(peer) = state.find_peer_for_model(&model_to_use).await else {
+                let selection_exclude = exclude_peer.take();
+                let Some(peer) = state
+                    .find_peer_for_model(&model_to_use, selection_exclude.as_deref())
+                    .await
+                else {
                     // No peer currently supports this model. Either it really
                     // does not exist anywhere, or every peer that advertises
                     // it is currently filtered (open circuit, draining,
@@ -745,37 +790,48 @@ pub async fn route_request(
                         tracing::debug!(
                             event = "forward_probe_denied",
                             peer = %peer.node_id,
-                            "Peer circuit recovering and probe slot taken; waiting to retry"
+                            "Peer circuit recovering and probe slot taken"
                         );
                         drop(peer_forward_guard);
-                        // A denied probe slot frees by time passing, not only
-                        // by capacity events — re-check at the next probe
-                        // deadline even if nothing notifies.
-                        let probe_deadline = Duration::from_millis(
-                            state
-                                .config
-                                .cluster
-                                .circuit_breaker
-                                .half_open_probe_interval_ms
-                                .max(250),
-                        );
-                        if let Ok(res) = tokio::time::timeout(
-                            probe_deadline,
-                            wait_for_capacity_or_disconnect(&state.capacity_notify, &conn_handle),
-                        )
-                        .await
-                        {
-                            res?;
+                        let repeat =
+                            last_probe_denied.as_deref() == Some(peer.node_id.as_str());
+                        last_probe_denied = Some(peer.node_id.clone());
+                        exclude_peer = Some(peer.node_id.clone());
+                        if repeat {
+                            // Selection keeps landing on this recovering
+                            // peer: park until the next probe deadline. The
+                            // slot frees by time passing, not only by
+                            // capacity events.
+                            let probe_deadline = Duration::from_millis(
+                                state
+                                    .config
+                                    .cluster
+                                    .circuit_breaker
+                                    .half_open_probe_interval_ms
+                                    .max(250),
+                            );
+                            if let Ok(res) = tokio::time::timeout(
+                                probe_deadline,
+                                wait_for_capacity_or_disconnect(
+                                    &state.capacity_notify,
+                                    &conn_handle,
+                                ),
+                            )
+                            .await
+                            {
+                                res?;
+                            }
                         }
+                        // Otherwise retry immediately, excluding this peer,
+                        // so a healthy alternative is reached without delay.
                         continue;
                     }
                     ForwardOutcome::Transport(e) => {
-                        // Already recorded as circuit-breaker failure inside
-                        // send_peer_request? No — record explicitly here. The
+                        // The failure was recorded (with this dispatch's
+                        // probe attribution) inside attempt_peer_forward. The
                         // forwarder retries against any peer that comes back
                         // online (including this one once its circuit
                         // resets).
-                        state.circuit_breaker.record_failure(&peer.node_id).await;
                         warn!(
                             event = "forward_transport_retry",
                             peer = %peer.node_id,
@@ -824,7 +880,7 @@ pub async fn route_request(
         // Cluster-aware routing: wait for capacity if model exists but no node available
         let best_node = loop {
             if let Some(node) = state
-                .select_best_node(&model_name, &profile, prefer_local)
+                .select_best_node(&model_name, &profile, prefer_local, None)
                 .await
             {
                 break node;
@@ -1068,25 +1124,29 @@ pub async fn route_request(
                         // attempt_peer_forward: a recovering peer admits at
                         // most one probe per interval, and this dispatch
                         // bypasses attempt_peer_forward.
-                        let fallback_peer = match state.find_peer_for_model(&model_to_use).await {
-                            Some(peer)
-                                if state
-                                    .circuit_breaker
-                                    .try_claim_dispatch_sync(&peer.node_id) =>
-                            {
-                                Some(peer)
-                            }
+                        let fallback_peer = match state
+                            .find_peer_for_model(&model_to_use, None)
+                            .await
+                        {
                             Some(peer) => {
-                                tracing::debug!(
-                                    event = "forward_probe_denied",
-                                    peer = %peer.node_id,
-                                    "Peer circuit recovering and probe slot taken; skipping spawn-failure fallback"
-                                );
-                                None
+                                match state.circuit_breaker.try_claim_dispatch_sync(&peer.node_id)
+                                {
+                                    crate::circuit_breaker::DispatchDecision::Admit {
+                                        probe_ticket,
+                                    } => Some((peer, probe_ticket)),
+                                    crate::circuit_breaker::DispatchDecision::Deny => {
+                                        tracing::debug!(
+                                            event = "forward_probe_denied",
+                                            peer = %peer.node_id,
+                                            "Peer circuit recovering and probe slot taken; skipping spawn-failure fallback"
+                                        );
+                                        None
+                                    }
+                                }
                             }
                             None => None,
                         };
-                        if let Some(peer) = fallback_peer {
+                        if let Some((peer, probe_ticket)) = fallback_peer {
                             info!(
                                 event = "local_spawn_failed_peer_fallback",
                                 model = %model_name,
@@ -1117,7 +1177,8 @@ pub async fn route_request(
                                         PeerResponse::Http(resp) => resp.status(),
                                         PeerResponse::Noise { status, .. } => *status,
                                     };
-                                    record_peer_status(&state, &peer.node_id, status).await;
+                                    record_peer_status(&state, &peer.node_id, status, probe_ticket)
+                                        .await;
 
                                     let tokens_counter = Arc::new(AtomicU64::new(0));
                                     let tokens_for_cleanup = tokens_counter.clone();
@@ -1173,7 +1234,10 @@ pub async fn route_request(
                                 Err(peer_err) => {
                                     // peer_forward_guard drops on fall-through,
                                     // releasing the counter.
-                                    state.circuit_breaker.record_failure(&peer.node_id).await;
+                                    state
+                                        .circuit_breaker
+                                        .record_failure(&peer.node_id, probe_ticket)
+                                        .await;
                                     warn!(
                                         peer = %peer.node_id,
                                         error = ?peer_err,
@@ -1248,6 +1312,11 @@ pub async fn route_request(
                 build_forward_headers(&parts.headers, current_hops, &request_id);
 
             let mut current_node = best_node;
+            // Set when a dispatch was probe-denied: the immediate re-select
+            // excludes that peer so a healthy alternative is reached without
+            // waiting out the probe interval. Consumed by the next selection.
+            let mut exclude_peer: Option<String> = None;
+            let mut last_probe_denied: Option<String> = None;
             loop {
                 info!(
                     event = "forward_remote",
@@ -1274,6 +1343,7 @@ pub async fn route_request(
                 .await;
 
                 let mut probe_wait_deadline: Option<Duration> = None;
+                let mut skip_wait = false;
                 match outcome {
                     ForwardOutcome::StreamingSurface(resp) => {
                         let tokens_counter = Arc::new(AtomicU64::new(0));
@@ -1350,25 +1420,35 @@ pub async fn route_request(
                         tracing::debug!(
                             event = "forward_probe_denied",
                             peer = %current_node.node_id,
-                            "Peer circuit recovering and probe slot taken; waiting to retry"
+                            "Peer circuit recovering and probe slot taken"
                         );
                         drop(peer_forward_guard);
-                        // A denied probe slot frees by time passing; bound
-                        // the wait below by the next probe deadline.
-                        probe_wait_deadline = Some(Duration::from_millis(
-                            state
-                                .config
-                                .cluster
-                                .circuit_breaker
-                                .half_open_probe_interval_ms
-                                .max(250),
-                        ));
+                        let repeat =
+                            last_probe_denied.as_deref() == Some(current_node.node_id.as_str());
+                        last_probe_denied = Some(current_node.node_id.clone());
+                        exclude_peer = Some(current_node.node_id.clone());
+                        if repeat {
+                            // Selection keeps landing on this recovering
+                            // peer: bound the wait below by the next probe
+                            // deadline, since the slot frees by time passing.
+                            probe_wait_deadline = Some(Duration::from_millis(
+                                state
+                                    .config
+                                    .cluster
+                                    .circuit_breaker
+                                    .half_open_probe_interval_ms
+                                    .max(250),
+                            ));
+                        } else {
+                            // First denial: re-select immediately, excluding
+                            // this peer, so a healthy alternative is reached
+                            // without waiting out the probe interval.
+                            skip_wait = true;
+                        }
                     }
                     ForwardOutcome::Transport(e) => {
-                        state
-                            .circuit_breaker
-                            .record_failure(&current_node.node_id)
-                            .await;
+                        // Failure already recorded inside attempt_peer_forward
+                        // with this dispatch's probe attribution.
                         warn!(
                             event = "forward_transport_retry",
                             peer = %current_node.node_id,
@@ -1384,8 +1464,13 @@ pub async fn route_request(
                 // Wait for cluster state to change (capacity freed, peer
                 // recovered, gossip update, drain finished) before retrying.
                 // Probe-denied attempts additionally wake at the next probe
-                // deadline, since a probe slot frees by time passing.
-                match probe_wait_deadline {
+                // deadline, since a probe slot frees by time passing — or
+                // skip the wait entirely on a first denial, to re-select an
+                // alternative peer immediately.
+                if skip_wait {
+                    // fall through to re-selection
+                } else {
+                    match probe_wait_deadline {
                     Some(deadline) => {
                         if let Ok(res) = tokio::time::timeout(
                             deadline,
@@ -1399,6 +1484,7 @@ pub async fn route_request(
                     None => {
                         wait_for_capacity_or_disconnect(&state.capacity_notify, &conn_handle)
                             .await?;
+                    }
                     }
                 }
 
@@ -1420,8 +1506,14 @@ pub async fn route_request(
                 // the same peer-or-better via this loop until the peer
                 // actually serves it.
                 current_node = loop {
+                    let selection_exclude = exclude_peer.take();
                     if let Some(node) = state
-                        .select_best_node(&model_name, &profile, prefer_local)
+                        .select_best_node(
+                            &model_name,
+                            &profile,
+                            prefer_local,
+                            selection_exclude.as_deref(),
+                        )
                         .await
                     {
                         break node;

--- a/src/router.rs
+++ b/src/router.rs
@@ -748,7 +748,25 @@ pub async fn route_request(
                             "Peer circuit recovering and probe slot taken; waiting to retry"
                         );
                         drop(peer_forward_guard);
-                        wait_for_capacity_or_disconnect(&state.capacity_notify, &conn_handle).await?;
+                        // A denied probe slot frees by time passing, not only
+                        // by capacity events — re-check at the next probe
+                        // deadline even if nothing notifies.
+                        let probe_deadline = Duration::from_millis(
+                            state
+                                .config
+                                .cluster
+                                .circuit_breaker
+                                .half_open_probe_interval_ms
+                                .max(250),
+                        );
+                        if let Ok(res) = tokio::time::timeout(
+                            probe_deadline,
+                            wait_for_capacity_or_disconnect(&state.capacity_notify, &conn_handle),
+                        )
+                        .await
+                        {
+                            res?;
+                        }
                         continue;
                     }
                     ForwardOutcome::Transport(e) => {
@@ -1233,6 +1251,7 @@ pub async fn route_request(
                 )
                 .await;
 
+                let mut probe_wait_deadline: Option<Duration> = None;
                 match outcome {
                     ForwardOutcome::StreamingSurface(resp) => {
                         let tokens_counter = Arc::new(AtomicU64::new(0));
@@ -1312,6 +1331,16 @@ pub async fn route_request(
                             "Peer circuit recovering and probe slot taken; waiting to retry"
                         );
                         drop(peer_forward_guard);
+                        // A denied probe slot frees by time passing; bound
+                        // the wait below by the next probe deadline.
+                        probe_wait_deadline = Some(Duration::from_millis(
+                            state
+                                .config
+                                .cluster
+                                .circuit_breaker
+                                .half_open_probe_interval_ms
+                                .max(250),
+                        ));
                     }
                     ForwardOutcome::Transport(e) => {
                         state
@@ -1332,7 +1361,24 @@ pub async fn route_request(
 
                 // Wait for cluster state to change (capacity freed, peer
                 // recovered, gossip update, drain finished) before retrying.
-                wait_for_capacity_or_disconnect(&state.capacity_notify, &conn_handle).await?;
+                // Probe-denied attempts additionally wake at the next probe
+                // deadline, since a probe slot frees by time passing.
+                match probe_wait_deadline {
+                    Some(deadline) => {
+                        if let Ok(res) = tokio::time::timeout(
+                            deadline,
+                            wait_for_capacity_or_disconnect(&state.capacity_notify, &conn_handle),
+                        )
+                        .await
+                        {
+                            res?;
+                        }
+                    }
+                    None => {
+                        wait_for_capacity_or_disconnect(&state.capacity_notify, &conn_handle)
+                            .await?;
+                    }
+                }
 
                 if state.draining.load(Ordering::Relaxed) {
                     state.metrics.inc_errors();

--- a/src/router.rs
+++ b/src/router.rs
@@ -247,11 +247,13 @@ async fn attempt_peer_forward(
     // Pass through streaming successful responses without buffering. A 5xx
     // never opens a stream because the peer commits to its response shape
     // before opening one — error responses are always non-streaming JSON.
-    // The status is recorded at stream handoff; for non-streaming responses
-    // recording waits until the body is buffered, so a body-read failure is
-    // recorded as the probe's failure rather than a premature success.
+    // Streaming successes are recorded WITHOUT the probe ticket: only the
+    // headers have arrived, the stream can still fail mid-body, and a stream
+    // failure is never recorded — so headers alone must not drive a
+    // recovering circuit toward closed. Recovery is carried by non-streaming
+    // probes and the gossip prober instead.
     if response_streaming && status.is_success() {
-        record_peer_status(state, peer_id, status, probe_ticket).await;
+        record_peer_status(state, peer_id, status, false).await;
         return ForwardOutcome::StreamingSurface(resp);
     }
 
@@ -696,7 +698,31 @@ pub async fn route_request(
                         model = %model_to_use,
                         "All peers advertising model are currently unavailable, waiting for cluster capacity"
                     );
-                    wait_for_capacity_or_disconnect(&state.capacity_notify, &conn_handle).await?;
+                    // During a probe-denial episode (the excluded recovering
+                    // peer may be the only one advertising the model) the
+                    // probe slot frees by time passing, so bound the wait by
+                    // the probe deadline instead of relying on a Notify.
+                    if last_probe_denied.is_some() {
+                        let probe_deadline = Duration::from_millis(
+                            state
+                                .config
+                                .cluster
+                                .circuit_breaker
+                                .half_open_probe_interval_ms
+                                .max(250),
+                        );
+                        if let Ok(res) = tokio::time::timeout(
+                            probe_deadline,
+                            wait_for_capacity_or_disconnect(&state.capacity_notify, &conn_handle),
+                        )
+                        .await
+                        {
+                            res?;
+                        }
+                    } else {
+                        wait_for_capacity_or_disconnect(&state.capacity_notify, &conn_handle)
+                            .await?;
+                    }
                     continue;
                 };
 
@@ -1177,7 +1203,16 @@ pub async fn route_request(
                                         PeerResponse::Http(resp) => resp.status(),
                                         PeerResponse::Noise { status, .. } => *status,
                                     };
-                                    record_peer_status(&state, &peer.node_id, status, probe_ticket)
+                                    // Successes are recorded without the
+                                    // probe ticket here: the body has not
+                                    // been read yet (it streams to the
+                                    // client below), so headers alone must
+                                    // not drive recovery. Failure statuses
+                                    // keep the ticket so a failed probe
+                                    // escalates the block window.
+                                    let attribution =
+                                        probe_ticket && peer_status_is_failure(status);
+                                    record_peer_status(&state, &peer.node_id, status, attribution)
                                         .await;
 
                                     let tokens_counter = Arc::new(AtomicU64::new(0));
@@ -1523,7 +1558,30 @@ pub async fn route_request(
                         model = %model_name,
                         "No node available during retry, waiting for cluster capacity"
                     );
-                    wait_for_capacity_or_disconnect(&state.capacity_notify, &conn_handle).await?;
+                    // During a probe-denial episode the excluded recovering
+                    // peer may be the only candidate; its probe slot frees by
+                    // time passing, so bound the wait by the probe deadline.
+                    if last_probe_denied.is_some() {
+                        let probe_deadline = Duration::from_millis(
+                            state
+                                .config
+                                .cluster
+                                .circuit_breaker
+                                .half_open_probe_interval_ms
+                                .max(250),
+                        );
+                        if let Ok(res) = tokio::time::timeout(
+                            probe_deadline,
+                            wait_for_capacity_or_disconnect(&state.capacity_notify, &conn_handle),
+                        )
+                        .await
+                        {
+                            res?;
+                        }
+                    } else {
+                        wait_for_capacity_or_disconnect(&state.capacity_notify, &conn_handle)
+                            .await?;
+                    }
                 };
             }
         }

--- a/src/router.rs
+++ b/src/router.rs
@@ -132,8 +132,12 @@ fn peer_status_is_failure(status: StatusCode) -> bool {
 async fn record_peer_status(state: &NodeState, peer_id: &str, status: StatusCode) {
     if peer_status_is_failure(status) {
         state.circuit_breaker.record_failure(peer_id).await;
-    } else {
-        state.circuit_breaker.record_success(peer_id).await;
+    } else if state.circuit_breaker.record_success(peer_id).await {
+        // The circuit just advanced toward recovery. Wake routing loops that
+        // parked on capacity_notify after filtering this peer out, so they
+        // retry (or send the next recovery probe) immediately instead of
+        // waiting for an unrelated capacity event.
+        state.capacity_notify.notify_waiters();
     }
 }
 
@@ -186,6 +190,10 @@ enum ForwardOutcome {
     /// Peer transport failed (network error, handshake, etc.). Caller should
     /// record a circuit-breaker failure and may retry.
     Transport(AppError),
+    /// The circuit breaker declined to admit this request: the peer's
+    /// circuit is recovering and the probe slot for this interval is taken.
+    /// Not a peer failure — the caller should wait for capacity and retry.
+    ProbeDenied,
 }
 
 /// Forward a request to a peer and classify the outcome. Buffers non-streaming
@@ -198,6 +206,12 @@ async fn attempt_peer_forward(
     response_streaming: bool,
 ) -> ForwardOutcome {
     let peer_id = request.peer_id;
+    // Circuit-breaker admission happens here, at the commit point, rather
+    // than during candidate filtering: filtering scans peers that are never
+    // dispatched to, and must not burn a recovering peer's probe slot.
+    if !state.circuit_breaker.try_claim_dispatch_sync(peer_id) {
+        return ForwardOutcome::ProbeDenied;
+    }
     let resp = match send_peer_request(state, request).await {
         Ok(resp) => resp,
         Err(e) => return ForwardOutcome::Transport(e),
@@ -722,6 +736,16 @@ pub async fn route_request(
                             peer = %peer.node_id,
                             reason = %reason,
                             "Peer reported saturation, waiting for cluster capacity"
+                        );
+                        drop(peer_forward_guard);
+                        wait_for_capacity_or_disconnect(&state.capacity_notify, &conn_handle).await?;
+                        continue;
+                    }
+                    ForwardOutcome::ProbeDenied => {
+                        tracing::debug!(
+                            event = "forward_probe_denied",
+                            peer = %peer.node_id,
+                            "Peer circuit recovering and probe slot taken; waiting to retry"
                         );
                         drop(peer_forward_guard);
                         wait_for_capacity_or_disconnect(&state.capacity_notify, &conn_handle).await?;
@@ -1278,6 +1302,14 @@ pub async fn route_request(
                             peer = %current_node.node_id,
                             reason = %reason,
                             "Peer reported saturation, waiting for cluster capacity"
+                        );
+                        drop(peer_forward_guard);
+                    }
+                    ForwardOutcome::ProbeDenied => {
+                        tracing::debug!(
+                            event = "forward_probe_denied",
+                            peer = %current_node.node_id,
+                            "Peer circuit recovering and probe slot taken; waiting to retry"
                         );
                         drop(peer_forward_guard);
                     }

--- a/src/router.rs
+++ b/src/router.rs
@@ -1064,7 +1064,29 @@ pub async fn route_request(
                     // If local spawning failed repeatedly, try forwarding to a peer
                     // before returning an error to the client.
                     if matches!(e, NodeError::SpawnFailuresExhausted) {
-                        if let Some(peer) = state.find_peer_for_model(&model_to_use).await {
+                        // Same circuit-breaker commit-point admission as
+                        // attempt_peer_forward: a recovering peer admits at
+                        // most one probe per interval, and this dispatch
+                        // bypasses attempt_peer_forward.
+                        let fallback_peer = match state.find_peer_for_model(&model_to_use).await {
+                            Some(peer)
+                                if state
+                                    .circuit_breaker
+                                    .try_claim_dispatch_sync(&peer.node_id) =>
+                            {
+                                Some(peer)
+                            }
+                            Some(peer) => {
+                                tracing::debug!(
+                                    event = "forward_probe_denied",
+                                    peer = %peer.node_id,
+                                    "Peer circuit recovering and probe slot taken; skipping spawn-failure fallback"
+                                );
+                                None
+                            }
+                            None => None,
+                        };
+                        if let Some(peer) = fallback_peer {
                             info!(
                                 event = "local_spawn_failed_peer_fallback",
                                 model = %model_name,


### PR DESCRIPTION
Fixes #79

## Problem

The circuit breaker's recovery state machine never runs in production. Open → HalfOpen → Closed transitions exist only in the async `should_allow()`, which has no production callers — the actual request-path gate is `should_allow_sync()` (peer-candidate filtering), which checks state under a read lock and performs no transitions. The blanket `#[allow(dead_code)]` on the impl hid this. Both nodes' full journal history contains zero "transitioning to half-open" / "closed after successful recovery" lines despite circuits opening in production.

Concretely:

- **An open circuit stops blocking after its first backoff window, permanently.** Nothing moves `last_state_change` forward again (`record_failure` while Open doesn't), so a still-down peer is retried by every routed request after the first window, and exponential backoff never escalates.
- **An opened circuit never closes.** `record_success` while Open was an explicit no-op (its "shouldn't happen" assumption only holds for the never-called async path), so the circuit stays `Open` in `proxy_circuit_breaker_state` indefinitely after the peer recovers, with `consecutive_opens` never reset.
- **The half-open "limited probes" contract was unimplemented** — both gates admitted every request.

## Fix

"Open with backoff elapsed" is the recovery probe phase, driven entirely by the paths production exercises:

- `should_allow_sync` admits at most one probe per `half_open_probe_interval_ms` (new config, default 1000ms, 0 disables gating). The probe stamp is an atomic on the per-peer circuit, so the read-lock-only gate can claim probes without write-lock contention — preserving the documented hot-path trade-off.
- `record_success` arriving in the probe phase transitions to HalfOpen (or directly to Closed when `success_threshold` is met), restoring full traffic and resetting the escalation counter.
- `record_failure` in the probe phase restarts the block window with escalated backoff — re-blocking a still-down peer, which previously never happened again.
- Results arriving while the backoff is still running are stale responses from requests sent before the circuit opened; they leave state unchanged (and are now covered by a test).
- The async `should_allow` gains the same probe gating, so both APIs agree on semantics.

## Changes

- `src/circuit_breaker.rs`: probe phase + gating as above; `PeerCircuit` gains `created`/`last_probe_ms`; new `half_open_probe_interval_ms` config field (`#[serde(default)]`).
- `config.example.yaml`, `SPEC.md`: document the new field.
- Tests: four new production-path tests (recovery through `should_allow_sync` + `record_*` alone; failed probe re-blocks with escalated backoff; stale in-window results change nothing; probe gating admits one per interval). All fourteen pre-existing circuit breaker tests pass unmodified.
- Version 1.11.1, CHANGELOG updated.

## Testing

- 371 unit tests pass (4 new), 8 integration tests pass, fmt/clippy clean.