### PR TITLE
fix: count per-model request latency once on the local serving path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.2] - 2026-06-14
+
+### Fixed
+
+- Per-model latency is no longer double-counted for locally-served requests.
+  The local serving path added each request's duration to `total_latency_ms`
+  twice — once directly and once inside `observe_latency` — so the counter grew
+  at twice the true rate. This halved the derived `estimated_tokens_per_second`
+  reported in `/v1/models` metadata and `/cluster/nodes` model stats, and
+  inflated the `proxy_hash_total_latency_ms` Prometheus counter. Because the
+  same throughput estimate feeds the cluster scheduler's performance bonus
+  (`min(tps, 200) * 5`), the understated value also subtly skewed node
+  selection, weighting throughput about half as much as intended and turning
+  the 200 tok/s bonus clamp into an effective 400 tok/s clamp. Latency now
+  accumulates exactly once on every path. Forwarded (proxied-to-peer) requests
+  continue to accumulate `total_latency_ms` without feeding the local p95
+  sample window, since their wall-clock time includes the peer round-trip and
+  the peer's own queueing and generation. The bug had been present since the
+  first release.
+
 ## [1.16.1] - 2026-06-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.16.1"
+version = "1.16.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.16.1"
+version = "1.16.2"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -64,6 +64,12 @@ impl Default for HashMetrics {
 }
 
 impl HashMetrics {
+    /// Record one locally-served request's latency. This is the single
+    /// accumulation point for `total_latency_ms`, so callers must not also add
+    /// to that counter themselves — doing both double-counts the latency and
+    /// halves the derived `tokens_per_second`. The latency is also pushed into
+    /// the bounded p95 sample window, which only locally-served requests feed
+    /// (see `observe_forwarded_latency`).
     pub fn observe_latency(&self, ms: u64) {
         self.total_latency_ms.fetch_add(ms, Ordering::Relaxed);
         let mut samples = self.latency_samples.lock();
@@ -71,6 +77,15 @@ impl HashMetrics {
             samples.pop_front();
         }
         samples.push_back(ms);
+    }
+
+    /// Record a forwarded (proxied-to-peer) request's latency. It accumulates
+    /// `total_latency_ms` exactly like `observe_latency`, but deliberately does
+    /// not feed the p95 sample window: a forwarded request's wall-clock time
+    /// includes the peer round-trip and the peer's own queueing and
+    /// generation, so it would pollute this node's local-generation p95.
+    pub fn observe_forwarded_latency(&self, ms: u64) {
+        self.total_latency_ms.fetch_add(ms, Ordering::Relaxed);
     }
 
     pub fn observe_memory(&self, vram_mb: u64, sysmem_mb: u64) {
@@ -1444,6 +1459,36 @@ mod tests {
 
         let tps = hm.tokens_per_second();
         assert!((tps - 500.0).abs() < 0.01); // 1000 tokens / 2 seconds = 500 TPS
+    }
+
+    #[test]
+    fn test_observe_latency_accumulates_total_once() {
+        // `observe_latency` is the single accumulation point for
+        // `total_latency_ms`. A caller that also added the same value would
+        // double-count it and halve the derived tokens/sec, so the method must
+        // add each observation exactly once.
+        let hm = HashMetrics::default();
+        hm.observe_latency(1000);
+        hm.observe_latency(1000);
+        assert_eq!(hm.total_latency_ms.load(Ordering::Relaxed), 2000);
+        assert_eq!(hm.latency_samples.lock().len(), 2);
+
+        // 1000 generated tokens over the 2 s of accumulated latency is 500 TPS;
+        // a double-counted total would report 250.
+        hm.tokens_generated_total.fetch_add(1000, Ordering::Relaxed);
+        assert!((hm.tokens_per_second() - 500.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn test_observe_forwarded_latency_accumulates_total_without_sample() {
+        // Forwarded requests still accumulate `total_latency_ms`, but must not
+        // feed the p95 sample window (their wall-clock time includes the peer
+        // round-trip and the peer's own queueing and generation).
+        let hm = HashMetrics::default();
+        hm.observe_forwarded_latency(1500);
+        hm.observe_forwarded_latency(500);
+        assert_eq!(hm.total_latency_ms.load(Ordering::Relaxed), 2000);
+        assert!(hm.latency_samples.lock().is_empty());
     }
 
     #[tokio::test]

--- a/src/router.rs
+++ b/src/router.rs
@@ -1202,9 +1202,10 @@ pub async fn route_request(
                                         state.notify_queue(&model_name, &profile_id).await;
                                     }
                                     let duration = start_time.elapsed().as_millis() as u64;
-                                    hash_metrics
-                                        .total_latency_ms
-                                        .fetch_add(duration, Ordering::Relaxed);
+                                    // `observe_latency` already accumulates
+                                    // `total_latency_ms` (and records the p95
+                                    // sample); adding it again here would
+                                    // double-count the latency.
                                     hash_metrics.observe_latency(duration);
                                     hash_metrics.tokens_generated_total.fetch_add(
                                         tokens_for_cleanup.load(Ordering::Relaxed),
@@ -1329,9 +1330,7 @@ pub async fn route_request(
                                             state.metrics.dec_current_requests();
                                             peer_forward_guard.release();
                                             let duration = start_time.elapsed().as_millis() as u64;
-                                            hash_metrics
-                                                .total_latency_ms
-                                                .fetch_add(duration, Ordering::Relaxed);
+                                            hash_metrics.observe_forwarded_latency(duration);
                                             hash_metrics.tokens_generated_total.fetch_add(
                                                 tokens_for_cleanup.load(Ordering::Relaxed),
                                                 Ordering::Relaxed,
@@ -1494,9 +1493,7 @@ pub async fn route_request(
                                 state.metrics.dec_current_requests();
                                 peer_forward_guard.release();
                                 let duration = start_time.elapsed().as_millis() as u64;
-                                hash_metrics
-                                    .total_latency_ms
-                                    .fetch_add(duration, Ordering::Relaxed);
+                                hash_metrics.observe_forwarded_latency(duration);
                                 hash_metrics.tokens_generated_total.fetch_add(
                                     tokens_for_cleanup.load(Ordering::Relaxed),
                                     Ordering::Relaxed,
@@ -1527,9 +1524,7 @@ pub async fn route_request(
                                 state.metrics.dec_current_requests();
                                 peer_forward_guard.release();
                                 let duration = start_time.elapsed().as_millis() as u64;
-                                hash_metrics
-                                    .total_latency_ms
-                                    .fetch_add(duration, Ordering::Relaxed);
+                                hash_metrics.observe_forwarded_latency(duration);
                                 hash_metrics.tokens_generated_total.fetch_add(
                                     tokens_for_cleanup.load(Ordering::Relaxed),
                                     Ordering::Relaxed,


### PR DESCRIPTION
Fixes #113.

## Summary

The local serving path recorded each request's duration into the per-hash `total_latency_ms` counter twice — once with a direct `fetch_add`, and once inside `observe_latency`, which already accumulates `total_latency_ms` before recording the p95 sample. The counter grew at twice the true rate for every locally-served request.

That corrupted everything derived from it: `estimated_tokens_per_second` (reported in `/v1/models` metadata and `/cluster/nodes` model stats) came out at roughly half the real throughput, and the `proxy_hash_total_latency_ms` Prometheus counter was inflated 2x. The same throughput estimate also feeds the cluster scheduler's performance bonus (`min(tps, 200) * 5`), so the understated value weighted throughput about half as much as intended during node selection and turned the 200 tok/s bonus clamp into an effective 400 tok/s clamp.

The three peer-forwarding cleanup paths already accumulated the latency exactly once, so only the local path was wrong — which also left the local and forwarded paths inconsistent.

## Fix

Centralize all `total_latency_ms` mutation behind two intent-revealing methods on `HashMetrics`:

- `observe_latency` — locally-served requests: accumulates the total once and feeds the bounded p95 sample window. The redundant direct `fetch_add` at the call site is removed.
- `observe_forwarded_latency` — proxied-to-peer requests: accumulates the total once and deliberately does **not** feed the p95 sample window, since a forwarded request's wall-clock time includes the peer round-trip and the peer's own queueing and generation, which would pollute this node's local-generation p95.

All four request-cleanup paths now accumulate latency exactly once, and `total_latency_ms` is no longer mutated by scattered raw atomic ops, preventing this class of bug from recurring. Behavior on the forwarding paths is unchanged (byte-for-byte equivalent accounting); only the local path's double-count is removed.

This is a metrics-accounting correction only — no API shape, endpoint, or config surface changes. The `estimated_tokens_per_second` field and `proxy_hash_total_latency_ms` counter keep their meaning; their values simply become accurate.

## Tests

- `test_observe_latency_accumulates_total_once` — verifies a single accumulation per call, one p95 sample per call, and the correct (un-halved) tokens/sec.
- `test_observe_forwarded_latency_accumulates_total_without_sample` — verifies the total accumulates while the p95 window stays empty.
- Full suite green: 406 unit tests, 8 integration tests; `cargo fmt --check` and `clippy` clean.

## Impact / risk

Low. The change removes a redundant counter increment and renames the forwarded-path accounting to an equivalent helper. Existing persisted `total_latency_ms` values (loaded from the metrics snapshot on restart) remain as-is; new requests accumulate correctly from that point, so post-deploy `estimated_tokens_per_second` converges upward toward the true value as fresh samples accrue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)