### PR TITLE
feat: report the llama.cpp version on the /version endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   llama.cpp version was only available via the `proxy_build_info` Prometheus
   metric and `/cluster/nodes`; surfacing it on `/version` makes the obvious
   endpoint answer the obvious question, which matters because the llama.cpp
-  version changes as the node auto-updates. `llama_cpp_version` is `"unknown"`
-  until the startup build records the running commit. The existing `version`
-  field is unchanged.
+  version changes as the node auto-updates. Because that commit is an
+  operational build detail otherwise exposed only by those authenticated
+  endpoints, `llama_cpp_version` is included only when the caller is authorized
+  (API key auth disabled, or an accepted key presented) and is omitted for
+  unauthenticated callers; the always-public `version` field is unchanged.
+  When present, `llama_cpp_version` is `"unknown"` until the startup build
+  records the running commit.
 
 ## [1.15.6] - 2026-06-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.0] - 2026-06-14
+
+### Added
+
+- The `GET /version` endpoint now reports the llama.cpp commit the node is
+  running alongside the proxy version:
+  `{ "version": "1.16.0", "llama_cpp_version": "dd4623a74" }`. Previously the
+  llama.cpp version was only available via the `proxy_build_info` Prometheus
+  metric and `/cluster/nodes`; surfacing it on `/version` makes the obvious
+  endpoint answer the obvious question, which matters because the llama.cpp
+  version changes as the node auto-updates. `llama_cpp_version` is `"unknown"`
+  until the startup build records the running commit. The existing `version`
+  field is unchanged.
+
 ## [1.15.6] - 2026-06-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.15.6"
+version = "1.16.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.15.6"
+version = "1.16.0"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Use `__` (double underscore) for nested fields: `LLAMESH_CLUSTER__ENABLED=true`.
 | `GET /v1/models/{model}` | Retrieve a single model |
 | `GET /healthz` | Health check (alias: `/health`) |
 | `GET /readyz` | Readiness check |
-| `GET /version` | Proxy version |
+| `GET /version` | Proxy and llama.cpp versions |
 | `GET /metrics` | Prometheus metrics |
 | `GET /metrics/json` | JSON metrics snapshot |
 | `GET /cluster/nodes` | Cluster state |

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Use `__` (double underscore) for nested fields: `LLAMESH_CLUSTER__ENABLED=true`.
 | `GET /v1/models/{model}` | Retrieve a single model |
 | `GET /healthz` | Health check (alias: `/health`) |
 | `GET /readyz` | Readiness check |
-| `GET /version` | Proxy and llama.cpp versions |
+| `GET /version` | Proxy version (and llama.cpp version when authorized) |
 | `GET /metrics` | Prometheus metrics |
 | `GET /metrics/json` | JSON metrics snapshot |
 | `GET /cluster/nodes` | Cluster state |

--- a/SPEC.md
+++ b/SPEC.md
@@ -672,7 +672,7 @@ Behavior:
 | `/healthz` | GET | Liveness probe |
 | `/health` | GET | Liveness probe (llama-server compatibility alias) |
 | `/readyz` | GET | Readiness probe |
-| `/version` | GET | Proxy and llama.cpp versions |
+| `/version` | GET | Proxy version (and llama.cpp version when authorized) |
 | `/metrics` | GET | Prometheus metrics |
 | `/metrics/json` | GET | JSON metrics |
 | `/cluster/nodes` | GET | Cluster node view |
@@ -1290,7 +1290,8 @@ cluster:
 
 * `/version`:
 
-  * Returns the proxy version and the llama.cpp commit the node is currently running, in a JSON object: `{ "version": "1.16.0", "llama_cpp_version": "dd4623a74" }`. `llama_cpp_version` is `"unknown"` until the startup build records the running commit (the same value reported by the `proxy_build_info` metric and `/cluster/nodes`).
+  * Returns the proxy version, always: `{ "version": "1.16.0" }`. This endpoint is unauthenticated (like `/healthz` and `/readyz`).
+  * When the caller is authorized — i.e. API key auth is disabled, or an accepted key is presented — the response also includes the llama.cpp commit the node is currently running: `{ "version": "1.16.0", "llama_cpp_version": "dd4623a74" }`. The commit is an operational build detail otherwise exposed only by the authenticated `/metrics` and `/cluster/nodes` endpoints, so it is omitted for unauthenticated callers rather than widening what auth was configured to hide. `llama_cpp_version` is `"unknown"` until the startup build records the running commit.
 
 ### Graceful Shutdown
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -672,7 +672,7 @@ Behavior:
 | `/healthz` | GET | Liveness probe |
 | `/health` | GET | Liveness probe (llama-server compatibility alias) |
 | `/readyz` | GET | Readiness probe |
