### PR TITLE
fix: count reasoning_content and tool_calls in streaming token count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.3] - 2026-06-14
+
+### Fixed
+
+- Streaming token counting now counts `reasoning_content` and `tool_calls`
+  deltas in addition to `content`. Previously only visible `content` deltas were
+  counted, so `tokens_generated` (and the derived `estimated_tokens_per_second`
+  reported in `/v1/models`) undercounted responses from reasoning ("thinking")
+  and tool-calling models whenever the upstream stream omitted the authoritative
+  `usage` chunk. A `usage` chunk, when present, remains authoritative.
+
 ## [1.15.2] - 2026-06-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.15.2"
+version = "1.15.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.15.2"
+version = "1.15.3"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/src/router.rs
+++ b/src/router.rs
@@ -1931,10 +1931,27 @@ fn process_line(line: &[u8], counter: &AtomicU64) {
             if let Some(choices) = val.get("choices").and_then(|c| c.as_array()) {
                 if let Some(choice) = choices.first() {
                     if let Some(delta) = choice.get("delta") {
-                        if let Some(content) = delta.get("content").and_then(|c| c.as_str()) {
-                            if !content.is_empty() {
-                                counter.fetch_add(1, Ordering::Relaxed);
-                            }
+                        // Count any delta carrying generated output: visible
+                        // content, reasoning content (thinking models emit it in
+                        // a separate field), or tool-call fragments. A
+                        // content-only check undercounts streams from reasoning
+                        // and tool-calling models whenever the upstream omits the
+                        // authoritative `usage` chunk.
+                        let nonempty_str = |key: &str| {
+                            delta
+                                .get(key)
+                                .and_then(|v| v.as_str())
+                                .is_some_and(|s| !s.is_empty())
+                        };
+                        let has_tool_calls = delta
+                            .get("tool_calls")
+                            .and_then(|v| v.as_array())
+                            .is_some_and(|a| !a.is_empty());
+                        if nonempty_str("content")
+                            || nonempty_str("reasoning_content")
+                            || has_tool_calls
+                        {
+                            counter.fetch_add(1, Ordering::Relaxed);
                         }
                     }
                 }
@@ -2358,6 +2375,47 @@ mod tests {
         let prev = counter.load(Ordering::Relaxed);
         process_line(b"data: [DONE]", &counter);
         assert_eq!(counter.load(Ordering::Relaxed), prev);
+    }
+
+    #[test]
+    fn test_process_line_counts_reasoning_content() {
+        use std::sync::atomic::AtomicU64;
+        let counter = AtomicU64::new(0);
+
+        // Thinking models stream reasoning in a separate `reasoning_content`
+        // field; it is generated output and must be counted.
+        process_line(
+            b"data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"thinking\"}}]}",
+            &counter,
+        );
+        assert_eq!(counter.load(Ordering::Relaxed), 1);
+
+        // Empty reasoning_content does not increment.
+        process_line(
+            b"data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"\"}}]}",
+            &counter,
+        );
+        assert_eq!(counter.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn test_process_line_counts_tool_calls() {
+        use std::sync::atomic::AtomicU64;
+        let counter = AtomicU64::new(0);
+
+        // A tool-call delta carries generated output and must be counted.
+        process_line(
+            b"data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0}]}}]}",
+            &counter,
+        );
+        assert_eq!(counter.load(Ordering::Relaxed), 1);
+
+        // An empty tool_calls array does not increment.
+        process_line(
+            b"data: {\"choices\":[{\"delta\":{\"tool_calls\":[]}}]}",
+            &counter,
+        );
+        assert_eq!(counter.load(Ordering::Relaxed), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The streaming token counter (`process_line`) incremented `tokens_generated` only for non-empty `content` deltas. Streamed responses can also carry generated output in `reasoning_content` (reasoning/"thinking" models) and `tool_calls` (tool-calling models), so those responses undercounted — which also underestimates the `estimated_tokens_per_second` derived from the count and surfaced in `/v1/models`.

This only affects the fallback heuristic: when the upstream stream includes an authoritative `usage` chunk, that value still overrides the running count. Many `llama-server` streaming configurations omit `usage`, so the heuristic is what is used.

The fix counts a delta once if it carries any generated output — non-empty `content`, non-empty `reasoning_content`, or a non-empty `tool_calls` array.

## Testing

- `cargo fmt --check` and `cargo clippy --bin llamesh --release` are clean (zero warnings)
- `cargo test --bin llamesh` — 388 unit tests pass, including two new `process_line` tests covering `reasoning_content` and `tool_calls` counting (and that empty values do not increment); the existing `content` / `usage` / `[DONE]` behavior is unchanged.

Closes #101