### PR TITLE
fix: send Retry-After on draining 503 responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.4] - 2026-06-14
+
+### Fixed
+
+- `503` responses returned while a node is draining for shutdown now carry a
+  `Retry-After` header, like the other retryable `503`s (queue full/timeout, no
+  capacity, spawn failures). Previously a draining node rejected new requests
+  with a bare `503`, giving OpenAI-compatible clients no backoff hint during a
+  rolling restart. Draining is transient — the node is restarting and should
+  accept requests again shortly — so it now returns `Retry-After: 5`, matching
+  the transient-condition tier. The four draining rejection sites are unified
+  behind a single `AppError::node_draining()` constructor, so they share one
+  message, type, and retry hint instead of drifting (two had previously diverged
+  to "Node is shutting down" versus "Node is draining"). The error-model section
+  of the spec now documents the per-condition `Retry-After` values.
+
 ## [1.16.3] - 2026-06-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.16.3"
+version = "1.16.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.16.3"
+version = "1.16.4"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/SPEC.md
+++ b/SPEC.md
@@ -757,7 +757,7 @@ The proxy uses standard HTTP status codes with the following canonical mappings:
     * `draining`: Node is shutting down and not accepting new requests.
     * `peer_unavailable_retry`: Peer is temporarily unavailable, client should retry.
 
-For `503` responses, the proxy may include a `Retry-After` header (e.g., `Retry-After: 30` for `spawn_failures_exhausted`).
+For the `503` responses it generates, the proxy includes a `Retry-After` header hinting how long to wait before retrying: `5` seconds for transient conditions (`queue_full`, `queue_timeout`, `draining`) and `30` seconds for capacity-bound conditions (`no_capacity`, `spawn_failures_exhausted`).
 
 ### Health and Readiness
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,5 @@
 use axum::{
-    http::{HeaderMap, HeaderName, HeaderValue, StatusCode},
+    http::{header::RETRY_AFTER, HeaderMap, HeaderName, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
     Json,
 };
@@ -108,6 +108,17 @@ impl AppError {
             "client_disconnected",
         )
     }
+
+    /// 503 returned while this node is draining for shutdown and no longer
+    /// accepting new work. The condition is transient — the node is restarting
+    /// and should accept requests again shortly — so the response carries a
+    /// short `Retry-After` hint, matching the other retryable 503s the router
+    /// returns (queue full/timeout). Centralizing it here keeps every draining
+    /// rejection identical in message, type, and retry hint.
+    pub fn node_draining() -> Self {
+        Self::service_unavailable("Node is draining for shutdown", "draining")
+            .with_header(RETRY_AFTER, HeaderValue::from_static("5"))
+    }
 }
 
 #[cfg(test)]
@@ -181,6 +192,18 @@ mod tests {
         let err = AppError::internal_server_error("oops");
         assert_eq!(err.status, StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(err.error.type_, "internal_error");
+    }
+
+    #[test]
+    fn test_node_draining_sets_retry_after() {
+        let err = AppError::node_draining();
+        assert_eq!(err.status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(err.error.type_, "draining");
+        // Draining is retryable, so the response must hint when to retry.
+        let headers = err
+            .headers
+            .expect("draining 503 must carry a Retry-After header");
+        assert_eq!(headers.get(RETRY_AFTER).unwrap(), "5");
     }
 
     #[test]

--- a/src/router.rs
+++ b/src/router.rs
@@ -659,10 +659,7 @@ pub async fn route_request(
     let endpoint_kind = EndpointKind::from_path(&path_only);
 
     if state.draining.load(Ordering::Relaxed) {
-        return Err(AppError::service_unavailable(
-            "Node is draining",
-            "draining",
-        ));
+        return Err(AppError::node_draining());
     }
 
     // Auth Check
@@ -780,10 +777,7 @@ pub async fn route_request(
                     // change before giving up.
                     if state.draining.load(Ordering::Relaxed) {
                         state.metrics.inc_errors();
-                        return Err(AppError::service_unavailable(
-                            "Node is shutting down",
-                            "draining",
-                        ));
+                        return Err(AppError::node_draining());
                     }
                     // We can only distinguish "no one will ever serve this"
                     // from "no one can serve it right now" by checking
@@ -1029,10 +1023,7 @@ pub async fn route_request(
             if state.draining.load(Ordering::Relaxed) {
                 state.metrics.inc_errors();
                 hash_metrics.errors_total.fetch_add(1, Ordering::Relaxed);
-                return Err(AppError::service_unavailable(
-                    "Node is shutting down",
-                    "draining",
-                ));
+                return Err(AppError::node_draining());
             }
 
             // Model exists locally but no node can serve right now
@@ -1624,10 +1615,7 @@ pub async fn route_request(
                 if state.draining.load(Ordering::Relaxed) {
                     state.metrics.inc_errors();
                     hash_metrics.errors_total.fetch_add(1, Ordering::Relaxed);
-                    return Err(AppError::service_unavailable(
-                        "Node is shutting down",
-                        "draining",
-                    ));
+                    return Err(AppError::node_draining());
                 }
 
                 // Re-select. Could be the same peer (its circuit may have


### PR DESCRIPTION
Fixes #117.

## Summary

When a node is draining for shutdown it rejects new requests with `503` / `type: "draining"`. Unlike every other retryable `503` the router returns (`queue_full`, `queue_timeout`, `no_capacity`, `spawn_failures_exhausted` — all of which set `Retry-After`), the draining responses carried no `Retry-After` header, so OpenAI-compatible clients got no backoff hint during a rolling restart.

Draining is a transient condition — the node is restarting and should accept requests again shortly — so it now returns `Retry-After: 5`, matching the transient-condition tier (`queue_full` / `queue_timeout` also use `5`; the capacity-bound `no_capacity` / `spawn_failures_exhausted` use `30`).

## Fix

- New `AppError::node_draining()` constructor: `503`, `type: "draining"`, a consistent message, and `Retry-After: 5`.
- The four inline draining rejection sites in `route_request` now call it. Previously two said `"Node is shutting down"` and another said `"Node is draining"`; they are now uniform. Surrounding metrics side-effects (`inc_errors`, per-hash error counts) are unchanged.
- `SPEC.md` error-model section now documents the per-condition `Retry-After` values (5s transient vs 30s capacity-bound) instead of a vague "may include".

No new API, endpoint, or config surface; this aligns draining with the already-documented `Retry-After` behavior and makes the retryable `503`s consistent.

## Tests

- `test_node_draining_sets_retry_after` asserts `503`, `type: "draining"`, and `Retry-After: 5`.
- Full suite green: 411 unit + 8 integration; `cargo fmt --check` and `clippy` clean.

## Out of scope (noted for follow-up)

`HEALABLE_PEER_ERROR_TYPES` does not include `"draining"`, so a request forwarded to a draining peer surfaces the 503 to the client rather than re-selecting another peer. That is a routing-behavior change with broader implications and is left for separate consideration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)