### PR TITLE
fix: never delete the active build during cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- The llama.cpp build cleanup (`keep_builds`) no longer deletes the build the
-  live binary is currently using. Cleanup previously removed the oldest builds
-  purely by timestamp until only `keep_builds` remained, so a small value
-  (`keep_builds: 0` in particular) or an out-of-order build timestamp could
-  delete the active build directory out from under the running server. The
-  build the binary symlink resolves to is now always retained, regardless of
-  `keep_builds` or age.
+- The llama.cpp build cleanup no longer deletes the build the live binary is
+  currently using. Cleanup previously removed the oldest build directories by
+  timestamp until only `keep_builds` remained, so a small value (`keep_builds:
+  0` in particular) or an out-of-order build timestamp could delete the active
+  build directory out from under the running server. The active build is now
+  always retained, and `keep_builds` counts the previous (non-active) builds
+  kept for rollback alongside it, so protecting the active build never reduces
+  rollback capacity.
 
 ## [1.15.1] - 2026-06-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.2] - 2026-06-14
+
+### Fixed
+
+- The llama.cpp build cleanup (`keep_builds`) no longer deletes the build the
+  live binary is currently using. Cleanup previously removed the oldest builds
+  purely by timestamp until only `keep_builds` remained, so a small value
+  (`keep_builds: 0` in particular) or an out-of-order build timestamp could
+  delete the active build directory out from under the running server. The
+  build the binary symlink resolves to is now always retained, regardless of
+  `keep_builds` or age.
+
 ## [1.15.1] - 2026-06-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.15.1"
+version = "1.15.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.15.1"
+version = "1.15.2"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/SPEC.md
+++ b/SPEC.md
@@ -168,7 +168,7 @@ llama_cpp:
     - "-j32"
   auto_update_interval_seconds: 86400  # once per day; set to 0 when pinning to specific version
   enabled: true                        # set to false to disable auto-build
-  keep_builds: 3                       # recent builds to keep; active always kept (default: 3)
+  keep_builds: 3                       # previous builds kept for rollback; active always kept (default: 3)
 
 # Cluster / mesh config
 cluster:
@@ -1083,7 +1083,7 @@ Each node is responsible for its local `llama.cpp`.
 * On update:
 
   * Configure and build `llama.cpp` with configured `build_args` in per-commit build directories (`build-<hash>/`).
-  * `keep_builds` controls how many recent builds are retained (default 3); the build the live binary currently resolves to is always kept regardless of this count or age.
+  * `keep_builds` controls how many previous (non-active) builds are retained for rollback (default 3); the build the live binary currently resolves to is always kept in addition, regardless of this count or age.
   * Run smoke test:
 
     * `llama-server --help` or simple trivial prompt.

--- a/SPEC.md
+++ b/SPEC.md
@@ -168,7 +168,7 @@ llama_cpp:
     - "-j32"
   auto_update_interval_seconds: 86400  # once per day; set to 0 when pinning to specific version
   enabled: true                        # set to false to disable auto-build
-  keep_builds: 3                       # number of old builds to keep (default: 3)
+  keep_builds: 3                       # recent builds to keep; active always kept (default: 3)
 
 # Cluster / mesh config
 cluster:
@@ -1083,7 +1083,7 @@ Each node is responsible for its local `llama.cpp`.
 * On update:
 
   * Configure and build `llama.cpp` with configured `build_args` in per-commit build directories (`build-<hash>/`).
-  * `keep_builds` config controls retention (default 3 old builds).
+  * `keep_builds` controls how many recent builds are retained (default 3); the build the live binary currently resolves to is always kept regardless of this count or age.
   * Run smoke test:
 
     * `llama-server --help` or simple trivial prompt.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -119,8 +119,8 @@ llama_cpp:
   # Set to false if managing llama.cpp builds externally
   enabled: true
 
-  # Number of builds to keep, most recent first (default: 3). The build the
-  # live binary currently uses is always retained even beyond this count, so a
+  # Number of previous builds to keep for rollback, besides the one currently
+  # in use (default: 3). The active build is always kept in addition, so a
   # value of 0 keeps only the active build.
   keep_builds: 3
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -119,7 +119,9 @@ llama_cpp:
   # Set to false if managing llama.cpp builds externally
   enabled: true
 
-  # Number of old builds to keep (default: 3)
+  # Number of builds to keep, most recent first (default: 3). The build the
+  # live binary currently uses is always retained even beyond this count, so a
+  # value of 0 keeps only the active build.
   keep_builds: 3
 
 # -----------------------------------------------------------------------------

