### PR TITLE
fix: validate circuit breaker tuning at startup; saturate backoff multiply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.18.2] - 2026-06-15
+
+### Fixed
+
+- Config validation now rejects degenerate per-peer circuit breaker settings at
+  startup (when cluster mode and the breaker are both enabled). A zero
+  `failure_threshold` or `success_threshold` would open or close a peer's
+  circuit without the intended number of failures or recovery probes; a zero
+  `open_duration_base_ms` or `open_duration_max_ms` collapses the open-state
+  backoff to nothing, so a failing peer is re-probed on every request with no
+  spacing; and a base backoff greater than the max is immediately capped, so the
+  exponential backoff never grows. Each deserialized cleanly but degraded peer
+  failure handling at runtime, so they are now caught with a clear message, like
+  the existing gossip, port, and HTTP-limit checks. `half_open_probe_interval_ms`
+  is exempt, since `0` is a documented value that disables probe gating. As
+  defense in depth, the backoff multiplication is now saturating, so a large
+  (but valid) base can no longer overflow and wrap to a near-zero backoff.
+
 ## [1.18.1] - 2026-06-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.18.1"
+version = "1.18.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.18.1"
+version = "1.18.2"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -192,13 +192,14 @@ cluster:
   circuit_breaker:
     # Enable circuit breaker (default: true)
     enabled: true
-    # Number of consecutive failures before opening circuit (default: 5)
+    # Number of consecutive failures before opening circuit (default: 5, must be > 0)
     failure_threshold: 5
-    # Number of successes in half-open state to close circuit (default: 2)
+    # Number of successes in half-open state to close circuit (default: 2, must be > 0)
     success_threshold: 2
-    # Base backoff duration in ms when circuit opens (default: 5000)
+    # Base backoff duration in ms when circuit opens
+    # (default: 5000, must be > 0 and <= open_duration_max_ms)
     open_duration_base_ms: 5000
-    # Max backoff duration in ms with exponential backoff (default: 60000)
+    # Max backoff duration in ms with exponential backoff (default: 60000, must be > 0)
     open_duration_max_ms: 60000
     # Minimum interval in ms between recovery probes once an open circuit's
     # backoff has elapsed; limits traffic to a recovering peer until the

--- a/src/circuit_breaker.rs
+++ b/src/circuit_breaker.rs
@@ -503,9 +503,12 @@ impl CircuitBreaker {
         let base = self.config.open_duration_base_ms;
         let max = self.config.open_duration_max_ms;
 
-        // Exponential backoff: base * 2^(consecutive_opens - 1), capped at max
+        // Exponential backoff: base * 2^(consecutive_opens - 1), capped at max.
+        // `saturating_mul` guards the multiply: with a large (but valid, <= max)
+        // base, `base * 1024` could otherwise overflow u64 and wrap to a tiny
+        // value that slips under the `.min(max)` cap, collapsing the backoff.
         let exponent = consecutive_opens.saturating_sub(1).min(10);
-        let backoff_ms = (base * 2u64.pow(exponent)).min(max);
+        let backoff_ms = base.saturating_mul(2u64.pow(exponent)).min(max);
 
         Duration::from_millis(backoff_ms)
     }
@@ -594,6 +597,26 @@ mod tests {
         assert_eq!(cb.calculate_backoff(4), Duration::from_millis(8000));
         assert_eq!(cb.calculate_backoff(5), Duration::from_millis(16000));
         assert_eq!(cb.calculate_backoff(6), Duration::from_millis(30000)); // Capped
+    }
+
+    #[test]
+    fn test_backoff_saturates_instead_of_overflowing() {
+        // A large (but valid: base <= max) base must not overflow the
+        // `base * 2^exponent` multiply and wrap to a tiny value that slips
+        // under the cap. `1 << 54` times `2^10` is exactly `1 << 64`, which
+        // wraps to 0 with a plain multiply; saturating multiplication clamps,
+        // and `.min(max)` then yields the configured maximum.
+        let cb = CircuitBreaker::new(CircuitBreakerConfig {
+            open_duration_base_ms: 1u64 << 54,
+            open_duration_max_ms: 1u64 << 60,
+            ..Default::default()
+        });
+        // The exponent caps at 10, so this is (1 << 54) * (1 << 10) = 1 << 64.
+        assert_eq!(
+            cb.calculate_backoff(11),
+            Duration::from_millis(1u64 << 60),
+            "backoff must saturate to max, not wrap to ~0"
+        );
     }
 
     #[tokio::test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -165,6 +165,58 @@ impl NodeConfig {
                      or disable cluster mode."
                 ));
             }
