### PR TITLE
docs: add SECURITY.md and CONTRIBUTING.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.2] - 2026-06-12
+
+### Documentation
+
+- Added `SECURITY.md` (security model summary, private vulnerability
+  reporting via GitHub, supported versions, scope) and `CONTRIBUTING.md`
+  (build and test instructions, quality gates, pull request and versioning
+  conventions, persistence-compatibility rules). README links both.
+  Private vulnerability reporting is enabled on the repository. (#81)
+
 ## [1.11.1] - 2026-06-12
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to llamesh
+
+Thanks for your interest in improving llamesh. This document covers the
+practical conventions the project follows.
+
+## Building and Testing
+
+Requirements: Rust 1.88+, CMake, a C/C++ compiler, and git.
+
+```bash
+cargo build --release
+
+# Unit tests (llamesh is a binary crate; there is no library target)
+cargo test --bin llamesh
+
+# Integration tests need the mock llama-server built first
+cargo build --release --bin mock_llama_server
+cargo test --test integration_test
+```
+
+## Quality Gates
+
+The tree is kept clean against all three of these — please make sure your
+change keeps them that way:
+
+```bash
+cargo fmt --check    # zero diffs
+cargo clippy         # zero warnings
+cargo test           # all tests pass
+```
+
+Any new warning or formatting diff is attributable to the change that
+introduced it.
+
+## Pull Requests
+
+- **Open a tracking issue first** describing the problem or proposal, and
+  close it from the PR (`Fixes #NNN`).
+- **One logical change per PR.** Unrelated cleanups belong in their own PR.
+- **Conventional commit titles**: `fix:`, `feat:`, `refactor:`, `docs:`,
+  with an optional scope (e.g. `fix(security):`).
+- **Version with the change**: bump `Cargo.toml` (SemVer — `fix:` is a
+  patch, `feat:` is a minor), include the regenerated `Cargo.lock`, and add
+  a dated release section to `CHANGELOG.md` (Keep a Changelog format) as
+  part of the PR, not after it.
+- **Tests accompany behavior changes.** Bug fixes include a test that fails
+  without the fix where practical. Concurrency changes deserve particular
+  scrutiny — the request path is lock-order sensitive (see the lock-ordering
+  documentation at the top of `src/node_state/mod.rs`).
+- Pull requests receive automated review feedback; please address findings
+  (or explain why they do not apply) before merge.
+
+## Persistence Compatibility
+
+New fields on persisted state (`node-metrics.json`, written by
+`src/metrics.rs`) must carry `#[serde(default)]` so snapshots written by
+older versions still load — a parse failure silently resets all persisted
+counters on upgrade.
+
+## Documentation
+
+`SPEC.md` is the technical specification; update it when behavior it
+describes changes. `config.example.yaml` and `cookbook.example.yaml` are the
+annotated configuration references; new configuration fields should appear
+there with comments and defaults.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.11.1"
+version = "1.11.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.11.1"
+version = "1.11.2"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -192,6 +192,14 @@ Use `__` (double underscore) for nested fields: `LLAMESH_CLUSTER__ENABLED=true`.
 - **[config.example.yaml](config.example.yaml)** — Annotated example configuration.
 - **[cookbook.example.yaml](cookbook.example.yaml)** — Annotated example cookbook with model definitions.
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for build instructions, quality gates, and pull request conventions.
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for the security model and how to report vulnerabilities privately.
+
 ## License
 
 Licensed under the [Apache License, Version 2.0](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release receives security fixes. llamesh moves quickly and
+upgrades are designed to be drop-in: counters and learned state persist
+across in-place upgrades, and configuration is backwards compatible within a
+major version.
+
+## Reporting a Vulnerability
+
+Please report vulnerabilities privately via GitHub's
+[private vulnerability reporting](https://github.com/michaelkrauty/llamesh/security/advisories/new)
+("Report a vulnerability" under the repository's **Security** tab). Do not
+open a public issue for security reports.
+
+Reports are triaged on a best-effort basis. A fix, advisory, or explanation
+of why the report is out of scope will follow as quickly as practical.
+
+## Security Model
+
+llamesh's threat model and security posture are described in detail in
+[SPEC.md](SPEC.md) (see *Security Model*). The short version:
+
+- **Client authentication is optional.** When `auth` is configured, API keys
+  are required on client-facing endpoints and compared in constant time.
+  Without it, anyone who can reach the listen address can use the API and
+  the admin endpoints — deploy on a trusted network or behind your own
+  authenticating proxy if you leave auth off.
+- **Inter-node traffic** is encrypted with the Noise Protocol by default
+  (Trust-On-First-Use key exchange; key files are created with mode 600),
+  and mTLS is available as an alternative.
+- **TLS** for client traffic is optional and configured per node.
+- llamesh spawns and supervises `llama-server` processes and builds
+  llama.cpp from source when `llama_cpp.enabled` is set; the build pipeline
+  fetches from the configured git remote. Pin `llama_cpp.branch` to a tag or
+  commit if you need reproducible, reviewable builds.
+
+## Out of Scope
+
+- Vulnerabilities in [llama.cpp](https://github.com/ggml-org/llama.cpp)
+  itself — report those upstream.
+- Deployments that expose an unauthenticated llamesh directly to untrusted
+  networks; authentication exists for that purpose.


### PR DESCRIPTION
Fixes #81

## Summary

Adds the two standard community-health documents and links them from the README:

- **SECURITY.md** — private reporting via GitHub's vulnerability reporting (enabled on the repository as part of this change), supported-versions policy, a fact-checked summary of the security model (optional constant-time API key auth, Noise-encrypted inter-node traffic with TOFU defaults, mode-600 key material, TLS options), a supply-chain note about the llama.cpp build pipeline with the pin-to-tag mitigation, and explicit out-of-scope items. Every claim was verified against the code (`security.rs` constant-time compare, `ClusterNoiseConfig` defaults, SPEC's key-file modes).
- **CONTRIBUTING.md** — build/test invocations including the binary-crate `cargo test --bin llamesh` gotcha and the mock-server prerequisite for integration tests; the zero-warning `fmt`/`clippy`/test gates; PR conventions the project already follows (tracking issue first, one logical change, conventional commits, SemVer bump + `Cargo.lock` + CHANGELOG section in the PR); the `#[serde(default)]` persistence-compatibility rule; and where documentation lives.

Version 1.11.2 (docs-only patch), CHANGELOG updated.

## Testing

Docs-only change: 373 unit tests and clean `fmt`/`clippy` confirmed unaffected.