### PR TITLE
fix: reject zero http limits and timeouts at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.1] - 2026-06-14
+
+### Fixed
+
+- Config validation now rejects zero values for the `http` server limits and
+  timeouts (`request_body_limit_bytes`, `idle_timeout_seconds`,
+  `body_read_timeout_ms`, `protocol_detect_timeout_ms`) at startup, with a clear
+  message for each. Previously a zero deserialized cleanly but broke request
+  handling at runtime: a `request_body_limit_bytes` of 0 rejects every request
+  carrying a body, a zero millisecond timeout elapses immediately (so body reads
+  and protocol detection always time out — tokio treats a zero timeout as
+  already expired, not disabled), and a zero `idle_timeout_seconds` tears down
+  connections the moment they go idle. This matches the existing startup
+  validation for zero gossip and port settings.
+
 ## [1.16.0] - 2026-06-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.16.0"
+version = "1.16.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.16.0"
+version = "1.16.1"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -210,17 +210,20 @@ cluster:
 # -----------------------------------------------------------------------------
 
 http:
-  # Max request body size in bytes (required)
+  # Max request body size in bytes (required; must be > 0 — a 0 limit rejects
+  # every request that carries a body)
   request_body_limit_bytes: 1048576  # 1MB
 
-  # Idle connection timeout in seconds (required)
+  # Idle connection timeout in seconds (required; must be > 0 — a 0 timeout tears
+  # down connections the moment they go idle, defeating keep-alive)
   idle_timeout_seconds: 120
 
-  # Timeout in ms for reading a request body (default: 30000)
+  # Timeout in ms for reading a request body (default: 30000; must be > 0 — a 0
+  # timeout elapses immediately, so every body read times out)
   body_read_timeout_ms: 30000
 
   # Timeout in ms for protocol detection on a new connection, before any bytes
-  # arrive (TLS vs HTTP vs cluster traffic). (default: 10000)
+  # arrive (TLS vs HTTP vs cluster traffic). (default: 10000; must be > 0)
   protocol_detect_timeout_ms: 10000
 
 # -----------------------------------------------------------------------------

--- a/src/config.rs
+++ b/src/config.rs
@@ -167,6 +167,39 @@ impl NodeConfig {
             }
         }
 
+        // Validate HTTP server limits and timeouts. Each feeds a hyper or tokio
+        // primitive directly, and a zero value deserializes cleanly but breaks
+        // request handling at runtime, so catch it at startup. A zero millisecond
+        // timeout elapses immediately (tokio treats it as already expired), not
+        // "disabled". `request_body_limit_bytes` and `idle_timeout_seconds` are
+        // required and have no default, which makes a stray 0 easy to introduce.
+        if self.http.request_body_limit_bytes == 0 {
+            return Err(anyhow::anyhow!(
+                "http.request_body_limit_bytes is 0; every request carrying a body would be \
+                 rejected as too large. Set a positive byte limit."
+            ));
+        }
+        if self.http.idle_timeout_seconds == 0 {
+            return Err(anyhow::anyhow!(
+                "http.idle_timeout_seconds is 0; idle connections would be torn down the moment \
+                 they go idle, defeating HTTP keep-alive. Set a positive timeout."
+            ));
+        }
+        if self.http.body_read_timeout_ms == 0 {
+            return Err(anyhow::anyhow!(
+                "http.body_read_timeout_ms is 0; a zero timeout elapses immediately, so every \
+                 request body read would time out. Set a positive timeout, or omit it for the \
+                 default."
+            ));
+        }
+        if self.http.protocol_detect_timeout_ms == 0 {
+            return Err(anyhow::anyhow!(
+                "http.protocol_detect_timeout_ms is 0; a zero timeout elapses immediately, so \
+                 every connection's protocol detection would time out. Set a positive timeout, \
+                 or omit it for the default."
+            ));
+        }
+
         Ok(())
     }
 }
