### PR TITLE
feat: add GET /v1/models/{model} retrieve endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.0] - 2026-06-13
+
+### Added
+
+- `GET /v1/models/{model}` retrieves a single model by id, completing the
+  OpenAI "retrieve model" endpoint (used by SDK calls such as
+  `client.models.retrieve(...)`). It returns the same object shape as one entry
+  of `GET /v1/models` — including models advertised only by cluster peers — and
+  responds with `404 Not Found` and the standard error envelope (`type`
+  `model_not_found`) when no local profile or peer advertises the id. The
+  default profile is addressed by the bare model name, other profiles as
+  `model:profile`.
+
 ## [1.14.0] - 2026-06-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.14.0"
+version = "1.15.0"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Use `__` (double underscore) for nested fields: `LLAMESH_CLUSTER__ENABLED=true`.
 | `POST /v1/embeddings` | Embeddings (requires `--embedding` profile) |
 | `POST /v1/rerank` | Reranking (requires `--reranking` profile; aliases: `/v1/reranking`, `/rerank`) |
 | `GET /v1/models` | List available models |
+| `GET /v1/models/{model}` | Retrieve a single model |
 | `GET /healthz` | Health check (alias: `/health`) |
 | `GET /readyz` | Readiness check |
 | `GET /version` | Proxy version |

--- a/SPEC.md
+++ b/SPEC.md
@@ -600,6 +600,12 @@ Implementation notes:
 * For models advertised by cluster peers, metadata is `{ "source": "cluster", "advertised_by": "<peer_node_id>", "cluster_url": "<peer_url>" }`.
 * When in cluster mode, returns the union of models supported by the cluster.
 
+### Retrieve a Model
+
+**Endpoint:** `GET /v1/models/{model}`
+
+Returns the single model object — the same shape as one element of the `GET /v1/models` `data` array — whose `id` matches the path parameter. The default profile is addressed by the bare model name and any other profile as `model:profile`. The catalog searched is identical to `GET /v1/models`, so a model advertised only by a cluster peer is retrievable too. If no local profile or peer advertises the id, the response is `404 Not Found` with the standard error envelope (`type` `model_not_found`).
+
 ### Embeddings
 
 **Endpoint:** `POST /v1/embeddings`
@@ -660,6 +666,7 @@ Behavior:
 | `/v1/reranking` | POST | Reranking (alias) |
 | `/rerank` | POST | Reranking (bare path alias) |
 | `/v1/models` | GET | Model listing |
+| `/v1/models/{model}` | GET | Retrieve a single model |
 | `/healthz` | GET | Liveness probe |
 | `/health` | GET | Liveness probe (llama-server compatibility alias) |
 | `/readyz` | GET | Readiness probe |

--- a/src/api.rs
+++ b/src/api.rs
@@ -346,6 +346,7 @@ pub async fn start_server(config: NodeConfig, node_state: NodeState) -> anyhow::
         .route("/v1/reranking", post(router::route_request)) // Alias
         .route("/rerank", post(router::route_request)) // Alias
         .route("/v1/models", get(router::list_models))
+        .route("/v1/models/:model", get(router::get_model))
         .route("/cluster/gossip", post(cluster::handle_gossip))
         .with_state(state.clone());
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -346,7 +346,10 @@ pub async fn start_server(config: NodeConfig, node_state: NodeState) -> anyhow::
         .route("/v1/reranking", post(router::route_request)) // Alias
         .route("/rerank", post(router::route_request)) // Alias
         .route("/v1/models", get(router::list_models))
-        .route("/v1/models/:model", get(router::get_model))
+        // Catch-all (`*model`) rather than a single segment so model ids that
+        // contain `/` — which the cookbook permits — are retrievable, matching
+        // exactly what `/v1/models` advertises.
+        .route("/v1/models/*model", get(router::get_model))
         .route("/cluster/gossip", post(cluster::handle_gossip))
         .with_state(state.clone());
 

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -3,7 +3,7 @@ mod peer_state;
 mod port_pool;
 mod spawn_reservations;
 
-pub use model_index::{build_pre_args, get_args_hash_for_key, ModelIndex};
+pub use model_index::{args_hash_for_profile, build_pre_args, get_args_hash_for_key, ModelIndex};
 pub use peer_state::{PeerModelStats, PeerState};
 pub use port_pool::PortPool;
 pub use spawn_reservations::SpawnReservations;

--- a/src/node_state/model_index.rs
+++ b/src/node_state/model_index.rs
@@ -164,8 +164,17 @@ pub async fn get_args_hash_for_key(cookbook: &RwLock<Cookbook>, key: &str) -> Op
         .iter()
         .find(|p| p.enabled && p.id == profile_id)?;
 