--- a/src/build_manager.rs
+++ b/src/build_manager.rs
@@ -428,27 +428,31 @@ impl BuildManager {
             .ok()
             .and_then(|bin| Some(bin.parent()?.parent()?.to_path_buf()));
 
-        // Keep the most recent builds based on config; the active build is
-        // always retained regardless of count or age.
+        // The active build is always retained. Among the remaining (non-active)
+        // builds, keep the `keep_builds` most recent and remove the older ones,
+        // so protecting the active build never reduces how many previous builds
+        // are kept for rollback — even when the active build is itself old.
+        let mut non_active = Vec::new();
+        for (path, _) in &builds {
+            let is_active = match &active_build_dir {
+                Some(active) => {
+                    tokio::fs::canonicalize(path).await.ok().as_deref() == Some(active.as_path())
+                }
+                None => false,
+            };
+            if !is_active {
+                non_active.push(path);
+            }
+        }
+
         let keep_count = self.config.keep_builds;
-        if builds.len() > keep_count {
-            let to_remove = builds.len() - keep_count;
-            let mut removed = 0;
-            for (path, _) in &builds {
-                if removed >= to_remove {
-                    break;
-                }
-                if let Some(active) = &active_build_dir {
-                    if tokio::fs::canonicalize(path).await.ok().as_deref() == Some(active.as_path())
-                    {
-                        continue;
-                    }
-                }
+        if non_active.len() > keep_count {
+            let remove_upto = non_active.len() - keep_count;
+            for &path in &non_active[..remove_upto] {
                 info!("Removing old build: {}", path.display());
                 if let Err(e) = tokio::fs::remove_dir_all(path).await {
                     warn!("Failed to remove old build {}: {}", path.display(), e);
                 }
-                removed += 1;
             }
         }
 
@@ -1388,6 +1392,72 @@ fi
         );
         assert!(!llama.join("build-aaaaaaaaa").exists());
         assert!(!llama.join("build-ccccccccc").exists());
+
+        let _ = tokio::fs::remove_dir_all(&temp_dir).await;
+    }
+
+    #[tokio::test]
+    async fn cleanup_keeps_configured_non_active_builds() {
+        // Protecting the active build must not reduce how many previous builds
+        // are kept: with keep_builds=2 and the active build being the oldest,
+        // the two most recent non-active builds are retained alongside it, and
+        // only the older non-active build is removed.
+        let temp_dir = std::env::temp_dir().join(format!(
+            "llama-proxy-cleanup-keep-test-{}",
+            ulid::Ulid::new()
+        ));
+        let llama = temp_dir.join("llama.cpp");
+
+        // Four build dirs created with ascending modification times so the sort
+        // order is deterministic; the first created (active) is the oldest.
+        let names = [
+            "build-100000000",
+            "build-200000000",
+            "build-300000000",
+            "build-400000000",
+        ];
+        for name in names {
+            let bin = llama.join(name).join("bin");
+            tokio::fs::create_dir_all(&bin).await.unwrap();
+            tokio::fs::write(bin.join("llama-server"), b"#!/bin/true\n")
+                .await
+                .unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        // The active build is the oldest (build-100000000).
+        let link_dir = llama.join("build").join("bin");
+        tokio::fs::create_dir_all(&link_dir).await.unwrap();
+        let link = link_dir.join("llama-server");
+        let active = llama.join("build-100000000");
+        std::os::unix::fs::symlink(active.join("bin").join("llama-server"), &link).unwrap();
+
+        let config = crate::config::LlamaCppConfig {
+            repo_url: String::new(),
+            repo_path: llama.to_string_lossy().to_string(),
+            build_path: llama.join("build").to_string_lossy().to_string(),
+            binary_path: link.to_string_lossy().to_string(),
+            branch: String::new(),
+            build_args: vec![],
+            build_command_args: vec![],
+            auto_update_interval_seconds: 0,
+            enabled: true,
+            keep_builds: 2,
+        };
+        BuildManager::new(config)
+            .cleanup_old_builds()
+            .await
+            .unwrap();
+
+        // Active kept, plus the two most recent non-active builds; the oldest
+        // non-active build is removed.
+        assert!(active.exists(), "active build must be kept");
+        assert!(llama.join("build-300000000").exists());
+        assert!(llama.join("build-400000000").exists());
+        assert!(
+            !llama.join("build-200000000").exists(),
+            "the oldest non-active build should be removed"
+        );
 
         let _ = tokio::fs::remove_dir_all(&temp_dir).await;
     }

--- a/src/build_manager.rs
+++ b/src/build_manager.rs
@@ -418,15 +418,37 @@ impl BuildManager {
         // Sort by creation time (oldest first)
         builds.sort_by_key(|(_, created)| *created);
 
-        // Keep recent builds based on config
+        // Resolve the build directory the live binary symlink currently points
+        // into, so cleanup never deletes the build that is actively serving —
+        // even when keep_builds is small (e.g. 0) or a build's timestamp is out
+        // of order. The managed layout is `<build-dir>/bin/llama-server`, so the
+        // build dir is two levels up from the resolved binary.
+        let active_build_dir = tokio::fs::canonicalize(&self.config.binary_path)
+            .await
+            .ok()
+            .and_then(|bin| Some(bin.parent()?.parent()?.to_path_buf()));
+
+        // Keep the most recent builds based on config; the active build is
+        // always retained regardless of count or age.
         let keep_count = self.config.keep_builds;
         if builds.len() > keep_count {
             let to_remove = builds.len() - keep_count;
-            for (path, _) in builds.iter().take(to_remove) {
+            let mut removed = 0;
+            for (path, _) in &builds {
+                if removed >= to_remove {
+                    break;
+                }
+                if let Some(active) = &active_build_dir {
+                    if tokio::fs::canonicalize(path).await.ok().as_deref() == Some(active.as_path())
+                    {
+                        continue;
+                    }
+                }
                 info!("Removing old build: {}", path.display());
                 if let Err(e) = tokio::fs::remove_dir_all(path).await {
                     warn!("Failed to remove old build {}: {}", path.display(), e);
                 }
+                removed += 1;
             }
         }
 
@@ -1316,5 +1338,57 @@ fi
 
         buf.clear();
         assert!(!read_line_capped(&mut reader, &mut buf, cap).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn cleanup_preserves_active_build() {
+        // Cleanup must never delete the build the live binary symlink resolves
+        // to, even when keep_builds is 0 (which would otherwise remove every
+        // build, including the one currently serving).
+        let temp_dir =
+            std::env::temp_dir().join(format!("llama-proxy-cleanup-test-{}", ulid::Ulid::new()));
+        let llama = temp_dir.join("llama.cpp");
+
+        // Three managed build dirs, each with a bin/llama-server file.
+        for name in ["build-aaaaaaaaa", "build-bbbbbbbbb", "build-ccccccccc"] {
+            let bin = llama.join(name).join("bin");
+            tokio::fs::create_dir_all(&bin).await.unwrap();
+            tokio::fs::write(bin.join("llama-server"), b"#!/bin/true\n")
+                .await
+                .unwrap();
+        }
+
+        // The live binary symlink (build/bin/llama-server) points at the middle
+        // build, so the active build is neither the newest nor the oldest.
+        let link_dir = llama.join("build").join("bin");
+        tokio::fs::create_dir_all(&link_dir).await.unwrap();
+        let link = link_dir.join("llama-server");
+        let active = llama.join("build-bbbbbbbbb");
+        std::os::unix::fs::symlink(active.join("bin").join("llama-server"), &link).unwrap();
+
+        let config = crate::config::LlamaCppConfig {
+            repo_url: String::new(),
+            repo_path: llama.to_string_lossy().to_string(),
+            build_path: llama.join("build").to_string_lossy().to_string(),
+            binary_path: link.to_string_lossy().to_string(),
+            branch: String::new(),
+            build_args: vec![],
+            build_command_args: vec![],
+            auto_update_interval_seconds: 0,
+            enabled: true,
+            keep_builds: 0,
+        };
+        let bm = BuildManager::new(config);
+        bm.cleanup_old_builds().await.unwrap();
+
+        // The active build survives; the other two are removed.
+        assert!(
+            active.exists(),
+            "active build dir must not be deleted by cleanup"
+        );
+        assert!(!llama.join("build-aaaaaaaaa").exists());
+        assert!(!llama.join("build-ccccccccc").exists());
+
+        let _ = tokio::fs::remove_dir_all(&temp_dir).await;
     }
 }


### PR DESCRIPTION
## Summary

`cleanup_old_builds` removed the oldest build directories purely by timestamp until only `keep_builds` remained, without protecting the build the live `llama-server` binary symlink resolves to. With `keep_builds: 0` it would delete *every* build including the one currently serving; more generally, an out-of-order build timestamp could select the active build for removal.

This resolves the active build directory by canonicalizing the binary symlink (`<build-dir>/bin/llama-server` → `<build-dir>`) and skips it during cleanup, so the serving build is always retained regardless of `keep_builds` or age. `keep_builds: 0` now keeps only the active build.

## Testing

- `cargo fmt --check` and `cargo clippy --bin llamesh --release` are clean (zero warnings)
- `cargo test --bin llamesh` — 385 unit tests pass, including a new `cleanup_preserves_active_build` test: it creates three build dirs, points the binary symlink at the middle one, runs cleanup with `keep_builds: 0`, and asserts the active build survives while the others are removed (the previous behavior would delete all three).

Docs clarified in `config.example.yaml` and `SPEC.md`.

Closes #99