@@ -948,8 +981,8 @@ mod tests {
                 version_mismatch_action: "warn".to_string(),
             },
             http: HttpConfig {
-                request_body_limit_bytes: 0,
-                idle_timeout_seconds: 0,
+                request_body_limit_bytes: 1_048_576,
+                idle_timeout_seconds: 120,
                 body_read_timeout_ms: 30_000,
                 protocol_detect_timeout_ms: 10_000,
             },
@@ -1014,8 +1047,8 @@ mod tests {
                 version_mismatch_action: "warn".to_string(),
             },
             http: HttpConfig {
-                request_body_limit_bytes: 0,
-                idle_timeout_seconds: 0,
+                request_body_limit_bytes: 1_048_576,
+                idle_timeout_seconds: 120,
                 body_read_timeout_ms: 30_000,
                 protocol_detect_timeout_ms: 10_000,
             },
@@ -1133,6 +1166,44 @@ mod tests {
         // The gossip loop never runs with cluster disabled, so these unused
         // fields must not be rejected (avoids breaking single-node configs).
         assert!(config_with_cluster(false, 0, 0).validate().is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_positive_http_settings() {
+        // The base test config carries valid (non-zero) HTTP settings.
+        assert!(config_with_ports(None).validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_zero_request_body_limit() {
+        // A 0 byte limit rejects every request carrying a body.
+        let mut config = config_with_ports(None);
+        config.http.request_body_limit_bytes = 0;
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_zero_idle_timeout() {
+        // A 0 idle timeout tears down connections the moment they go idle.
+        let mut config = config_with_ports(None);
+        config.http.idle_timeout_seconds = 0;
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_zero_body_read_timeout() {
+        // A 0 ms timeout elapses immediately, so body reads always time out.
+        let mut config = config_with_ports(None);
+        config.http.body_read_timeout_ms = 0;
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_zero_protocol_detect_timeout() {
+        // A 0 ms timeout elapses immediately, so protocol detection always times out.
+        let mut config = config_with_ports(None);
+        config.http.protocol_detect_timeout_ms = 0;
+        assert!(config.validate().is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`NodeConfig::validate()` already rejects zero-value footguns that load cleanly but break the node at runtime (a zero gossip interval, which panics `tokio::time::interval`; a zero gossip permit count; unusable port configs). The `http` server limits and timeouts had the same hazard but were unvalidated:

- `request_body_limit_bytes: 0` → `axum::body::to_bytes(body, 0)` rejects every request that carries a body, so all completions/embeddings fail as "body too large".
- `body_read_timeout_ms: 0` / `protocol_detect_timeout_ms: 0` → `tokio::time::timeout(Duration::ZERO, …)` is already expired on the first poll, so body reads and protocol detection time out immediately (a zero timeout is "immediate", not "disabled").
- `idle_timeout_seconds: 0` → the h2c idle watchdog treats `idle_for() >= Duration::ZERO` as always true and tears connections down the moment they go idle, and it also feeds hyper's `header_read_timeout`/`keep_alive_interval`.

`request_body_limit_bytes` and `idle_timeout_seconds` are required fields with no default, so a stray `0` is easy to introduce, and each only surfaces at request time with no hint that the config is the cause.

## Changes

- `src/config.rs`: reject a zero value for each of the four `http` numeric fields in `NodeConfig::validate()`, each with a message explaining the runtime consequence (matching the existing gossip/port validation). The two in-test base configs that used `http: { …: 0 }` (which "passed" only because nothing validated them) are updated to valid values.
- `config.example.yaml`: note that each field must be `> 0`.
- Adds unit tests for the accepted case and each rejected field.

## Behavior notes

- Fail-fast only: the rejected configs were already non-functional at runtime; this surfaces the misconfiguration at startup with a clear message instead of as opaque request failures. Valid configs are unaffected.

## Testing

- `cargo fmt --check`, `cargo clippy --bin llamesh --release` — clean.
- `cargo test --bin llamesh` — 404 passed, 0 failed (5 new).
- `cargo test --test integration_test` — 8 passed (spawned nodes validate fixture configs on startup).

Closes #111
