### PR TITLE
fix: bound the outbound HTTP requests that lacked a timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.3] - 2026-06-14
+
+### Fixed
+
+- Bound the two outbound HTTP requests that lacked a timeout, so an
+  unresponsive endpoint that accepts a connection but never replies can no
+  longer stall the proxy. The instance readiness health probe now applies a
+  per-request timeout: previously a `llama-server` that accepted the connection
+  but never answered `/health` could block the readiness loop indefinitely, past
+  the overall startup deadline, holding the spawn slot. The plaintext (non-Noise)
+  cluster gossip request now carries the same 10-second timeout the Noise gossip
+  path already used, so a hung peer cannot tie up a gossip task and its
+  concurrency permit. The Noise gossip path and both peer-forwarding paths were
+  already bounded; these were the only unbounded outbound calls.
+
 ## [1.16.2] - 2026-06-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.16.2"
+version = "1.16.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.16.2"
+version = "1.16.3"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/SPEC.md
+++ b/SPEC.md
@@ -941,6 +941,7 @@ Each instance is a `llama-server` process spawned by the proxy:
 * Health checking:
 
   * Uses the `/health` endpoint on the `llama-server` instance exclusively.
+  * The proxy polls `/health` until it returns `200` (ready) or the overall `startup_timeout_seconds` budget elapses. Each individual probe is bounded by its own short request timeout, so a server that accepts the connection but never responds cannot stall the readiness loop past that budget.
   * If spawn/health check fails:
 
     * Mark instance as failed, emit error logs.

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -12,6 +12,12 @@ use std::sync::Arc;
 use tokio::sync::Semaphore;
 use tracing::{debug, info};
 
+/// Per-request timeout for a single gossip exchange with a peer, applied on
+/// both the Noise and plaintext transports. Bounds each request so an
+/// unresponsive peer that accepts the connection but never replies cannot hold
+/// a gossip task (and its concurrency permit) open indefinitely.
+const GOSSIP_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PeerInfo {
     pub node_id: String,
@@ -164,7 +170,7 @@ pub async fn start_gossip_loop(state: Arc<NodeState>) {
                                     path: "/cluster/gossip",
                                     headers: &headers,
                                     body: &body,
-                                    timeout_duration: Some(std::time::Duration::from_secs(10)),
+                                    timeout_duration: Some(GOSSIP_REQUEST_TIMEOUT),
                                 },
                             )
                             .await
@@ -214,7 +220,13 @@ pub async fn start_gossip_loop(state: Arc<NodeState>) {
                         }
                     }
                 } else {
-                    match client.post(&url).json(&message).send().await {
+                    match client
+                        .post(&url)
+                        .json(&message)
+                        .timeout(GOSSIP_REQUEST_TIMEOUT)
+                        .send()
+                        .await
+                    {
                         Ok(resp) if resp.status().is_success() => {
                             // Record success - resets failure count, and on a
                             // recovery transition wakes parked routing waiters.

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -213,6 +213,33 @@ pub fn compute_args_hash(args: &[String]) -> String {
     )
 }
 
+/// Per-probe timeout for a single readiness health check (see [`probe_ready`]).
+/// Short enough that the readiness loop keeps its polling cadence and respects
+/// the overall startup timeout even when a probe stalls, yet generous enough to
+/// tolerate a busy server that is briefly slow to answer `/health`.
+const HEALTH_CHECK_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Issue a single readiness probe against `health_addr`, bounded by `timeout`.
+///
+/// Returns `true` only on a 2xx response — the server is up and the model is
+/// loaded and ready to serve. A 503 (model still loading), any other status, a
+/// connection error, or a timeout all return `false`, signalling the caller to
+/// keep polling. The timeout is essential: without it a server that accepts the
+/// connection but never sends a response would block the readiness loop
+/// indefinitely, past the overall startup deadline.
+async fn probe_ready(
+    client: &reqwest::Client,
+    health_addr: &str,
+    api_key: Option<&str>,
+    timeout: Duration,
+) -> bool {
+    let mut req = client.get(health_addr).timeout(timeout);
+    if let Some(key) = api_key {
+        req = req.header("Authorization", format!("Bearer {key}"));
+    }
+    matches!(req.send().await, Ok(resp) if resp.status().is_success())
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum InstanceStatus {
     Starting,
@@ -480,26 +507,22 @@ impl Instance {
                 ));
             }
 
-            // Only use /health endpoint to determine readiness.
-            // The /health endpoint returns 503 while the model is loading and 200 when ready.
-            // Note: /v1/models can return 200 even while model is still loading, so it's not
-            // a reliable indicator of readiness for serving requests.
-            let mut health_req = client.get(&health_addr);
-            if let Some(ref key) = api_key {
-                health_req = health_req.header("Authorization", format!("Bearer {key}"));
-            }
-
-            match health_req.send().await {
-                Ok(resp) => {
-                    if resp.status().is_success() {
-                        self.mark_ready();
-                        return Ok(());
-                    }
-                    // 503 means model is still loading, keep polling
-                }
-                Err(_) => {
-                    // Connection refused or timeout - server might not be up yet, keep polling
-                }
+            // Only use /health to determine readiness: it returns 503 while the
+            // model is still loading and 200 once it can serve. (/v1/models can
+            // return 200 before the model is loaded, so it is not reliable.)
+            // Each probe is bounded by HEALTH_CHECK_REQUEST_TIMEOUT so a server
+            // that accepts the connection but never answers cannot block this
+            // loop past the overall startup timeout.
+            if probe_ready(
+                client,
+                &health_addr,
+                api_key.as_deref(),
+                HEALTH_CHECK_REQUEST_TIMEOUT,
+            )
+            .await
+            {
+                self.mark_ready();
+                return Ok(());
             }
 
             tokio::time::sleep(Duration::from_millis(500)).await;
@@ -917,5 +940,86 @@ mod tests {
         assert!(params.n_layer.is_none());
         assert!(params.arch.is_none());
         assert!(params.model_name.is_none());
+    }
+
+    // The per-probe timeout must be positive and stay well under the minimum
+    // overall startup budget, so one probe can never consume the whole budget.
+    const _: () = {
+        assert!(
+            HEALTH_CHECK_REQUEST_TIMEOUT.as_secs() >= 1,
+            "health check request timeout must be at least 1 second"
+        );
+        assert!(
+            HEALTH_CHECK_REQUEST_TIMEOUT.as_secs() <= 30,
+            "health check request timeout must stay well under the startup budget"
+        );
+    };
+
+    /// Spawn a one-shot TCP server that accepts a single connection, reads the
+    /// request, and replies with the given HTTP status line. Returns the
+    /// `http://host:port/health` URL to probe.
+    async fn spawn_oneshot_http(status_line: &'static str) -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                let mut buf = [0u8; 1024];
+                let _ = sock.read(&mut buf).await;
+                let resp = format!("HTTP/1.1 {status_line}\r\nContent-Length: 0\r\n\r\n");
+                let _ = sock.write_all(resp.as_bytes()).await;
+                let _ = sock.flush().await;
+            }
+        });
+        format!("http://{addr}/health")
+    }
+
+    #[tokio::test]
+    async fn probe_ready_true_on_2xx() {
+        let url = spawn_oneshot_http("200 OK").await;
+        let client = reqwest::Client::builder().build().unwrap();
+        assert!(probe_ready(&client, &url, None, Duration::from_secs(5)).await);
+    }
+
+    #[tokio::test]
+    async fn probe_ready_false_on_503() {
+        let url = spawn_oneshot_http("503 Service Unavailable").await;
+        let client = reqwest::Client::builder().build().unwrap();
+        assert!(!probe_ready(&client, &url, None, Duration::from_secs(5)).await);
+    }
+
+    #[tokio::test]
+    async fn probe_ready_false_when_unreachable() {
+        // Bind then immediately drop to obtain a port nothing is listening on.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        let client = reqwest::Client::builder().build().unwrap();
+        let url = format!("http://{addr}/health");
+        assert!(!probe_ready(&client, &url, None, Duration::from_secs(5)).await);
+    }
+
+    #[tokio::test]
+    async fn probe_ready_times_out_on_stalled_server() {
+        // A server that accepts connections but never sends a response. Without
+        // the per-probe timeout this would block forever.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let mut held = Vec::new();
+            while let Ok((sock, _)) = listener.accept().await {
+                held.push(sock); // hold the connection open, never respond
+            }
+        });
+        let client = reqwest::Client::builder().build().unwrap();
+        let url = format!("http://{addr}/health");
+        let start = Instant::now();
+        let ready = probe_ready(&client, &url, None, Duration::from_millis(300)).await;
+        let elapsed = start.elapsed();
+        assert!(!ready, "a stalled server must not be reported ready");
+        assert!(
+            elapsed < Duration::from_secs(3),
+            "probe must time out promptly rather than hang, took {elapsed:?}"
+        );
     }
 }


