### PR TITLE
docs: correct config/spec values that don't match the code defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.18.5] - 2026-06-19
+
+### Documentation
+
+- Corrected two reference values in the example config and `SPEC.md` that did
+  not match the code. Under "Local paths (defaults shown)", `llama_cpp.binary_path`
+  carried a stray `build/` segment (`./llama.cpp/build/bin/llama-server`) where
+  the actual default is `./llama.cpp/bin/llama-server`; the sibling `repo_path`
+  and `build_path` already matched their defaults, so deleting the line yielded a
+  different path than the comment promised. And the idle-eviction "fallback
+  timeout" prose in `SPEC.md` said 600 seconds where the default is 300 (the same
+  document's example config already noted "default 300"). The
+  example-validation test now asserts the documented local paths equal their
+  `default_*()` functions, so they cannot silently drift again.
+
 ## [1.18.4] - 2026-06-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.18.4"
+version = "1.18.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.18.4"
+version = "1.18.5"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/SPEC.md
+++ b/SPEC.md
@@ -159,7 +159,7 @@ llama_cpp:
   repo_url: "https://github.com/ggml-org/llama.cpp.git"
   repo_path: "./llama.cpp"
   build_path: "./llama.cpp/build"
-  binary_path: "./llama.cpp/build/bin/llama-server"
+  binary_path: "./llama.cpp/bin/llama-server"
   branch: "master"                       # use release tag (e.g., "b6115") to pin version
   build_args:
     - "-DGGML_CUDA=ON"
@@ -961,7 +961,7 @@ Each instance is a `llama-server` process spawned by the proxy:
   * If `now - last_activity_time > idle_timeout_seconds` and `in_flight_requests == 0`:
 
     * Terminate instance gracefully.
-  * Fallback timeout of 600 seconds is applied if no profile-specific timeout is set.
+  * Fallback timeout of 300 seconds is applied if no profile-specific timeout is set.
 
 * Background monitoring:
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -95,7 +95,7 @@ llama_cpp:
   # Local paths (defaults shown)
   repo_path: "./llama.cpp"
   build_path: "./llama.cpp/build"
-  binary_path: "./llama.cpp/build/bin/llama-server"
+  binary_path: "./llama.cpp/bin/llama-server"
 
   # Branch, tag, or commit to build
   # Use release tags (e.g., "b6115") for stability, "master" for latest

--- a/src/config.rs
+++ b/src/config.rs
@@ -1585,6 +1585,12 @@ models:
         assert_eq!(config.http.body_read_timeout_ms, 30_000);
         assert_eq!(config.http.protocol_detect_timeout_ms, 10_000);
 
+        // The "# Local paths (defaults shown)" block must actually show the
+        // defaults, so deleting any of these lines yields the documented path.
+        assert_eq!(config.llama_cpp.repo_path, default_repo_path());
+        assert_eq!(config.llama_cpp.build_path, default_build_path());
+        assert_eq!(config.llama_cpp.binary_path, default_binary_path());
+
         let cookbook =
             load_cookbook(Path::new("cookbook.example.yaml")).expect("cookbook.example.yaml loads");
         cookbook


### PR DESCRIPTION
## Summary

Two reference values in the annotated docs had drifted from the code:

- **`llama_cpp.binary_path`** in `config.example.yaml` (under `# Local paths (defaults shown)`) and the reference config in `SPEC.md` showed `./llama.cpp/build/bin/llama-server`, but `default_binary_path()` returns `./llama.cpp/bin/llama-server`. The sibling `repo_path`/`build_path` already match their defaults exactly, so the stray `build/` segment (present since v1.0.0) was a typo — deleting the line to take the default yielded a different path than the comment promised. `binary_path` is the symlink location the build manager creates, so any value works; this just makes the documented "default" honest.
- **`SPEC.md` idle-eviction fallback prose** said 600 seconds, but the default is 300 (`default_idle_timeout_seconds`), which the same document's example config already notes (`# optional, default 300`).

Fixes #133.

## Changes

- `config.example.yaml` + `SPEC.md`: `binary_path` → `./llama.cpp/bin/llama-server`.
- `SPEC.md`: idle-eviction fallback timeout `600` → `300`.
- Extended the existing `example_config_and_cookbook_load_and_validate` test to assert the example's `repo_path`/`build_path`/`binary_path` equal their `default_*()` functions, so the "defaults shown" block can't silently drift again.
- Version bump to 1.18.5 and CHANGELOG entry (Documentation).

## Testing

- `cargo test --bin llamesh` — 430 passed. The new `binary_path` assertion fails before the example fix (`./llama.cpp/build/bin/llama-server` vs `./llama.cpp/bin/llama-server`) and passes after.
- `cargo fmt --check` clean; `cargo clippy` adds no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