+
+            // Validate the per-peer circuit breaker tuning. These feed the
+            // open/close thresholds and the exponential backoff
+            // (`open_duration_base_ms * 2^n`, capped at `open_duration_max_ms`).
+            // A zero value deserializes cleanly but degenerates the breaker: a
+            // zero failure or success threshold opens or closes the circuit
+            // without the intended number of failures / recovery probes, and a
+            // zero base or max collapses the backoff to nothing, so a failing
+            // peer is re-probed on every request with no spacing. A base larger
+            // than the max is immediately capped, so the backoff never grows.
+            // `half_open_probe_interval_ms` is intentionally exempt: 0 is a
+            // documented value that disables probe gating. Only checked in
+            // cluster mode with the breaker enabled, where these fields are used.
+            let cb = &self.cluster.circuit_breaker;
+            if cb.enabled {
+                if cb.failure_threshold == 0 {
+                    return Err(anyhow::anyhow!(
+                        "cluster.circuit_breaker.failure_threshold is 0; the circuit would open \
+                         without any failures, blocking all traffic to a peer. Set it to at \
+                         least 1, or disable the circuit breaker."
+                    ));
+                }
+                if cb.success_threshold == 0 {
+                    return Err(anyhow::anyhow!(
+                        "cluster.circuit_breaker.success_threshold is 0; a half-open circuit \
+                         would close without a successful recovery probe. Set it to at least 1."
+                    ));
+                }
+                if cb.open_duration_base_ms == 0 {
+                    return Err(anyhow::anyhow!(
+                        "cluster.circuit_breaker.open_duration_base_ms is 0; the open-state \
+                         backoff would collapse to zero, so a failing peer is re-probed with no \
+                         spacing. Set a positive base backoff."
+                    ));
+                }
+                if cb.open_duration_max_ms == 0 {
+                    return Err(anyhow::anyhow!(
+                        "cluster.circuit_breaker.open_duration_max_ms is 0; a zero cap forces \
+                         every backoff to zero, so a failing peer is re-probed with no spacing. \
+                         Set a positive maximum backoff."
+                    ));
+                }
+                if cb.open_duration_base_ms > cb.open_duration_max_ms {
+                    return Err(anyhow::anyhow!(
+                        "cluster.circuit_breaker.open_duration_base_ms ({}) is greater than \
+                         open_duration_max_ms ({}); the base backoff is immediately capped to the \
+                         maximum, so the exponential backoff never takes effect. Set base <= max.",
+                        cb.open_duration_base_ms,
+                        cb.open_duration_max_ms
+                    ));
+                }
+            }
         }
 
         // Validate HTTP server limits and timeouts. Each feeds a hyper or tokio