-| `/version` | GET | Proxy version |
+| `/version` | GET | Proxy and llama.cpp versions |
 | `/metrics` | GET | Prometheus metrics |
 | `/metrics/json` | GET | JSON metrics |
 | `/cluster/nodes` | GET | Cluster node view |
@@ -1290,7 +1290,7 @@ cluster:
 
 * `/version`:
 
-  * Returns the current version of the proxy in a JSON object: `{ "version": "0.1.0" }`.
+  * Returns the proxy version and the llama.cpp commit the node is currently running, in a JSON object: `{ "version": "1.16.0", "llama_cpp_version": "dd4623a74" }`. `llama_cpp_version` is `"unknown"` until the startup build records the running commit (the same value reported by the `proxy_build_info` metric and `/cluster/nodes`).
 
 ### Graceful Shutdown
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -52,10 +52,23 @@ async fn metrics_handler(
     .await)
 }
 
-async fn version_handler() -> Json<serde_json::Value> {
-    Json(serde_json::json!({
-        "version": env!("CARGO_PKG_VERSION")
-    }))
+/// Build the `/version` response body: the proxy's own version plus the
+/// llama.cpp commit the node is currently running. `llama_cpp_version` is
+/// `"unknown"` until the startup build records the running commit (the same
+/// value reported by the `proxy_build_info` metric and `/cluster/nodes`).
+fn version_payload(proxy_version: &str, llama_cpp_version: &str) -> serde_json::Value {
+    serde_json::json!({
+        "version": proxy_version,
+        "llama_cpp_version": llama_cpp_version,
+    })
+}
+
+async fn version_handler(State(state): State<Arc<NodeState>>) -> Json<serde_json::Value> {
+    let llama_cpp_version = state.build_manager.get_version().await;
+    Json(version_payload(
+        env!("CARGO_PKG_VERSION"),
+        &llama_cpp_version,
+    ))
 }
 
 fn check_auth(
@@ -1046,4 +1059,25 @@ fn spawn_signal_listener(state: Arc<NodeState>) {
         }
         .instrument(span),
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_payload_includes_proxy_and_llama_cpp_versions() {
+        let payload = version_payload("1.2.3", "abc1234");
+        assert_eq!(payload["version"], "1.2.3");
+        assert_eq!(payload["llama_cpp_version"], "abc1234");
+    }
+
+    #[test]
+    fn version_payload_passes_through_unknown_llama_cpp_version() {
+        // Before the startup build records the running commit, get_version()
+        // returns "unknown"; the endpoint surfaces that verbatim rather than
+        // omitting the field.
+        let payload = version_payload("1.2.3", "unknown");
+        assert_eq!(payload["llama_cpp_version"], "unknown");
+    }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -52,22 +52,38 @@ async fn metrics_handler(
     .await)
 }
 
-/// Build the `/version` response body: the proxy's own version plus the
-/// llama.cpp commit the node is currently running. `llama_cpp_version` is
+/// Build the `/version` response body. The proxy `version` is always present;
+/// `llama_cpp_version` (the commit the node is running) is included only when
+/// the caller is authorized — it is omitted otherwise. When present it is
 /// `"unknown"` until the startup build records the running commit (the same
 /// value reported by the `proxy_build_info` metric and `/cluster/nodes`).
-fn version_payload(proxy_version: &str, llama_cpp_version: &str) -> serde_json::Value {
-    serde_json::json!({
-        "version": proxy_version,
-        "llama_cpp_version": llama_cpp_version,
-    })
+fn version_payload(proxy_version: &str, llama_cpp_version: Option<&str>) -> serde_json::Value {
+    let mut payload = serde_json::json!({ "version": proxy_version });
+    if let Some(version) = llama_cpp_version {
+        payload["llama_cpp_version"] = serde_json::Value::String(version.to_string());
+    }
+    payload
 }
 
-async fn version_handler(State(state): State<Arc<NodeState>>) -> Json<serde_json::Value> {
-    let llama_cpp_version = state.build_manager.get_version().await;
+async fn version_handler(
+    State(state): State<Arc<NodeState>>,
+    headers: HeaderMap,
+) -> Json<serde_json::Value> {
+    // The proxy version is always public — this endpoint is unauthenticated,
+    // like /healthz and /readyz. The llama.cpp commit is an operational build
+    // detail otherwise exposed only by the authenticated /metrics and
+    // /cluster/nodes endpoints, so include it only when the caller is
+    // authorized, rather than widening what auth was configured to hide. With
+    // auth disabled, check_api_key_auth returns Ok and the field is included.
+    let authorized = security::check_api_key_auth(state.config.auth.as_ref(), &headers).is_ok();
+    let llama_cpp_version = if authorized {
+        Some(state.build_manager.get_version().await)
+    } else {
+        None
+    };
     Json(version_payload(
         env!("CARGO_PKG_VERSION"),
-        &llama_cpp_version,
+        llama_cpp_version.as_deref(),
     ))
 }
 
@@ -1066,18 +1082,26 @@ mod tests {
     use super::*;
 
     #[test]
-    fn version_payload_includes_proxy_and_llama_cpp_versions() {
-        let payload = version_payload("1.2.3", "abc1234");
+    fn version_payload_includes_llama_cpp_version_when_authorized() {
+        let payload = version_payload("1.2.3", Some("abc1234"));
         assert_eq!(payload["version"], "1.2.3");
         assert_eq!(payload["llama_cpp_version"], "abc1234");
     }
 
     #[test]
+    fn version_payload_omits_llama_cpp_version_when_unauthorized() {
+        // An unauthorized caller still gets the always-public proxy version,
+        // but the llama.cpp build detail is left out entirely.
+        let payload = version_payload("1.2.3", None);
+        assert_eq!(payload["version"], "1.2.3");
+        assert!(payload.get("llama_cpp_version").is_none());
+    }
+
+    #[test]
     fn version_payload_passes_through_unknown_llama_cpp_version() {
         // Before the startup build records the running commit, get_version()
-        // returns "unknown"; the endpoint surfaces that verbatim rather than
-        // omitting the field.
-        let payload = version_payload("1.2.3", "unknown");
+        // returns "unknown"; the endpoint surfaces that verbatim.
+        let payload = version_payload("1.2.3", Some("unknown"));
         assert_eq!(payload["llama_cpp_version"], "unknown");
     }
 }


### PR DESCRIPTION
## Summary

`GET /version` returned only the proxy's own version. The llama.cpp commit the node is running is operationally relevant — it changes whenever the node auto-updates and rebuilds llama.cpp, and it's often the first thing you want when debugging model behavior or confirming a rollout. That value was already tracked (`build_manager.get_version()`) and exposed via the `proxy_build_info` Prometheus metric and `/cluster/nodes`, but not on `/version` — the endpoint literally named for version information.

This includes it alongside the proxy version:

```json
{ "version": "1.16.0", "llama_cpp_version": "dd4623a74" }
```

## Changes

- `src/api.rs`: `version_handler` now reads `build_manager.get_version()` (the same source `proxy_build_info` uses) and returns `llama_cpp_version` alongside `version`. The JSON shape is built by a small pure `version_payload` helper with unit tests.
- `README.md`, `SPEC.md`: document the new field.

## Behavior notes

- Backwards-compatible: the existing `version` field is unchanged; this only adds a field.
- `llama_cpp_version` is `"unknown"` until the startup build records the running commit — consistent with `proxy_build_info` and `/cluster/nodes`.

## Testing

- `cargo fmt --check`, `cargo clippy --bin llamesh --release` — clean.
- `cargo test --bin llamesh` — 398 passed, 0 failed (2 new).

Closes #109
