### PR TITLE
fix: retry transient failures in the scheduled llama.cpp update check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.5] - 2026-06-14
+
+### Fixed
+
+- Scheduled (periodic) llama.cpp update checks now retry transient failures
+  with backoff instead of giving up after a single attempt. A momentary
+  `git fetch` network or DNS blip during the check previously skipped the whole
+  cycle — waiting a full `auto_update_interval_seconds` (commonly a day) before
+  trying again — and logged it at ERROR as a `llama_build_failure` event. The
+  check now retries within the cycle, re-acquiring the rebuild lock per attempt
+  (never held across a backoff sleep, so the manual rebuild endpoint stays
+  responsive), and only escalates to an ERROR-level `llama_build_failure` event
+  once the retry budget is exhausted. This brings the scheduled update path in
+  line with the resilience the initial build already had.
+
 ## [1.15.4] - 2026-06-14
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.15.4"
+version = "1.15.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.15.4"
+version = "1.15.5"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,19 @@ const INITIAL_BUILD_RETRY_DELAYS: &[Duration] = &[
     Duration::from_secs(600),
 ];
 
+/// Backoff schedule for a scheduled (periodic) llama.cpp update check. Unlike
+/// the initial build, this runs while the node is already serving with the
+/// network normally up, so a failure is usually a brief `git fetch` blip;
+/// retrying within the cycle smooths it over instead of skipping a whole
+/// `auto_update_interval_seconds` (commonly a day). Kept short and bounded so a
+/// persistently failing upstream build is reattempted only a few times before
+/// the next scheduled tick.
+const SCHEDULED_UPDATE_RETRY_DELAYS: &[Duration] = &[
+    Duration::from_secs(30),
+    Duration::from_secs(120),
+    Duration::from_secs(300),
+];
+
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
@@ -380,25 +393,65 @@ async fn main() -> anyhow::Result<()> {
         let bm = node_state.build_manager.clone();
         let lock = node_state.rebuild_lock.clone();
         let interval_secs = config.llama_cpp.auto_update_interval_seconds;
-        tokio::spawn(async move {
-            let mut interval = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
-            // The first tick completes immediately, so we skip it to avoid double-build on startup
-            interval.tick().await;
-
-            loop {
+        tokio::spawn(
+            async move {
+                let mut interval =
+                    tokio::time::interval(std::time::Duration::from_secs(interval_secs));
+                // The first tick completes immediately, so we skip it to avoid double-build on startup
                 interval.tick().await;
-                info!("Running scheduled llama.cpp update check");
 
-                // Try to acquire lock
-                if let Ok(_permit) = lock.try_lock() {
-                    if let Err(e) = bm.update_and_build().await {
-                        tracing::error!(event = "llama_build_failure", error = %e, "Scheduled update failed");
+                loop {
+                    interval.tick().await;
+                    info!("Running scheduled llama.cpp update check");
+
+                    // Defer to a build already running (manual rebuild, or a
+                    // still-running initial build): skip this cycle rather than
+                    // queueing behind it. The probe permit is released immediately;
+                    // the retry loop below re-acquires the lock per attempt.
+                    if lock.try_lock().is_err() {
+                        tracing::warn!(
+                            "Skipping scheduled update because a rebuild is already in progress"
+                        );
+                        continue;
                     }
-                } else {
-                    tracing::warn!("Skipping scheduled update because a rebuild is already in progress");
+
+                    // Retry transient failures (e.g. a momentary DNS/network blip
+                    // on `git fetch`) within this cycle instead of skipping a whole
+                    // auto_update_interval_seconds — commonly a day. The lock is
+                    // re-acquired per attempt and never held across a backoff
+                    // sleep, so the manual rebuild endpoint stays responsive
+                    // between attempts. Only an exhausted retry budget escalates to
+                    // an ERROR-level build-failure event; a transient blip that
+                    // recovers is logged at WARN by the retry helper and clears.
+                    let outcome = util::retry_with_backoff(
+                        "scheduled llama.cpp update",
+                        SCHEDULED_UPDATE_RETRY_DELAYS,
+                        || true,
+                        || {
+                            let bm = bm.clone();
+                            let lock = lock.clone();
+                            async move {
+                                let _permit = lock.lock().await;
+                                bm.update_and_build().await
+                            }
+                        },
+                    )
+                    .await;
+
+                    match outcome {
+                        util::RetryOutcome::Success(()) | util::RetryOutcome::Aborted(_) => {}
+                        util::RetryOutcome::Exhausted(e) => {
+                            tracing::error!(
+                                event = "llama_build_failure",
+                                error = %e,
+                                "Scheduled update failed after retries"
+                            );
+                        }
+                    }
                 }
             }
-        }.instrument(span.clone()));
+            .instrument(span.clone()),
+        );
     }
 
     // Binary swap watcher — drains running instances when build manager swaps the binary
@@ -440,4 +493,48 @@ async fn main() -> anyhow::Result<()> {
     shutdown_state.shutdown_all_instances().await;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    // A scheduled-update cycle must retry transient failures. An empty delay
+    // schedule would silently make a single `git fetch` blip skip a whole
+    // auto_update_interval_seconds (commonly a day) and log it at ERROR as a
+    // build failure — the regression this schedule guards against.
+    #[test]
+    fn scheduled_update_retry_delays_allow_retries() {
+        assert!(!SCHEDULED_UPDATE_RETRY_DELAYS.is_empty());
+    }
+
+    // A transient failure recovers within the scheduled retry budget without
+    // reaching the exhausted (ERROR-logged) outcome — the behavior this
+    // schedule exists to provide. Paused time auto-advances the backoff sleeps.
+    #[tokio::test(start_paused = true)]
+    async fn scheduled_update_recovers_from_transient_failure() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_op = calls.clone();
+        let outcome = util::retry_with_backoff(
+            "scheduled llama.cpp update",
+            SCHEDULED_UPDATE_RETRY_DELAYS,
+            || true,
+            || {
+                let calls = calls_op.clone();
+                async move {
+                    let n = calls.fetch_add(1, Ordering::SeqCst) + 1;
+                    if n == 1 {
+                        Err(anyhow::anyhow!("transient git fetch failure"))
+                    } else {
+                        Ok(())
+                    }
+                }
+            },
+        )
+        .await;
+        assert!(matches!(outcome, util::RetryOutcome::Success(())));
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
 }


### PR DESCRIPTION
## Summary

The scheduled (periodic) llama.cpp update check made a single attempt per cycle: it acquired the rebuild lock, called `update_and_build()` once, and logged any failure at ERROR as a `llama_build_failure` event. A transient `git fetch` failure — a momentary DNS or network blip — therefore skipped the whole cycle and waited a full `auto_update_interval_seconds` (default 86400, i.e. a day) before retrying, while surfacing a misleading ERROR-level build-failure event for what was a brief, self-correcting hiccup.

The initial-build path was already hardened against exactly this with `retry_with_backoff`, and its comment even calls out the hazard. This brings the scheduled path in line.

## Changes

- `src/main.rs`: wrap the scheduled update in `retry_with_backoff` with a short, bounded `SCHEDULED_UPDATE_RETRY_DELAYS` schedule (30s / 120s / 300s). The lock is re-acquired per attempt inside the op closure, so it is never held across a backoff sleep — the manual rebuild endpoint stays responsive between attempts, matching the initial-build path. Only `RetryOutcome::Exhausted` escalates to an ERROR-level `llama_build_failure`; a transient blip that recovers is logged at WARN by the retry helper and clears. The pre-existing "skip this cycle if a build is already in progress" behavior is preserved.
- Adds two unit tests: a regression guard that the retry schedule is non-empty (an empty schedule would silently disable retries), and a paused-time test that a transient failure recovers within the budget without reaching the exhausted/ERROR outcome.

## Behavior notes

- No config surface changes. The retry schedule is an internal constant, bounded so a persistently failing upstream build is reattempted only a few times before the next scheduled tick.
- `update_and_build()` is idempotent for an already-built commit (it skips the binary swap), so retrying after another path completed a build is a cheap no-op rather than a redundant swap/drain.

## Testing

- `cargo fmt --check`, `cargo clippy --bin llamesh --release` — clean.
- `cargo test --bin llamesh` — 391 passed, 0 failed (2 new).

Closes #105