@@ -1166,6 +1218,72 @@ mod tests {
         // The gossip loop never runs with cluster disabled, so these unused
         // fields must not be rejected (avoids breaking single-node configs).
         assert!(config_with_cluster(false, 0, 0).validate().is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_valid_circuit_breaker_when_cluster_enabled() {
+        // Defaults are valid; explicit minimum values are accepted too, and a
+        // zero probe interval is a documented value (disables probe gating).
+        assert!(config_with_cluster(true, 5, 16).validate().is_ok());
+        let mut config = config_with_cluster(true, 5, 16);
+        config.cluster.circuit_breaker.failure_threshold = 1;
+        config.cluster.circuit_breaker.success_threshold = 1;
+        config.cluster.circuit_breaker.open_duration_base_ms = 1;
+        config.cluster.circuit_breaker.open_duration_max_ms = 1;
+        config.cluster.circuit_breaker.half_open_probe_interval_ms = 0;
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_zero_circuit_breaker_thresholds() {
+        let mut config = config_with_cluster(true, 5, 16);
+        config.cluster.circuit_breaker.failure_threshold = 0;
+        assert!(config.validate().is_err());
+
+        let mut config = config_with_cluster(true, 5, 16);
+        config.cluster.circuit_breaker.success_threshold = 0;
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_zero_circuit_breaker_backoff_durations() {
+        let mut config = config_with_cluster(true, 5, 16);
+        config.cluster.circuit_breaker.open_duration_base_ms = 0;
+        assert!(config.validate().is_err());
+
+        let mut config = config_with_cluster(true, 5, 16);
+        config.cluster.circuit_breaker.open_duration_max_ms = 0;
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_circuit_breaker_base_backoff_above_max() {
+        // A base larger than the cap is immediately capped, so the exponential
+        // backoff never grows — almost certainly a swapped-values misconfig.
+        let mut config = config_with_cluster(true, 5, 16);
+        config.cluster.circuit_breaker.open_duration_base_ms = 2000;
+        config.cluster.circuit_breaker.open_duration_max_ms = 1000;
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_ignores_circuit_breaker_tuning_when_breaker_disabled() {
+        // A disabled breaker never uses these fields, so they must not be rejected.
+        let mut config = config_with_cluster(true, 5, 16);
+        config.cluster.circuit_breaker.enabled = false;
+        config.cluster.circuit_breaker.failure_threshold = 0;
+        config.cluster.circuit_breaker.open_duration_base_ms = 0;
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_ignores_circuit_breaker_tuning_when_cluster_disabled() {
+        // The breaker only runs in cluster mode; single-node configs must not
+        // be rejected for unused breaker fields.
+        let mut config = config_with_cluster(false, 5, 16);
+        config.cluster.circuit_breaker.failure_threshold = 0;
+        config.cluster.circuit_breaker.open_duration_base_ms = 0;
+        assert!(config.validate().is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The per-peer circuit breaker tuning (`cluster.circuit_breaker`) had no startup validation, unlike the gossip, port, and HTTP settings already checked in `NodeConfig::validate()`. Several degenerate values deserialize cleanly but quietly degrade peer failure handling at runtime.

## What changed

Validate the circuit breaker fields at startup, when cluster mode and the breaker are both enabled (the breaker only runs between peers):

- `failure_threshold == 0` — the circuit would open without any failures, blocking all traffic to a peer.
- `success_threshold == 0` — a half-open circuit would close without a successful recovery probe.
- `open_duration_base_ms == 0` / `open_duration_max_ms == 0` — the open-state backoff collapses to zero, so a failing peer is re-probed on every request with no spacing.
- `open_duration_base_ms > open_duration_max_ms` — the base is immediately capped to the max, so the exponential backoff never grows (a swapped-values misconfig).

`half_open_probe_interval_ms` is intentionally exempt — `0` is a documented value that disables probe gating.

As defense in depth, `calculate_backoff` now uses `saturating_mul` for the `base * 2^n` step: with a large (but valid, `base <= max`) base, the multiply could otherwise overflow `u64` and wrap to a small value that slips under the `.min(max)` cap, collapsing the backoff.

## Testing

- Six `config` tests cover each rejected case, the exemptions (breaker disabled, cluster disabled), and that valid/minimum values and a zero probe interval pass.
- `test_backoff_saturates_instead_of_overflowing` uses `1 << 54` base and `2^10` multiplier (exactly `1 << 64`), which wraps to 0 with a plain multiply and saturates to the cap with the fix.
- `cargo fmt --check`, `cargo clippy --release` (zero findings), 423 unit tests, and 8 integration tests pass. The annotated example config and SPEC use valid values, so they load unchanged; the example config gained brief `> 0` / `base <= max` notes.

## Versioning

Patch bump to `1.18.2`: a startup-validation hardening with no API or runtime-behavior change for valid configs, matching the precedent set by the gossip/port/HTTP-limit validation. `CHANGELOG.md` and `Cargo.lock` are updated.

Fixes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)
