### PR TITLE
fix: give every integration-test node a dedicated metrics file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.1] - 2026-06-12
+
+### Fixed
+
+- Every integration-test node now writes its metrics snapshot to a dedicated
+  `tests/metrics_<name>.json` file (removed before each run) instead of
+  inheriting the default `./node-metrics.json`. Test nodes were persisting
+  over each other's snapshots, over previous runs' state, and over the
+  metrics file of any production node running from the same checkout —
+  and loading that node's counters at startup. (#87)
+
 ## [1.13.0] - 2026-06-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.13.0"
+version = "1.13.1"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -89,6 +89,20 @@ pub async fn graceful_stop(child: &mut tokio::process::Child) {
     }
 }
 
+/// Dedicated per-node metrics file for a test, with leftovers from previous
+/// runs removed so persisted counters can't leak into metric assertions.
+/// Each spawned node's config must point `metrics_path` at the returned path
+/// (`./tests/metrics_<suffix>.json`): a unique file per node keeps test nodes
+/// from overwriting each other's snapshots — or the snapshot of a production
+/// node running from the same checkout, which is what the default
+/// `./node-metrics.json` would hit.
+pub async fn reset_metrics_file(root: &Path, suffix: &str) -> PathBuf {
+    let path = root.join(format!("tests/metrics_{suffix}.json"));
+    let _ = tokio::fs::remove_file(&path).await;
+    let _ = tokio::fs::remove_file(path.with_extension("tmp")).await;
+    path
+}
+
 pub async fn wait_for_ready(base_url: &str) -> bool {
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(1))

--- a/tests/fixtures/config_template.yaml
+++ b/tests/fixtures/config_template.yaml
@@ -9,6 +9,7 @@
 
 node_id: "{{NODE_ID}}"
 listen_addr: "{{LISTEN_ADDR}}"
