### PR TITLE
fix: return the OpenAI error envelope on upstream/peer body-read failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.18.1] - 2026-06-15
+
+### Fixed
+
+- Upstream and peer response-body read failures now return the standard OpenAI
+  error envelope instead of a bare plaintext body. When a local `llama-server`
+  or a cluster peer accepted a non-streaming request and sent `200` headers but
+  then failed to deliver the full body (e.g. the backend process was killed
+  mid-response, or the connection reset before the body finished), the proxy
+  replied with `502` and a raw string (`"Failed to read upstream response"` /
+  `"Failed to read peer response"`) carrying no `Content-Type: application/json`
+  and no `error` object. OpenAI-compatible clients deserialize the body as JSON,
+  so they saw a parse error instead of the real failure. Both paths now return
+  `{"error":{"message","type":"upstream_error","param","code"}}` like every
+  other error, unified behind a single `AppError::upstream_error()` constructor
+  (which the existing local upstream-error path now also uses).
+
 ## [1.18.0] - 2026-06-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.18.0"
+version = "1.18.1"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -97,6 +97,18 @@ impl AppError {
         Self::new(StatusCode::INTERNAL_SERVER_ERROR, message, "internal_error")
     }
 
+    /// `502` returned when an upstream `llama-server` or a cluster peer accepted
+    /// the request but then failed to deliver a complete response — for example
+    /// the backend process was killed mid-body, or the connection reset before
+    /// the body finished transferring. Surfaced as the standard OpenAI error
+    /// envelope like every other error, so SDK clients that parse the response
+    /// body as JSON receive a structured error instead of a parse failure.
+    /// Centralizing it keeps the upstream-failure rejections identical in type
+    /// across the router's local-serving and peer-forwarding paths.
+    pub fn upstream_error(message: impl Into<String>) -> Self {
+        Self::new(StatusCode::BAD_GATEWAY, message, "upstream_error")
+    }
+
     pub fn request_timeout(message: impl Into<String>) -> Self {
         Self::new(StatusCode::REQUEST_TIMEOUT, message, "request_timeout")
     }
@@ -192,6 +204,19 @@ mod tests {
         let err = AppError::internal_server_error("oops");
         assert_eq!(err.status, StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(err.error.type_, "internal_error");
+    }
+
+    #[test]
+    fn test_upstream_error() {
+        // A failed upstream/peer body read must surface as the OpenAI error
+        // envelope (502, type "upstream_error"), not a bare string body.
+        let err = AppError::upstream_error("backend closed the connection mid-body");
+        assert_eq!(err.status, StatusCode::BAD_GATEWAY);
+        assert_eq!(err.error.type_, "upstream_error");
+        assert_eq!(
+            AppError::upstream_error("x").into_response().status(),
+            StatusCode::BAD_GATEWAY
+        );
     }
 
     #[test]

--- a/src/router.rs
+++ b/src/router.rs
@@ -1221,11 +1221,7 @@ pub async fn route_request(
                             // Guard handles dec_current_requests and in_flight cleanup
                             hash_metrics.errors_total.fetch_add(1, Ordering::Relaxed);
 
-                            Err(AppError::new(
-                                StatusCode::BAD_GATEWAY,
-                                format!("Upstream error: {e}"),
-                                "upstream_error",
-                            ))
+                            Err(AppError::upstream_error(format!("Upstream error: {e}")))
                         }
                     }
                 }
@@ -1697,10 +1693,8 @@ async fn handle_non_streaming_response(
         Ok(b) => b,
         Err(e) => {
             error!("Failed to read upstream response body: {}", e);
-            return Response::builder()
-                .status(StatusCode::BAD_GATEWAY)
-                .body(Body::from("Failed to read upstream response"))
-                .unwrap_or_else(|_| Response::new(Body::from("Internal error")));
+            return AppError::upstream_error(format!("Failed to read upstream response body: {e}"))
+                .into_response();
         }
     };
 
@@ -1853,10 +1847,8 @@ async fn peer_response_to_client(
                     ),
                     Err(e) => {
                         error!("Failed to read peer response body: {}", e);
-                        Response::builder()
-                            .status(StatusCode::BAD_GATEWAY)
-                            .body(Body::from("Failed to read peer response"))
-                            .unwrap_or_else(|_| Response::new(Body::from("Internal error")))
+                        AppError::upstream_error(format!("Failed to read peer response body: {e}"))
+                            .into_response()
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Two `502` error paths in the router returned a bare plaintext body instead of the OpenAI error envelope that every other error produces. When a non-streaming request was served and the response body failed to read *after* the upstream had already sent `200` headers — the backend `llama-server` process killed mid-response, or the connection reset before the body finished — the proxy replied with a raw string and no `Content-Type: application/json`:

- `handle_non_streaming_response` (local serving) → `"Failed to read upstream response"`
- `peer_response_to_client` (peer forwarding) → `"Failed to read peer response"`

OpenAI-compatible clients always deserialize the response body as JSON, so they saw a parse error instead of the structured failure, masking the real upstream problem.

## What changed

- Both paths now return `{"error":{"message","type":"upstream_error","param","code"}}` with `Content-Type: application/json` and status `502`, like every other error.
- Added a single `AppError::upstream_error()` constructor and routed all three upstream-failure sites through it — including the existing local upstream-error site, which already used the `upstream_error` type but constructed it inline. This keeps the rejections identical in type and shape, mirroring how the draining `503`s were unified behind `AppError::node_draining()` in 1.16.4.

## Why these were the only ones

An audit of every raw-body response in `src/` confirmed these two were the only error paths bypassing the envelope; the remaining `Body::from(...)` uses are successful response passthrough (streaming/non-streaming bodies) and outbound request-body construction.

## Testing

- New `test_upstream_error` asserts the constructor yields `502` / type `upstream_error` and that `into_response()` carries the `502` status — matching the existing `AppError` test style.
- `cargo fmt --check`, `cargo clippy --release` (zero findings), 416 unit tests, and 8 integration tests all pass. The success paths are unchanged, so the integration suite exercises them unmodified.

The actual trigger (a `reqwest` body read failing mid-transfer) is impractical to simulate deterministically without adding mock infrastructure disproportionate to a mechanical bare-body→envelope swap, so the change is covered by the constructor unit test plus the unchanged-success-path integration suite.

## Versioning

Patch bump to `1.18.1`: a bugfix with no new public surface (the `upstream_error` type was already emitted by the existing local path). `CHANGELOG.md` and `Cargo.lock` are updated.

Fixes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)