### PR DESCRIPTION
Fixes #115.

## Summary

An audit of every outbound `*.send().await` found two HTTP requests with no timeout. Either can hang indefinitely when the remote accepts the connection but never responds.

- **Instance readiness health probe** (`Instance::wait_for_ready`): polls the spawned `llama-server`'s `/health` with no per-request timeout, and the overall `startup_timeout_seconds` deadline is only checked between polls. A server that accepts the connection but stalls blocks the probe indefinitely, holding the readiness loop and the spawn slot open past the deadline. Runs on every local spawn, all deployments.
- **Plaintext cluster gossip** (`start_gossip_loop`, non-Noise path): `client.post(url).json(msg).send()` with no timeout, on a client built without a default timeout. A hung peer keeps the spawned gossip task and its concurrency permit alive indefinitely; enough hung peers exhaust the gossip semaphore. Affects clusters with the Noise transport disabled (the Noise path already bounds at 10s).

## Fix

- The single readiness probe is extracted into a small `probe_ready` helper that takes an injectable `timeout` (`HEALTH_CHECK_REQUEST_TIMEOUT`, 5s in production). It returns `true` only on a 2xx; a 503, any other status, a connection error, or a timeout all return `false` so the loop keeps polling. Extracting it makes the timeout behavior directly unit-testable.
- Plaintext gossip now applies the same `GOSSIP_REQUEST_TIMEOUT` (10s) constant the Noise path uses; the constant replaces the Noise path's former literal so both transports share one bound.

The Noise gossip path and both peer-forwarding paths were already bounded; these were the only unbounded outbound calls. No API, endpoint, or config surface changes — this is internal robustness only.

## Tests

- `probe_ready_true_on_2xx` / `probe_ready_false_on_503` — classification via a one-shot TCP HTTP responder.
- `probe_ready_false_when_unreachable` — connection refused returns false promptly.
- `probe_ready_times_out_on_stalled_server` — a server that accepts but never replies returns within the (injected, short) timeout instead of hanging. This is the core regression guard.
- Compile-time bounds assertion on `HEALTH_CHECK_REQUEST_TIMEOUT`.
- Full suite green: 410 unit + 8 integration; `cargo fmt --check` and `clippy` clean.

## Validation note

The triggering condition (a backend that accepts a connection but never responds) is impractical to reproduce against the live cluster, so the timeout behavior is proven by the unit test above; live validation confirms normal spawns and gossip are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)