+metrics_path: "./tests/metrics_{{NODE_ID}}.json"
 max_vram_mb: 1048576
 max_sysmem_mb: 1024
 default_model: "{{DEFAULT_MODEL}}"

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -16,6 +16,7 @@ async fn test_standalone_proxy() {
     let root = std::env::current_dir().unwrap();
     let mock_script = setup_mock_script(&root, "standalone").await;
     let config_path = root.join("tests/config_standalone.yaml");
+    common::reset_metrics_file(&root, "standalone").await;
     let cookbook_path = root.join("tests/cookbook_standalone.yaml");
     let proxy_bin = llamesh_binary(&root);
 
@@ -23,6 +24,7 @@ async fn test_standalone_proxy() {
         r#"
 node_id: "test-node"
 listen_addr: "127.0.0.1:9190"
+metrics_path: "./tests/metrics_standalone.json"
 max_vram_mb: 1048576
 max_sysmem_mb: 1024
 default_model: "mock-model:default"
@@ -128,8 +130,10 @@ async fn test_cluster_proxy() {
     let proxy_bin = llamesh_binary(&root);
 
     let config_a_path = root.join("tests/config_node_a.yaml");
+    common::reset_metrics_file(&root, "node_a").await;
     let cookbook_a_path = root.join("tests/cookbook_node_a.yaml");
     let config_b_path = root.join("tests/config_node_b.yaml");
+    common::reset_metrics_file(&root, "node_b").await;
     let cookbook_b_path = root.join("tests/cookbook_node_b.yaml");
 
     // Node A (9192) knows about Node B (9193)
@@ -137,6 +141,7 @@ async fn test_cluster_proxy() {
         r#"
 node_id: "node-a"
 listen_addr: "127.0.0.1:9192"
+metrics_path: "./tests/metrics_node_a.json"
 public_url: "http://127.0.0.1:9192"
 max_vram_mb: 1048576
 max_sysmem_mb: 1024
@@ -200,6 +205,7 @@ models:
         r#"
 node_id: "node-b"
 listen_addr: "127.0.0.1:9193"
+metrics_path: "./tests/metrics_node_b.json"
 public_url: "http://127.0.0.1:9193"
 max_vram_mb: 1048576
 max_sysmem_mb: 1024
@@ -325,6 +331,7 @@ async fn test_disabled_model() {
     let root = std::env::current_dir().unwrap();
     let mock_script = setup_mock_script(&root, "disabled").await;
     let config_path = root.join("tests/config_disabled.yaml");
+    common::reset_metrics_file(&root, "disabled").await;
     let cookbook_path = root.join("tests/cookbook_disabled.yaml");
     let proxy_bin = llamesh_binary(&root);
 
@@ -332,6 +339,7 @@ async fn test_disabled_model() {
         r#"
 node_id: "test-node"
 listen_addr: "127.0.0.1:9094"
+metrics_path: "./tests/metrics_disabled.json"
 max_vram_mb: 1048576
 max_sysmem_mb: 1024
 default_model: "enabled-model:default"
@@ -490,6 +498,7 @@ async fn test_token_counting() {
     let root = std::env::current_dir().unwrap();
     let mock_script = setup_mock_script(&root, "tokens").await;
     let config_path = root.join("tests/config_tokens.yaml");
+    common::reset_metrics_file(&root, "tokens").await;
     let cookbook_path = root.join("tests/cookbook_tokens.yaml");
     let proxy_bin = llamesh_binary(&root);
 
@@ -497,6 +506,7 @@ async fn test_token_counting() {
         r#"
 node_id: "test-node"
 listen_addr: "127.0.0.1:9195"
+metrics_path: "./tests/metrics_tokens.json"
 max_vram_mb: 1048576
 max_sysmem_mb: 1024
 default_model: "mock-model:default"
@@ -664,6 +674,7 @@ async fn test_instance_auth() {
     let root = std::env::current_dir().unwrap();
     let mock_script = setup_mock_script(&root, "auth").await;
     let config_path = root.join("tests/config_auth.yaml");
+    common::reset_metrics_file(&root, "auth").await;
     let cookbook_path = root.join("tests/cookbook_auth.yaml");
     let proxy_bin = llamesh_binary(&root);
 
@@ -671,6 +682,7 @@ async fn test_instance_auth() {
         r#"
 node_id: "test-node"
 listen_addr: "127.0.0.1:9197"
+metrics_path: "./tests/metrics_auth.json"
 max_vram_mb: 1048576
 max_sysmem_mb: 1024
 default_model: "auth-model:default"
@@ -771,6 +783,7 @@ async fn test_crash_recovery() {
     let root = std::env::current_dir().unwrap();
     let mock_script = setup_mock_script(&root, "crash").await;
     let config_path = root.join("tests/config_crash.yaml");
+    common::reset_metrics_file(&root, "crash").await;
     let cookbook_path = root.join("tests/cookbook_crash.yaml");
     let proxy_bin = llamesh_binary(&root);
 
@@ -778,6 +791,7 @@ async fn test_crash_recovery() {
         r#"
 node_id: "test-node"
 listen_addr: "127.0.0.1:9198"
+metrics_path: "./tests/metrics_crash.json"
 max_vram_mb: 1048576
 max_sysmem_mb: 1024
 default_model: "crash-model:default"
@@ -915,6 +929,7 @@ async fn test_queueing() {
     let root = std::env::current_dir().unwrap();
     let mock_script = setup_mock_script(&root, "queue").await;
     let config_path = root.join("tests/config_queue.yaml");
+    common::reset_metrics_file(&root, "queue").await;
     let cookbook_path = root.join("tests/cookbook_queue.yaml");
     let proxy_bin = llamesh_binary(&root);
 
@@ -922,6 +937,7 @@ async fn test_queueing() {
         r#"
 node_id: "test-node"
 listen_addr: "127.0.0.1:9199"
+metrics_path: "./tests/metrics_queue.json"
 max_vram_mb: 1048576
 max_sysmem_mb: 1024
 default_model: "queue-model:default"
@@ -1065,6 +1081,7 @@ async fn test_hop_counter_validation() {
     let root = std::env::current_dir().unwrap();
     let mock_script = setup_mock_script(&root, "hops").await;
     let config_path = root.join("tests/config_hops.yaml");
+    common::reset_metrics_file(&root, "hops").await;
     let cookbook_path = root.join("tests/cookbook_hops.yaml");
     let proxy_bin = llamesh_binary(&root);
 
@@ -1072,6 +1089,7 @@ async fn test_hop_counter_validation() {
         r#"
 node_id: "test-node-hops"
 listen_addr: "127.0.0.1:9201"
+metrics_path: "./tests/metrics_hops.json"
 max_vram_mb: 1048576
 max_sysmem_mb: 1024
 default_model: "mock-model:default"

--- a/tests/integration_test_admin_auth.rs
+++ b/tests/integration_test_admin_auth.rs
@@ -11,6 +11,7 @@ async fn test_admin_auth() {
     let root = std::env::current_dir().unwrap();
     let mock_script = setup_mock_script(&root, "admin_auth").await;
     let config_path = root.join("tests/config_admin_auth.yaml");
+    common::reset_metrics_file(&root, "admin_auth").await;
     let cookbook_path = root.join("tests/cookbook_admin_auth.yaml");
     let proxy_bin = llamesh_binary(&root);
 
@@ -18,6 +19,7 @@ async fn test_admin_auth() {
         r#"
 node_id: "test-node"
 listen_addr: "127.0.0.1:9200"
+metrics_path: "./tests/metrics_admin_auth.json"
 max_vram_mb: 1048576
 max_sysmem_mb: 1024
 default_model: "mock-model:default"

--- a/tests/integration_test_cancellation.rs
+++ b/tests/integration_test_cancellation.rs
@@ -28,6 +28,7 @@ fn config_yaml(mock_script: &Path) -> String {
         r#"
 node_id: "{NODE_ID}"
 listen_addr: "{LISTEN_ADDR}"
+metrics_path: "./tests/metrics_cancellation.json"
 max_vram_mb: 1048576
 max_sysmem_mb: 1024
 default_model: "mock-model:default"
@@ -151,6 +152,7 @@ async fn cancelled_request_does_not_leak_in_flight_counter() {
     let root = std::env::current_dir().unwrap();
     let mock_script = setup_slow_body_mock_script(&root, "cancellation", 5000).await;
     let config_path = root.join("tests/config_cancellation.yaml");
+    common::reset_metrics_file(&root, "cancellation").await;
     let cookbook_path = root.join("tests/cookbook_cancellation.yaml");
     let proxy_bin = llamesh_binary(&root);
 

--- a/tests/integration_test_features.rs
+++ b/tests/integration_test_features.rs
@@ -14,6 +14,7 @@ async fn test_embeddings_and_rerank() {
     let root = std::env::current_dir().unwrap();
     let mock_script = setup_mock_script(&root, "features").await;
     let config_path = root.join("tests/config_features.yaml");
+    common::reset_metrics_file(&root, "features").await;
     let cookbook_path = root.join("tests/cookbook_features.yaml");
     let proxy_bin = llamesh_binary(&root);
 
@@ -21,6 +22,7 @@ async fn test_embeddings_and_rerank() {
         r#"
 node_id: "test-node"
 listen_addr: "127.0.0.1:9200"
+metrics_path: "./tests/metrics_features.json"
 max_vram_mb: 1048576
 max_sysmem_mb: 1024
 default_model: "embedding-model:default"

--- a/tests/integration_test_h2c.rs
+++ b/tests/integration_test_h2c.rs
@@ -46,12 +46,14 @@ async fn write_watchdog_fixtures(
 ) -> (std::path::PathBuf, std::path::PathBuf, std::path::PathBuf) {
     let mock_script = setup_mock_script(root, suffix).await;
     let config_path = root.join(format!("tests/config_{suffix}.yaml"));
+    common::reset_metrics_file(root, suffix).await;
     let cookbook_path = root.join(format!("tests/cookbook_{suffix}.yaml"));
 
     let config_content = format!(
         r#"
 node_id: "test-node-{suffix}"
 listen_addr: "127.0.0.1:{listen_port}"
+metrics_path: "./tests/metrics_{suffix}.json"
 max_vram_mb: 1048576
 max_sysmem_mb: 1024
 default_model: "mock-model:default"
@@ -248,6 +250,7 @@ async fn test_h2c_prior_knowledge() {
     let root = std::env::current_dir().unwrap();
     let mock_script = setup_mock_script(&root, "h2c").await;
     let config_path = root.join("tests/config_h2c.yaml");
+    common::reset_metrics_file(&root, "h2c").await;
     let cookbook_path = root.join("tests/cookbook_h2c.yaml");
     let proxy_bin = llamesh_binary(&root);
 
@@ -255,6 +258,7 @@ async fn test_h2c_prior_knowledge() {
         r#"
 node_id: "test-node-h2c"
 listen_addr: "127.0.0.1:9202"
+metrics_path: "./tests/metrics_h2c.json"
 max_vram_mb: 1048576
 max_sysmem_mb: 1024
 default_model: "mock-model:default"

--- a/tests/integration_test_peer_forward_cancellation.rs
+++ b/tests/integration_test_peer_forward_cancellation.rs
@@ -48,6 +48,7 @@ fn config_node(
         r#"
 node_id: "{node_id}"
 listen_addr: "{listen}"
+metrics_path: "./tests/metrics_{node_id}.json"
 public_url: "http://{listen}"
 max_vram_mb: 1048576
 max_sysmem_mb: 1024
@@ -205,6 +206,8 @@ async fn cancelled_peer_forward_does_not_leak_current_requests() {
     let mock_script = setup_mock_script(&root, "peer_fwd_cancel").await;
 
     let config_a_path = root.join("tests/config_peer_fwd_cancel_a.yaml");
+    common::reset_metrics_file(&root, "node-a-cancel").await;
+    common::reset_metrics_file(&root, "node-b-cancel").await;
     let cookbook_a_path = root.join("tests/cookbook_peer_fwd_cancel_a.yaml");
     let config_b_path = root.join("tests/config_peer_fwd_cancel_b.yaml");
     let cookbook_b_path = root.join("tests/cookbook_peer_fwd_cancel_b.yaml");
@@ -359,6 +362,8 @@ async fn cancelled_peer_forward_during_noise_body_buffer_does_not_leak_current_r
     let mock_script = setup_slow_body_mock_script(&root, "peer_fwd_body_cancel", 5000).await;
 
     let config_a_path = root.join("tests/config_peer_fwd_body_cancel_a.yaml");
+    common::reset_metrics_file(&root, "node-a-body-cancel").await;
+    common::reset_metrics_file(&root, "node-b-body-cancel").await;
     let cookbook_a_path = root.join("tests/cookbook_peer_fwd_body_cancel_a.yaml");
     let config_b_path = root.join("tests/config_peer_fwd_body_cancel_b.yaml");
     let cookbook_b_path = root.join("tests/cookbook_peer_fwd_body_cancel_b.yaml");

--- a/tests/integration_test_reload_eviction.rs
+++ b/tests/integration_test_reload_eviction.rs
@@ -20,6 +20,7 @@ fn config_yaml(mock_script: &std::path::Path) -> String {
         r#"
 node_id: "test-reload-drain"
 listen_addr: "{}"
+metrics_path: "./tests/metrics_reload_eviction.json"
 max_vram_mb: 1048576
 max_sysmem_mb: 1024
 default_model: "mock-model:default"
@@ -274,6 +275,7 @@ async fn reload_drains_orphaned_instances() {
     let root = std::env::current_dir().unwrap();
     let mock_script = setup_mock_script(&root, "reload_eviction").await;
     let config_path = root.join("tests/config_reload_eviction.yaml");
+    common::reset_metrics_file(&root, "reload_eviction").await;
     let cookbook_path = root.join("tests/cookbook_reload_eviction.yaml");
     let proxy_bin = llamesh_binary(&root);
 

--- a/tests/loop_prevention_test.rs
+++ b/tests/loop_prevention_test.rs
@@ -13,6 +13,7 @@ async fn start_mock_node(suffix: &str, port_offset: u16) -> (tokio::process::Chi
     let root = std::env::current_dir().unwrap();
     let mock_script = setup_mock_script(&root, &id).await;
     let config_path = root.join(format!("tests/config_{id}.yaml"));
+    common::reset_metrics_file(&root, &id).await;
     let cookbook_path = root.join(format!("tests/cookbook_{id}.yaml"));
     let proxy_bin = llamesh_binary(&root);
 
@@ -20,6 +21,7 @@ async fn start_mock_node(suffix: &str, port_offset: u16) -> (tokio::process::Chi
         r#"
 node_id: "{}"
 listen_addr: "{}"
+metrics_path: "./tests/metrics_{}.json"
 max_vram_mb: 1048576
 max_sysmem_mb: 1024
 default_model: "mock-model:default"
@@ -52,6 +54,7 @@ http:
 "#,
         id,
         listen,
+        id,
         15000 + port_offset,
         15009 + port_offset,
         mock_script.display()

--- a/tests/stress_test.rs
+++ b/tests/stress_test.rs
@@ -43,6 +43,7 @@ async fn test_stress_basic() {
     let root = std::env::current_dir().unwrap();
     let mock_script = setup_mock_script(&root, "stress").await;
     let config_path = root.join("tests/config_stress.yaml");
+    common::reset_metrics_file(&root, "stress").await;
     let cookbook_path = root.join("tests/cookbook_stress.yaml");
     let proxy_bin = llamesh_binary(&root);
 
@@ -50,6 +51,7 @@ async fn test_stress_basic() {
         r#"
 node_id: "stress-node"
 listen_addr: "127.0.0.1:9096"
+metrics_path: "./tests/metrics_stress.json"
 max_vram_mb: 1048576
 max_sysmem_mb: 8192
 default_model: "stress-model:default"


### PR DESCRIPTION
Fixes #87

## Summary

Integration test configs never set `metrics_path`, so every spawned test node inherited the default `./node-metrics.json` relative to the working directory. The background persistence loop writes that file every 10 seconds — and since v1.13.0, immediately whenever an instance becomes ready — so test nodes were persisting over each other's snapshots, over previous runs' state, and over the metrics file of any production node running from the same checkout. They also *loaded* whatever that file contained at startup, so test assertions were implicitly depending on the foreign file not colliding with mock-model hashes.

Every node config across the suite (21 spawned nodes over 10 test files, plus the config template fixture) now points `metrics_path` at a dedicated `tests/metrics_<name>.json`, unique per spawned node — multi-node tests key the filename on the node id. A shared `reset_metrics_file` helper removes the file and its `.tmp` sibling before each run, which is load-bearing: with persistent dedicated files, the token-accounting tests would otherwise see accumulated totals on a second run.

The `tests/metrics_*.json` pattern was already gitignored by #86, which fixed this for the one test it added; this completes the migration for the rest of the suite.

## Testing

- Full suite run twice back to back with identical results — the second run proves no persisted state leaks into metric assertions.
- Verified every spawned node's snapshot lands in `tests/metrics_*.json` (17 distinct files after a full run) and none in `./node-metrics.json`.
- `cargo fmt --check` and `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)