### PR TITLE
feat: mirror queue-wait and operational counters in the JSON metrics snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.0] - 2026-06-13
+
+### Added
+
+- The JSON metrics snapshot (`/metrics/json` and the persisted
+  `node-metrics.json`) now mirrors five counters that were previously exposed
+  only by the Prometheus `/metrics` endpoint: `queue_pending_tokens`,
+  `queue_wait_total_ms`, `queue_wait_count`, `token_counting_disabled_total`,
+  and `skipped_stream_cleanups_total`. Tooling and dashboards that read the
+  JSON endpoint can now observe queue-wait latency (mean wait =
+  `queue_wait_total_ms / queue_wait_count`), pending slot reservations, and the
+  two operational health counters without scraping Prometheus. The values are
+  mirrored for observability and — like `queue_length` and their Prometheus
+  counterparts — start fresh on restart rather than being restored on load, so
+  `/metrics/json` reports the same values as `/metrics` at every moment. Each
+  new field is `#[serde(default)]`, so older snapshots remain loadable and the
+  durable counters (`requests_total`, `errors_total`, `queue_drops_*`) are
+  unaffected.
+
 ## [1.13.3] - 2026-06-13
 
 ### Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.13.3"
+version = "1.14.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.13.3"
+version = "1.14.0"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -230,6 +230,35 @@ pub struct MetricsSnapshot {
     pub queue_drops_timeout: u64,
     #[serde(default)]
     pub queue_drops_global_limit: u64,
+    /// In-flight queue tokens (pending slot reservations awaiting a notified
+    /// waiter). Runtime gauge mirrored here so `/metrics/json` matches the
+    /// Prometheus `proxy_queue_pending_tokens`; like `queue_length` it starts
+    /// fresh on restart and is not restored on load. `#[serde(default)]` keeps
+    /// snapshots written by older versions loadable.
+    #[serde(default)]
+    pub queue_pending_tokens: u64,
+    /// Cumulative queue wait time (ms) and the number of requests that waited;
+    /// together they give the mean queue wait (`queue_wait_total_ms /
+    /// queue_wait_count`). Mirrored so `/metrics/json` matches the Prometheus
+    /// `proxy_queue_wait_total_ms` / `proxy_queue_wait_count`. Like those
+    /// counters they start fresh on restart, so they are serialized for
+    /// observability but not restored on load. `#[serde(default)]` keeps older
+    /// snapshots loadable.
+    #[serde(default)]
+    pub queue_wait_total_ms: u64,
+    #[serde(default)]
+    pub queue_wait_count: u64,
+    /// Times token counting was disabled for a response (token usage
+    /// unavailable) and stream cleanups skipped during shutdown. Process-global
+    /// counters mirrored so `/metrics/json` matches the Prometheus
+    /// `proxy_token_counting_disabled_total` /
+    /// `proxy_skipped_stream_cleanups_total`; they reset on restart like their
+    /// Prometheus counterparts. `#[serde(default)]` keeps older snapshots
+    /// loadable.
+    #[serde(default)]
+    pub token_counting_disabled_total: u64,
+    #[serde(default)]
+    pub skipped_stream_cleanups_total: u64,
     pub hashes: HashMap<String, HashMetricsSnapshot>,
     pub updated_at: String,
     #[serde(default)]
@@ -570,6 +599,13 @@ impl Metrics {
             queue_drops_full: self.queue_drops_full.load(Ordering::Relaxed),
             queue_drops_timeout: self.queue_drops_timeout.load(Ordering::Relaxed),
             queue_drops_global_limit: self.queue_drops_global_limit.load(Ordering::Relaxed),
+            queue_pending_tokens: self.queue_pending_tokens.load(Ordering::Relaxed),
+            queue_wait_total_ms: self.queue_wait_total_ms.load(Ordering::Relaxed),
+            queue_wait_count: self.queue_wait_count.load(Ordering::Relaxed),
+            token_counting_disabled_total: crate::router::TOKEN_COUNTING_DISABLED
+                .load(Ordering::Relaxed),
+            skipped_stream_cleanups_total: crate::router::SKIPPED_STREAM_CLEANUPS
+                .load(Ordering::Relaxed),
             hashes,
             updated_at: chrono::Utc::now().to_rfc3339(),
             is_building: build_status
@@ -1100,6 +1136,14 @@ mod tests {
         assert_eq!(snapshot.queue_drops_full, 0);
         assert_eq!(snapshot.queue_drops_timeout, 0);
         assert_eq!(snapshot.queue_drops_global_limit, 0);
+        // Parity metrics added in 1.14.0 also default when absent, so an
+        // in-place upgrade from an older snapshot stays loadable instead of
+        // resetting every counter via the parse-error fallback.
+        assert_eq!(snapshot.queue_pending_tokens, 0);
+        assert_eq!(snapshot.queue_wait_total_ms, 0);
+        assert_eq!(snapshot.queue_wait_count, 0);
+        assert_eq!(snapshot.token_counting_disabled_total, 0);
+        assert_eq!(snapshot.skipped_stream_cleanups_total, 0);
     }
 
     #[tokio::test]
@@ -1124,6 +1168,62 @@ mod tests {
         assert_eq!(restored.queue_drops_timeout.load(Ordering::Relaxed), 2);
         assert_eq!(restored.queue_drops_global_limit.load(Ordering::Relaxed), 1);
         assert_eq!(restored.queue_length.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn queue_wait_and_pending_metrics_surface_in_snapshot() {
+        // queue_pending_tokens, queue_wait_total_ms and queue_wait_count are
+        // exposed by Prometheus; the JSON snapshot must surface the same values
+        // so `/metrics/json` reaches parity with `/metrics`.
+        let metrics = Metrics::new();
+        metrics.inc_pending_tokens();
+        metrics.inc_pending_tokens();
+        metrics.observe_queue_wait(120);
+        metrics.observe_queue_wait(80);
+
+        let snapshot = metrics.snapshot("n".into(), "v".into(), None).await;
+        assert_eq!(snapshot.queue_pending_tokens, 2);
+        assert_eq!(snapshot.queue_wait_total_ms, 200);
+        assert_eq!(snapshot.queue_wait_count, 2);
+
+        // These are runtime metrics mirrored for observability, not durable
+        // counters: like queue_length they start fresh after a restart.
+        let restored = Metrics::from_snapshot(snapshot);
+        assert_eq!(restored.queue_pending_tokens.load(Ordering::Relaxed), 0);
+        assert_eq!(restored.queue_wait_total_ms.load(Ordering::Relaxed), 0);
+        assert_eq!(restored.queue_wait_count.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn parity_metrics_deserialize_from_snapshot_json() {
+        // A snapshot carrying the parity metrics (added 1.14.0) deserializes
+        // them, including the two process-global counters
+        // (token_counting_disabled_total, skipped_stream_cleanups_total) that
+        // the JSON mirrors from Prometheus rather than from the Metrics struct.
+        let json = r#"{
+            "node_id": "n",
+            "llama_cpp_version": "abc",
+            "requests_total": 5,
+            "errors_total": 1,
+            "current_requests": 0,
+            "queue_pending_tokens": 3,
+            "queue_wait_total_ms": 450,
+            "queue_wait_count": 9,
+            "token_counting_disabled_total": 4,
+            "skipped_stream_cleanups_total": 2,
+            "hashes": {},
+            "updated_at": "2026-06-13T00:00:00Z"
+        }"#;
+        let snapshot: MetricsSnapshot =
+            serde_json::from_str(json).expect("snapshot with parity metrics must deserialize");
+        assert_eq!(snapshot.queue_pending_tokens, 3);
+        assert_eq!(snapshot.queue_wait_total_ms, 450);
+        assert_eq!(snapshot.queue_wait_count, 9);
+        assert_eq!(snapshot.token_counting_disabled_total, 4);
+        assert_eq!(snapshot.skipped_stream_cleanups_total, 2);
+        // Unrelated persisted counters still load alongside the new fields.
+        assert_eq!(snapshot.requests_total, 5);
+        assert_eq!(snapshot.errors_total, 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

The Prometheus `/metrics` endpoint exposes five counters that the JSON metrics snapshot served at `/metrics/json` (and persisted to `node-metrics.json`) did not carry, so tooling and dashboards that read the JSON endpoint were blind to queue-wait latency and the operational health counters. This adds them to `MetricsSnapshot` so the two endpoints report the same values.

The mirrored fields are `queue_pending_tokens`, `queue_wait_total_ms`, `queue_wait_count`, `token_counting_disabled_total`, and `skipped_stream_cleanups_total`. JSON consumers can now compute mean queue wait as `queue_wait_total_ms / queue_wait_count` and watch pending slot reservations and the two health counters without scraping Prometheus.

## Design

All five metrics already start fresh on each restart: the two operational counters are process-global statics in `router.rs`, and the queue metrics are not restored by `from_snapshot`. They are therefore mirrored for observability only — serialized in `snapshot()` but not restored on load — so `/metrics/json` reports exactly what `/metrics` reports at every moment, and the restore path that the durable counters depend on is left untouched. Each new field is `#[serde(default)]`, so a snapshot written by an older release still loads and the durable counters (`requests_total`, `errors_total`, `queue_drops_*`) are never reset by a missing field.

## Testing

- `cargo fmt --check` and `cargo clippy --bin llamesh --release` are clean (zero warnings)
- `cargo test --bin llamesh` — 384 unit tests pass, including three new/extended metrics tests:
  - `queue_wait_and_pending_metrics_surface_in_snapshot` — live counters surface through `snapshot()` and reset on load
  - `parity_metrics_deserialize_from_snapshot_json` — all five fields (including the two static-derived ones) deserialize from JSON alongside the durable counters
  - `snapshot_without_active_instances_field_still_loads` — extended to assert the new fields default to 0 when an older snapshot omits them
- Integration suites `integration_test` and `integration_test_admin_auth` pass

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)