### PR TITLE
fix: preserve repeated headers when relaying to and from cluster peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.18.3] - 2026-06-19
+## [1.18.4] - 2026-06-19
+
+### Fixed
+
+- Repeated request headers are no longer dropped when forwarding to a cluster
+  peer. `build_forward_headers` copied the incoming headers with
+  `HeaderMap::insert` while iterating, but `HeaderMap::iter` yields a separate
+  entry per value and `insert` replaces all prior values for a name, so a client
+  that sent the same header more than once (e.g. multiple `Cookie` lines, or
+  repeated `Accept-Encoding`) had every value but the last silently dropped
+  before the request reached the peer. The copy now uses `append`, which
+  preserves every value; the proxy-set `x-llama-mesh-hops` and `x-request-id`
+  headers remain single-valued and authoritative. Single-valued headers (the
+  common case, including `Authorization`) are unaffected.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Repeated request headers are no longer dropped when forwarding to a cluster
-  peer. `build_forward_headers` copied the incoming headers with
-  `HeaderMap::insert` while iterating, but `HeaderMap::iter` yields a separate
-  entry per value and `insert` replaces all prior values for a name, so a client
-  that sent the same header more than once (e.g. multiple `Cookie` lines, or
-  repeated `Accept-Encoding`) had every value but the last silently dropped
-  before the request reached the peer. The copy now uses `append`, which
-  preserves every value; the proxy-set `x-llama-mesh-hops` and `x-request-id`
-  headers remain single-valued and authoritative. Single-valued headers (the
-  common case, including `Authorization`) are unaffected.
+- Repeated headers are no longer dropped when relaying between clients and
+  cluster peers. Both the outgoing request headers (`build_forward_headers`) and
+  the peer's response headers (rebuilt from the Noise transport's parsed header
+  list) were copied into a fresh `HeaderMap` with `HeaderMap::insert` while
+  iterating, but `HeaderMap::iter` yields a separate entry per value and `insert`
+  replaces all prior values for a name. A request that repeated a header (e.g.
+  multiple `Cookie` lines, or repeated `Accept-Encoding`) lost every value but
+  the last on the way to the peer, and a response that repeated one (most
+  commonly several `Set-Cookie` lines) lost every value but the last on the way
+  back to the client. Both copies now use `append`, which preserves every value;
+  the proxy-set `x-llama-mesh-hops` and `x-request-id` request headers stay
+  single-valued and authoritative. The reqwest forward path already preserved
+  repeated values (it clones the upstream map), so this brings the Noise path in
+  line. Single-valued headers (the common case, including `Authorization`) are
+  unaffected.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unaffected. Single-valued headers (the common case, including `Authorization`)
   are unchanged.
 
+## [1.18.3] - 2026-06-19
+
 ### Fixed
 
 - Config validation now rejects a zero `max_instances_per_node` at startup. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,20 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Repeated headers are no longer dropped when relaying between clients and
-  cluster peers. Both the outgoing request headers (`build_forward_headers`) and
-  the peer's response headers (rebuilt from the Noise transport's parsed header
-  list) were copied into a fresh `HeaderMap` with `HeaderMap::insert` while
-  iterating, but `HeaderMap::iter` yields a separate entry per value and `insert`
-  replaces all prior values for a name. A request that repeated a header (e.g.
-  multiple `Cookie` lines, or repeated `Accept-Encoding`) lost every value but
-  the last on the way to the peer, and a response that repeated one (most
-  commonly several `Set-Cookie` lines) lost every value but the last on the way
-  back to the client. Both copies now use `append`, which preserves every value;
-  the proxy-set `x-llama-mesh-hops` and `x-request-id` request headers stay
-  single-valued and authoritative. The reqwest forward path already preserved
-  repeated values (it clones the upstream map), so this brings the Noise path in
-  line. Single-valued headers (the common case, including `Authorization`) are
-  unaffected.
+  cluster peers. Several places rebuilt a `HeaderMap` from a header list (or
+  another map) with `HeaderMap::insert` while iterating; because `iter` yields a
+  separate entry per value and `insert` replaces all prior values for a name, a
+  header sent more than once lost every value but the last. This affected the
+  outgoing request copy (`build_forward_headers`), the encrypted-peer request
+  receiver that rebuilds the Axum request, and the encrypted-peer response relay,
+  so a request with several `Cookie` lines — or a response with several
+  `Set-Cookie` lines — was silently collapsed to a single value end to end. All
+  three now use `append`, which preserves every value; the proxy-set
+  `x-llama-mesh-hops` and `x-request-id` request headers stay single-valued and
+  authoritative. The reqwest forward path already cloned the upstream map and was
+  unaffected. Single-valued headers (the common case, including `Authorization`)
+  are unchanged.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.18.3"
+version = "1.18.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.18.3"
+version = "1.18.4"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/src/api.rs
+++ b/src/api.rs
@@ -988,6 +988,24 @@ async fn handle_noise_gossip(
     }
 }
 
