### PR TITLE
feat: report effective backoff in circuit-breaker open/reopen logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.4] - 2026-06-14
+
+### Changed
+
+- Circuit-breaker "now blocking" warnings now report the effective backoff
+  duration (`backoff_ms`) and a uniform `consecutive_opens` count across all
+  three open/reopen transitions (open after consecutive failures, reopen from
+  half-open, reopen after a failed recovery probe). Previously the logs carried
+  only the open count, so operators had to recompute the exponential backoff
+  schedule by hand to know how long a peer would stay blocked before the next
+  recovery probe. This is a logging-only change; circuit-breaker behavior is
+  unchanged.
+
 ## [1.15.3] - 2026-06-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.15.3"
+version = "1.15.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.15.3"
+version = "1.15.4"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/src/circuit_breaker.rs
+++ b/src/circuit_breaker.rs
@@ -419,9 +419,18 @@ impl CircuitBreaker {
                     circuit.consecutive_opens += 1;
                     circuit.success_count = 0;
                     circuit.reset_probe();
+                    // The backoff now in effect: the circuit blocks dispatches
+                    // for this long before a recovery probe is admitted. Logged
+                    // so operators see the block duration without recomputing
+                    // the exponential schedule from `consecutive_opens` by hand.
+                    let backoff_ms = self
+                        .calculate_backoff(circuit.consecutive_opens)
+                        .as_millis() as u64;
                     tracing::warn!(
                         peer_id = %peer_id,
                         failures = circuit.failure_count,
+                        consecutive_opens = circuit.consecutive_opens,
+                        backoff_ms,
                         "Circuit breaker opened after consecutive failures"
                     );
                 }
@@ -436,8 +445,13 @@ impl CircuitBreaker {
                     circuit.consecutive_opens += 1;
                     circuit.success_count = 0;
                     circuit.reset_probe();
+                    let backoff_ms = self
+                        .calculate_backoff(circuit.consecutive_opens)
+                        .as_millis() as u64;
                     tracing::warn!(
                         peer_id = %peer_id,
+                        consecutive_opens = circuit.consecutive_opens,
+                        backoff_ms,
                         "Circuit breaker reopened after failure in half-open state"
                     );
                 }
@@ -455,9 +469,13 @@ impl CircuitBreaker {
                     circuit.consecutive_opens += 1;
                     circuit.success_count = 0;
                     circuit.reset_probe();
+                    let backoff_ms = self
+                        .calculate_backoff(circuit.consecutive_opens)
+                        .as_millis() as u64;
                     tracing::warn!(
                         peer_id = %peer_id,
                         consecutive_opens = circuit.consecutive_opens,
+                        backoff_ms,
                         "Circuit breaker reopened after failed recovery probe"
                     );
                 }
@@ -921,5 +939,66 @@ mod tests {
         // Large consecutive opens shouldn't overflow
         assert_eq!(cb.calculate_backoff(100), Duration::from_millis(60000));
         assert_eq!(cb.calculate_backoff(u32::MAX), Duration::from_millis(60000));
+    }
+
+    /// Minimal `MakeWriter` that captures formatted log output into a shared
+    /// buffer, so tests can assert on emitted fields with no extra dependency
+    /// and no global subscriber.
+    #[derive(Clone, Default)]
+    struct CaptureWriter(Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl std::io::Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+        type Writer = CaptureWriter;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    #[tokio::test]
+    async fn open_log_reports_effective_backoff() {
+        // A current-thread `#[tokio::test]` keeps the scoped subscriber on the
+        // same thread across awaits, so warn events from the calls below are
+        // captured.
+        let buf = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .json()
+            .with_max_level(tracing::Level::WARN)
+            .with_writer(CaptureWriter(buf.clone()))
+            .finish();
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let cb = CircuitBreaker::new(CircuitBreakerConfig {
+            failure_threshold: 1,
+            open_duration_base_ms: 5000,
+            open_duration_max_ms: 60000,
+            ..Default::default()
+        });
+
+        // First open: consecutive_opens = 1 -> backoff 5000 * 2^0 = 5000ms.
+        cb.record_failure("p", false).await;
+        // A ticketed probe failure while open escalates the block: this is the
+        // same reopen path a real failed recovery probe drives.
+        // consecutive_opens = 2 -> backoff 5000 * 2^1 = 10000ms.
+        cb.record_failure("p", true).await;
+
+        let logged = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+        assert!(
+            logged.contains("\"backoff_ms\":5000"),
+            "expected first open to log backoff_ms=5000; got: {logged}"
+        );
+        assert!(
+            logged.contains("\"backoff_ms\":10000"),
+            "expected escalated reopen to log backoff_ms=10000; got: {logged}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

The three circuit-breaker "now blocking" warnings recorded the open count but not the backoff duration in effect, so an operator reading the logs couldn't tell how long a peer would stay blocked before the next recovery probe without recomputing the exponential schedule (`open_duration_base_ms * 2^(consecutive_opens - 1)`, capped at `open_duration_max_ms`) by hand. The fields were also inconsistent: the open-after-consecutive-failures and reopen-from-half-open logs omitted `consecutive_opens` entirely, while reopen-after-failed-recovery-probe included it.

This adds the effective backoff as `backoff_ms` to all three open/reopen transitions and includes a uniform `consecutive_opens` field across them, so each log line is self-describing: which peer, how many times the circuit has opened, and how long it will block before the next probe. The logged value is produced by the already-tested `calculate_backoff` and is exactly what `should_allow`/`should_allow_sync` enforce afterward.

This is a logging-only change. Circuit-breaker state transitions, timing, and the `proxy_circuit_breaker_state` Prometheus gauge are all unchanged.

## Changes

- `src/circuit_breaker.rs`: compute and log `backoff_ms` at the three open/reopen WARN sites; add `consecutive_opens` to the two that lacked it.
- Adds a dependency-free tracing-capture unit test (`open_log_reports_effective_backoff`) asserting the logged `backoff_ms` matches the schedule on the first open (5000ms) and on an escalated reopen (10000ms).

## Testing

- `cargo fmt --check`, `cargo clippy --bin llamesh --release` — clean.
- `cargo test --bin llamesh` — 389 passed, 0 failed (21 circuit-breaker tests including the new one).

Closes #103