+    Some(args_hash_for_profile(profile))
+}
+
+/// Compute the args-hash for a profile directly, without any cookbook lookup.
+/// Callers that already hold the profile — e.g. while iterating the cookbook
+/// under its read lock — use this to avoid re-locking the cookbook, which would
+/// be a nested read that tokio's write-preferring `RwLock` can deadlock against
+/// a queued writer (a cookbook hot-reload).
+pub fn args_hash_for_profile(profile: &Profile) -> String {
     let (pre_args, _, _) = build_pre_args(profile);
-    Some(compute_args_hash(&pre_args))
+    compute_args_hash(&pre_args)
 }
 
 #[cfg(test)]

--- a/src/router.rs
+++ b/src/router.rs
@@ -456,69 +456,95 @@ async fn collect_models(state: &NodeState) -> Vec<Value> {
     // instances would currently be spawned from.
     let llama_cpp_version = state.current_llama_cpp_version().await;
 
-    let cookbook = state.cookbook.read().await;
-    for model in &cookbook.models {
-        if !model.enabled {
-            continue;
-        }
-        for profile in &model.profiles {
-            if !profile.enabled {
+    // Phase 1: snapshot the local catalog under the cookbook read lock,
+    // computing each profile's args_hash inline (we already hold the profile).
+    // The per-profile metric and instance lookups in phase 2 must not run while
+    // this guard is held — `get_args_hash_for_key` re-locks the cookbook, and
+    // tokio's write-preferring `RwLock` can deadlock that nested read against a
+    // queued hot-reload — so gather everything they need here and release first.
+    struct LocalProfile {
+        id: String,
+        model_name: String,
+        model_description: Option<String>,
+        profile_id: String,
+        profile_description: Option<String>,
+        idle_timeout_seconds: u64,
+        args_hash: String,
+    }
+    let local_profiles: Vec<LocalProfile> = {
+        let cookbook = state.cookbook.read().await;
+        let mut rows = Vec::new();
+        for model in &cookbook.models {
+            if !model.enabled {
                 continue;
             }
-            let is_default = profile.id == "default";
-            // Use bare model name for default profile, otherwise model:profile
-            let id = if is_default {
-                model.name.clone()
-            } else {
-                format!("{}:{}", model.name, profile.id)
-            };
-            let entry_id = id.clone();
-
-            // Look up metrics by args_hash
-            let (tps, persisted_params) =
-                if let Some(args_hash) = state.get_args_hash_for_key(&id).await {
-                    let hash_metrics = state.metrics.get_hash_metrics(&args_hash).await;
-                    (
-                        hash_metrics.tokens_per_second(),
-                        hash_metrics.get_parsed_params(llama_cpp_version.as_deref()),
-                    )
+            for profile in &model.profiles {
+                if !profile.enabled {
+                    continue;
+                }
+                let is_default = profile.id == "default";
+                // Use bare model name for default profile, otherwise model:profile
+                let id = if is_default {
+                    model.name.clone()
                 } else {
-                    (0.0, None)
+                    format!("{}:{}", model.name, profile.id)
                 };
-
-            // Parsed model params: prefer a running, still-current instance
-            // (freshest), fall back to the params persisted from the last
-            // instance startup.
-            let parsed_params = state
-                .get_parsed_params_for_model(&model.name, &profile.id, llama_cpp_version.as_deref())
-                .await
-                .or(persisted_params);
-
-            let metadata = json!({
-                "model": model.name.as_str(),
-                "model_description": model.description.as_deref(),
-                "profile_id": profile.id.as_str(),
-                "profile_description": profile.description.as_deref(),
-                "idle_timeout_seconds": profile.idle_timeout_seconds,
-                "estimated_tokens_per_second": tps,
-                "parsed_model_params": parsed_params,
-            });
-
-            let model_obj = json!({
-                "id": id,
-                "object": "model",
-                "created": current_time,
-                "owned_by": owned_by.as_str(),
-                "permission": [],
-                "root": model.name.as_str(),
-                "parent": null,
-                "metadata": metadata.clone(),
-            });
-            data.push(model_obj);
-            seen_ids.insert(entry_id);
+                rows.push(LocalProfile {
+                    id,
+                    model_name: model.name.clone(),
+                    model_description: model.description.clone(),
+                    profile_id: profile.id.clone(),
+                    profile_description: profile.description.clone(),
+                    idle_timeout_seconds: profile.idle_timeout_seconds,
+                    args_hash: crate::node_state::args_hash_for_profile(profile),
+                });
+            }
         }
+        rows
+    };
+
+    // Phase 2: the cookbook guard is released, so it is safe to take the metric
+    // and instance locks without risking the nested-read deadlock above.
+    for row in local_profiles {
+        // Look up metrics by args_hash
+        let hash_metrics = state.metrics.get_hash_metrics(&row.args_hash).await;
+        let tps = hash_metrics.tokens_per_second();
+        let persisted_params = hash_metrics.get_parsed_params(llama_cpp_version.as_deref());
+
+        // Parsed model params: prefer a running, still-current instance
+        // (freshest), fall back to the params persisted from the last
+        // instance startup.
+        let parsed_params = state
+            .get_parsed_params_for_model(
+                &row.model_name,
+                &row.profile_id,
+                llama_cpp_version.as_deref(),
+            )
+            .await
+            .or(persisted_params);
+
+        let metadata = json!({
+            "model": row.model_name.clone(),
+            "model_description": row.model_description,
+            "profile_id": row.profile_id,
+            "profile_description": row.profile_description,
+            "idle_timeout_seconds": row.idle_timeout_seconds,
+            "estimated_tokens_per_second": tps,
+            "parsed_model_params": parsed_params,
+        });
+
+        data.push(json!({
+            "id": row.id.clone(),
+            "object": "model",
+            "created": current_time,
+            "owned_by": owned_by.as_str(),
+            "permission": [],
+            "root": row.model_name,
+            "parent": null,
+            "metadata": metadata,
+        }));
+        seen_ids.insert(row.id);
     }
-    drop(cookbook);
 
     if state.config.cluster.enabled {
         let peers = state.peers.read().await;
@@ -561,10 +587,12 @@ pub async fn list_models(
     })))
 }
 
-/// `GET /v1/models/:model` — the OpenAI "retrieve model" endpoint. Returns the
+/// `GET /v1/models/{model}` — the OpenAI "retrieve model" endpoint. Returns the
 /// single model object whose `id` matches, or 404 if this node neither serves
 /// the model nor sees a peer advertising it. The match is exact on the
 /// advertised id, so a non-default profile must be requested as `model:profile`.
+/// Registered as a catch-all so ids containing `/` resolve to the same object
+/// `/v1/models` lists.
 pub async fn get_model(
     State(state): State<Arc<NodeState>>,
     Path(model): Path<String>,
@@ -573,9 +601,12 @@ pub async fn get_model(
     crate::security::check_api_key_auth(state.config.auth.as_ref(), &headers)
         .map_err(AppError::authentication_error)?;
 
+    // A catch-all capture can carry a leading slash; strip it so the match is
+    // exact against the advertised id (which never starts with `/`).
+    let model = model.trim_start_matches('/');
     let data = collect_models(&state).await;
     data.into_iter()
-        .find(|m| m.get("id").and_then(|v| v.as_str()) == Some(model.as_str()))
+        .find(|m| m.get("id").and_then(|v| v.as_str()) == Some(model))
         .map(Json)
         .ok_or_else(|| {
             AppError::model_not_found(format!(

--- a/src/router.rs
+++ b/src/router.rs
@@ -5,7 +5,7 @@ use crate::instance::Instance;
 use crate::node_state::{NodeError, NodeState};
 use axum::{
     body::Body,
-    extract::State,
+    extract::{Path, State},
     http::{header::RETRY_AFTER, HeaderMap, HeaderValue, Method, Request, Response, StatusCode},
     response::IntoResponse,
     response::Json,
@@ -438,13 +438,11 @@ async fn send_peer_request(
     }
 }
 
-pub async fn list_models(
-    State(state): State<Arc<NodeState>>,
-    headers: HeaderMap,
-) -> Result<Json<Value>, AppError> {
-    crate::security::check_api_key_auth(state.config.auth.as_ref(), &headers)
-        .map_err(AppError::authentication_error)?;
-
+/// Build the OpenAI-style model objects this node advertises: every enabled
+/// local `model:profile`, plus any models advertised by cluster peers. Shared by
+/// `list_models` (`GET /v1/models`) and `get_model` (`GET /v1/models/:model`) so
+/// the two endpoints never disagree on the catalog.
+async fn collect_models(state: &NodeState) -> Vec<Value> {
     let mut data = Vec::new();
     let current_time = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -546,10 +544,45 @@ pub async fn list_models(
         }
     }
 
+    data
+}
+
+pub async fn list_models(
+    State(state): State<Arc<NodeState>>,
+    headers: HeaderMap,
+) -> Result<Json<Value>, AppError> {
+    crate::security::check_api_key_auth(state.config.auth.as_ref(), &headers)
+        .map_err(AppError::authentication_error)?;
+
+    let data = collect_models(&state).await;
     Ok(Json(json!({
         "object": "list",
         "data": data
     })))
+}
+
+/// `GET /v1/models/:model` — the OpenAI "retrieve model" endpoint. Returns the
+/// single model object whose `id` matches, or 404 if this node neither serves
+/// the model nor sees a peer advertising it. The match is exact on the
+/// advertised id, so a non-default profile must be requested as `model:profile`.
+pub async fn get_model(
+    State(state): State<Arc<NodeState>>,
+    Path(model): Path<String>,
+    headers: HeaderMap,
+) -> Result<Json<Value>, AppError> {
+    crate::security::check_api_key_auth(state.config.auth.as_ref(), &headers)
+        .map_err(AppError::authentication_error)?;
+
+    let data = collect_models(&state).await;
+    data.into_iter()
+        .find(|m| m.get("id").and_then(|v| v.as_str()) == Some(model.as_str()))
+        .map(Json)
+        .ok_or_else(|| {
+            AppError::model_not_found(format!(
+                "Model '{model}' not found in local cookbook or any peer"
+            ))
+            .with_param("model")
+        })
 }
 
 pub async fn route_request(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -72,6 +72,14 @@ models:
         idle_timeout_seconds: 5
         max_instances: 1
         llama_server_args: ""
+  - name: "vendor/slashed-model"
+    description: "Model whose id contains a slash"
+    profiles:
+      - id: "default"
+        model_path: "./models/mock.gguf"
+        idle_timeout_seconds: 5
+        max_instances: 1
+        llama_server_args: ""
 "#;
     tokio::fs::write(&cookbook_path, cookbook_content)
         .await
@@ -135,6 +143,17 @@ models:
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     let err: serde_json::Value = resp.json().await.unwrap();
     assert_eq!(err["error"]["type"], "model_not_found");
+
+    // A model id containing '/' must retrieve via the catch-all route, matching
+    // exactly what the listing advertises.
+    let resp = client
+        .get("http://127.0.0.1:9190/v1/models/vendor/slashed-model")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let model: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(model["id"], "vendor/slashed-model");
 
     let body = serde_json::json!({
         "model": "mock-model:default",

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -92,12 +92,49 @@ models:
     );
 
     let client = reqwest::Client::new();
+    // The cookbook finishes loading shortly after the liveness probe passes, so
+    // poll the listing until the model is advertised before exercising retrieve.
+    let mut listed = false;
+    for _ in 0..40 {
+        let resp = client
+            .get("http://127.0.0.1:9190/v1/models")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: serde_json::Value = resp.json().await.unwrap();
+        if body["data"]
+            .as_array()
+            .is_some_and(|d| d.iter().any(|m| m["id"] == "mock-model"))
+        {
+            listed = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    assert!(listed, "mock-model never appeared in /v1/models");
+
+    // Retrieve a single model (OpenAI `GET /v1/models/{id}`): the default
+    // profile is advertised under the bare model name.
     let resp = client
-        .get("http://127.0.0.1:9190/v1/models")
+        .get("http://127.0.0.1:9190/v1/models/mock-model")
         .send()
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
+    let model: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(model["id"], "mock-model");
+    assert_eq!(model["object"], "model");
+
+    // An unknown model id returns 404 with the OpenAI error envelope.
+    let resp = client
+        .get("http://127.0.0.1:9190/v1/models/no-such-model")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let err: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(err["error"]["type"], "model_not_found");
 
     let body = serde_json::json!({
         "model": "mock-model:default",


### PR DESCRIPTION
## Summary

Adds the OpenAI "retrieve model" endpoint, `GET /v1/models/{model}`, the companion to the existing `GET /v1/models` listing. OpenAI SDKs call it via `client.models.retrieve(...)`; previously a client wanting a single model's metadata had to fetch and filter the whole list.

The handler returns the same model object shape as one entry of the listing, drawn from the same catalog — so a model advertised only by a cluster peer is retrievable too. The list and retrieve handlers now share a `collect_models()` helper, so the two views can never disagree on the catalog. An id that no local profile or peer advertises returns `404 Not Found` with the standard error envelope (`type` `model_not_found`). The default profile is addressed by the bare model name, other profiles as `model:profile`, matching how the listing advertises ids.

## Testing

- `cargo fmt --check` and `cargo clippy --bin llamesh --release` are clean (zero warnings)
- `cargo test --bin llamesh` — 384 unit tests pass
- `cargo test --test integration_test` — the `test_standalone_proxy` case now also exercises retrieve for a known id (200, correct object) and an unknown id (404, `model_not_found`); the full integration and model-params suites pass
- Manually verified against a local node: list, retrieve-found, and retrieve-not-found all behave as documented

Docs updated in `README.md` and `SPEC.md`.

Closes #95