+/// Rebuild an Axum request `HeaderMap` from a Noise request's parsed
+/// `(name, value)` header list. Uses `append` so a header the client sent more
+/// than once (e.g. multiple `Cookie` lines, which the Noise transport carries as
+/// separate lines) keeps every value; `insert` would drop all but the last,
+/// re-collapsing the duplicates the sender preserved.
+fn build_noise_request_headers(raw: &[(String, String)]) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    for (name, value) in raw {
+        if let (Ok(name), Ok(value)) = (
+            HeaderName::from_bytes(name.as_bytes()),
+            axum::http::HeaderValue::from_str(value),
+        ) {
+            headers.append(name, value);
+        }
+    }
+    headers
+}
+
 async fn handle_noise_http_request(
     state: Arc<NodeState>,
     request: crate::noise::transport::NoiseRequest,
@@ -997,14 +1015,7 @@ async fn handle_noise_http_request(
         .uri(request.path.as_str());
 
     if let Some(headers) = builder.headers_mut() {
-        for (name, value) in request.headers {
-            if let (Ok(name), Ok(value)) = (
-                HeaderName::from_bytes(name.as_bytes()),
-                axum::http::HeaderValue::from_str(&value),
-            ) {
-                headers.insert(name, value);
-            }
-        }
+        *headers = build_noise_request_headers(&request.headers);
     }
 
     let req = match builder.body(Body::from(request.body)) {
@@ -1092,6 +1103,31 @@ mod tests {
         let payload = version_payload("1.2.3", Some("abc1234"));
         assert_eq!(payload["version"], "1.2.3");
         assert_eq!(payload["llama_cpp_version"], "abc1234");
+    }
+
+    #[test]
+    fn build_noise_request_headers_preserves_repeated_cookie() {
+        use axum::http::header::{AUTHORIZATION, COOKIE};
+
+        // A Noise-forwarded request carries headers as separate (name, value)
+        // pairs (the sender preserves each repeated value as its own line).
+        // Rebuilding the Axum request with insert would re-collapse them;
+        // append keeps every value so the downstream handler sees them all.
+        let raw = vec![
+            ("Cookie".to_string(), "a=1".to_string()),
+            ("Authorization".to_string(), "Bearer x".to_string()),
+            ("Cookie".to_string(), "b=2".to_string()),
+        ];
+
+        let headers = build_noise_request_headers(&raw);
+
+        let cookies: Vec<&str> = headers
+            .get_all(COOKIE)
+            .iter()
+            .map(|v| v.to_str().unwrap())
+            .collect();
+        assert_eq!(cookies, vec!["a=1", "b=2"]);
+        assert_eq!(headers.get(AUTHORIZATION).unwrap(), "Bearer x");
     }
 
     #[test]

--- a/src/router.rs
+++ b/src/router.rs
@@ -350,7 +350,13 @@ fn build_forward_headers(source: &HeaderMap, current_hops: usize, request_id: &s
         ) {
             continue;
         }
-        forward_headers.insert(name.clone(), value.clone());
+        // `append`, not `insert`: a client may send the same header name more
+        // than once (e.g. multiple Cookie lines), and `HeaderMap::iter` yields a
+        // separate pair per value. `insert` would replace all prior values for
+        // the name, silently dropping every value but the last before forwarding
+        // to a peer. `append` preserves them all (the first occurrence still
+        // creates the entry).
+        forward_headers.append(name.clone(), value.clone());
     }
     forward_headers.insert(
         axum::http::header::HeaderName::from_static("x-llama-mesh-hops"),
@@ -2309,6 +2315,58 @@ mod tests {
     fn test_is_healable_error_body_rejects_missing_type() {
         let body = br#"{"error": {"message": "x"}}"#;
         assert!(!is_healable_error_body(body.as_slice()));
+    }
+
+    #[test]
+    fn build_forward_headers_preserves_repeated_request_headers() {
+        use axum::http::header::{HeaderName, AUTHORIZATION, CONNECTION, COOKIE, HOST};
+
+        // A client can send the same header name more than once (e.g. multiple
+        // Cookie lines, or repeated Accept-Encoding). HeaderMap::iter yields one
+        // pair per value and HeaderMap::insert replaces all prior values, so all
+        // but the last would be dropped before forwarding to a peer; append keeps
+        // every value.
+        let mut source = HeaderMap::new();
+        source.append(COOKIE, HeaderValue::from_static("a=1"));
+        source.append(COOKIE, HeaderValue::from_static("b=2"));
+        source.insert(AUTHORIZATION, HeaderValue::from_static("Bearer token"));
+        // Hop-by-hop headers must still be stripped.
+        source.insert(HOST, HeaderValue::from_static("example.com"));
+        source.insert(CONNECTION, HeaderValue::from_static("keep-alive"));
+        // A stale hop count carried by the incoming request must be replaced by
+        // the proxy's own count, not accumulated.
+        source.insert(
+            HeaderName::from_static("x-llama-mesh-hops"),
+            HeaderValue::from_static("2"),
+        );
+
+        let forwarded = build_forward_headers(&source, 2, "req-123");
+
+        // Both repeated cookie values survive, in order.
+        let cookies: Vec<&str> = forwarded
+            .get_all(COOKIE)
+            .iter()
+            .map(|v| v.to_str().unwrap())
+            .collect();
+        assert_eq!(cookies, vec!["a=1", "b=2"]);
+
+        // Single-valued passthrough headers are preserved.
+        assert_eq!(forwarded.get(AUTHORIZATION).unwrap(), "Bearer token");
+
+        // Hop-by-hop headers are dropped.
+        assert!(forwarded.get(HOST).is_none());
+        assert!(forwarded.get(CONNECTION).is_none());
+
+        // The proxy's hop count replaces any incoming value and stays single-valued.
+        let hops: Vec<&HeaderValue> = forwarded
+            .get_all(HeaderName::from_static("x-llama-mesh-hops"))
+            .iter()
+            .collect();
+        assert_eq!(hops.len(), 1);
+        assert_eq!(forwarded.get("x-llama-mesh-hops").unwrap(), "3");
+
+        // The request id is set.
+        assert_eq!(forwarded.get("x-request-id").unwrap(), "req-123");
     }
 
     #[test]

--- a/src/router.rs
+++ b/src/router.rs
@@ -372,6 +372,25 @@ fn build_forward_headers(source: &HeaderMap, current_hops: usize, request_id: &s
     forward_headers
 }
 
+/// Build the client-facing response header map from a peer's parsed response
+/// headers. The Noise transport delivers headers as `(name, value)` pairs (one
+/// per header line), so this rebuilds a `HeaderMap` from them — using `append`
+/// so a repeated response header (e.g. multiple `Set-Cookie` lines) keeps every
+/// value. The reqwest forward path clones the upstream `HeaderMap` wholesale and
+/// so already preserves repeated values; this keeps the Noise path consistent.
+fn build_peer_response_headers(raw: &[(String, String)]) -> HeaderMap {
+    let mut response_headers = HeaderMap::new();
+    for (name, value) in raw {
+        if let (Ok(name), Ok(value)) = (
+            axum::http::HeaderName::from_bytes(name.as_bytes()),
+            HeaderValue::from_str(value),
+        ) {
+            response_headers.append(name, value);
+        }
+    }
+    response_headers
+}
+
 async fn send_peer_request(
     state: &NodeState,
     request: PeerRequest<'_>,
@@ -402,15 +421,7 @@ async fn send_peer_request(
         let status = StatusCode::from_u16(response.head.status).map_err(|e| {
             AppError::internal_server_error(format!("Invalid peer response status: {e}"))
         })?;
-        let mut response_headers = HeaderMap::new();
-        for (name, value) in &response.head.headers {
-            if let (Ok(name), Ok(value)) = (
-                axum::http::HeaderName::from_bytes(name.as_bytes()),
-                HeaderValue::from_str(value),
-            ) {
-                response_headers.insert(name, value);
-            }
-        }
+        let response_headers = build_peer_response_headers(&response.head.headers);
 
         Ok(PeerResponse::Noise {
             status,
@@ -2367,6 +2378,31 @@ mod tests {
 
         // The request id is set.
         assert_eq!(forwarded.get("x-request-id").unwrap(), "req-123");
+    }
+
+    #[test]
+    fn build_peer_response_headers_preserves_repeated_set_cookie() {
+        use axum::http::header::{CONTENT_TYPE, SET_COOKIE};
+
+        // A peer's response can carry the same header more than once — most
+        // commonly several Set-Cookie lines. The Noise transport delivers these
+        // as separate (name, value) pairs; rebuilding with insert would keep
+        // only the last, append keeps them all.
+        let raw = vec![
+            ("Set-Cookie".to_string(), "a=1".to_string()),
+            ("Content-Type".to_string(), "application/json".to_string()),
+            ("Set-Cookie".to_string(), "b=2".to_string()),
+        ];
+
+        let headers = build_peer_response_headers(&raw);
+
+        let cookies: Vec<&str> = headers
+            .get_all(SET_COOKIE)
+            .iter()
+            .map(|v| v.to_str().unwrap())
+            .collect();
+        assert_eq!(cookies, vec!["a=1", "b=2"]);
+        assert_eq!(headers.get(CONTENT_TYPE).unwrap(), "application/json");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When relaying between a client and a cluster peer, llamesh rebuilt a `HeaderMap` with `HeaderMap::insert` while iterating, in three places along the encrypted (Noise) path:

- `build_forward_headers` — outgoing request headers → peer
- `handle_noise_http_request` (now `build_noise_request_headers`) — the receiving peer rebuilding the Axum request
- the Noise response relay (now `build_peer_response_headers`) — peer response headers → client

`HeaderMap::iter` yields a separate entry per value and `insert` replaces all prior values for a name, so a repeated header lost every value but the last. Because the bug sat on both the send and receive sides of the request hop, a multi-value request header was collapsed end to end: even though the sender preserved it and the wire serializer writes one line per value, the receiving peer re-collapsed it. On the response side, a peer returning several `Set-Cookie` lines had all but the last dropped before reaching the client.

All three copies now use `HeaderMap::append`, which preserves every value (the first occurrence still creates the entry). The proxy-set `x-llama-mesh-hops` and `x-request-id` request headers stay `insert`, so they remain single-valued and authoritative. The reqwest forward path already preserved repeated values (it clones the upstream `HeaderMap`), so it was unaffected. Single-valued headers (the common case, including `Authorization`) are unchanged.

Fixes #131.

## Changes

- `build_forward_headers`: `insert` → `append` in the request passthrough-copy loop.
- New `build_noise_request_headers` helper (extracted from `handle_noise_http_request`): rebuilds the incoming Axum request `HeaderMap` with `append`.
- New `build_peer_response_headers` helper (extracted from the inline Noise response loop): rebuilds the client-facing `HeaderMap` with `append`.
- Three unit tests, one per site (repeated `Cookie` preserved on forward and on receive; repeated `Set-Cookie` preserved on response); these copy paths had no prior unit coverage.
- Version bump to 1.18.4 and CHANGELOG entry.

## Testing

- `cargo test --bin llamesh` — 430 passed (was 427; +3 new). Each new test fails before its fix (`["b=2"]` vs `["a=1", "b=2"]`) and passes after.
- All integration tests pass (22 across 10 files), including the peer-forward suites.
- `cargo fmt --check` clean; `cargo clippy` adds no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
