### PR TITLE
fix: locate the Noise frame header/body boundary on raw bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.18.6] - 2026-06-19
+
+### Fixed
+
+- Noise HTTP frame parsing now locates the header/body boundary on the raw
+  bytes instead of a UTF-8-lossy view. `parse_http_request` and
+  `parse_http_response_head` found the `\r\n\r\n` boundary in a
+  `String::from_utf8_lossy(data)` and then applied that offset to slice the body
+  out of the original `data`. The two offset spaces diverge if any byte before
+  the boundary is invalid UTF-8 — `from_utf8_lossy` expands each to a 3-byte
+  U+FFFD — so a non-ASCII header byte would shift the body slice and corrupt the
+  forwarded request/response body. The peers that build these frames only emit
+  ASCII headers, so this was not reachable in practice, but the parser is now
+  robust to its byte input regardless. Parsing of valid ASCII headers is
+  unchanged.
+
 ## [1.18.5] - 2026-06-19
 
 ### Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.18.5"
+version = "1.18.6"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.18.5"
+version = "1.18.6"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/src/noise/transport.rs
+++ b/src/noise/transport.rs
@@ -290,17 +290,23 @@ pub async fn send_data(
     Ok(())
 }
 
+/// Find the byte offset of the `\r\n\r\n` header/body boundary in a raw HTTP
+/// frame, searching the raw bytes so the returned offset stays consistent with
+/// slicing the original buffer for the body.
+fn find_header_boundary(data: &[u8]) -> Option<usize> {
+    data.windows(4).position(|w| w == b"\r\n\r\n")
+}
+
 /// Parse HTTP request from bytes
 fn parse_http_request(data: &[u8]) -> Result<NoiseRequest> {
-    let data_str = String::from_utf8_lossy(data);
-
-    // Find header/body boundary
-    let header_end = data_str
-        .find("\r\n\r\n")
+    // Find the header/body boundary on the raw bytes so `body_start` stays
+    // consistent with slicing `data` for the body below. Searching a
+    // String::from_utf8_lossy view would expand any non-ASCII header byte to a
+    // 3-byte U+FFFD and shift the offset relative to the original buffer.
+    let header_end = find_header_boundary(data)
         .ok_or_else(|| NoiseError::Transport("Invalid HTTP request: no header boundary".into()))?;
-
-    let header_part = &data_str[..header_end];
     let body_start = header_end + 4;
+    let header_part = String::from_utf8_lossy(&data[..header_end]);
 
     // Parse request line
     let mut lines = header_part.lines();
@@ -336,13 +342,12 @@ fn parse_http_request(data: &[u8]) -> Result<NoiseRequest> {
 }
 
 fn parse_http_response_head(data: &[u8]) -> Result<NoiseResponseHead> {
-    let data_str = String::from_utf8_lossy(data);
-    let header_end = data_str
-        .find("\r\n\r\n")
+    // Boundary on the raw bytes so `body_start` matches the original buffer
+    // (see parse_http_request).
+    let header_end = find_header_boundary(data)
         .ok_or_else(|| NoiseError::Transport("Invalid HTTP response: no header boundary".into()))?;
-
-    let header_part = &data_str[..header_end];
     let body_start = header_end + 4;
+    let header_part = String::from_utf8_lossy(&data[..header_end]);
     let mut lines = header_part.lines();
     let status_line = lines
         .next()
@@ -484,6 +489,36 @@ mod tests {
         let request = b"\r\n\r\n";
         let result = parse_http_request(request);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_http_request_non_ascii_header_byte_keeps_body_intact() {
+        // A non-ASCII byte in the header region must not shift the body slice.
+        // The header/body boundary is found on the raw bytes, so the body offset
+        // stays consistent with the original buffer. Computing it against a
+        // String::from_utf8_lossy view instead would expand each invalid byte to
+        // a 3-byte U+FFFD and slice the body in the wrong place.
+        let mut request: Vec<u8> = Vec::new();
+        request.extend_from_slice(b"POST /v1/x HTTP/1.1\r\nX-Bin: ");
+        request.extend_from_slice(&[0xFF, 0xFE]); // invalid UTF-8 in a header value
+        request.extend_from_slice(b"\r\n\r\nBODYDATA123");
+
+        let parsed = parse_http_request(&request).unwrap();
+        assert_eq!(parsed.method, "POST");
+        assert_eq!(parsed.path, "/v1/x");
+        assert_eq!(parsed.body.as_ref(), b"BODYDATA123");
+    }
+
+    #[test]
+    fn test_parse_http_response_head_non_ascii_header_byte_keeps_body_intact() {
+        let mut response: Vec<u8> = Vec::new();
+        response.extend_from_slice(b"HTTP/1.1 200 OK\r\nX-Bin: ");
+        response.extend_from_slice(&[0xFF, 0xFE]); // invalid UTF-8 in a header value
+        response.extend_from_slice(b"\r\n\r\nFIRSTBODY");
+
+        let parsed = parse_http_response_head(&response).unwrap();
+        assert_eq!(parsed.status, 200);
+        assert_eq!(parsed.first_body.as_ref(), b"FIRSTBODY");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`parse_http_request` and `parse_http_response_head` (`src/noise/transport.rs`) found the `\r\n\r\n` header/body boundary in a `String::from_utf8_lossy(data)` view and then used that offset to slice the body out of the original raw `data`. `header_end` is an offset into the lossy-decoded string, but `body_start` indexes the raw bytes — and the two diverge when a byte before the boundary is invalid UTF-8, because `from_utf8_lossy` expands each to a 3-byte `U+FFFD`. A non-ASCII header byte would therefore shift the body slice and corrupt the forwarded request/response body.

The fix finds the boundary on the raw bytes (`find_header_boundary`, a `windows(4).position(...)` scan) so the offset matches the slice, and decodes only the header region lossily for parsing. The boundary's byte position is identical for valid ASCII headers, so behavior is unchanged for all real traffic — this only corrects the malformed/non-ASCII case.

The peers that build these frames only emit ASCII headers (`HeaderValue::to_str()` is checked before serialization), so the divergence is **not reachable in normal operation** — this is latent robustness hardening on the encrypted transport, not a live defect.

Fixes #135.

## Changes

- New `find_header_boundary` helper; `parse_http_request` and `parse_http_response_head` use it for a raw-byte boundary offset and decode only `data[..header_end]` lossily for header parsing.
- Two unit tests (request and response) feeding a non-ASCII header byte and asserting the body is sliced intact (each fails before the fix: body shifted by the 4-byte `U+FFFD` expansion).

## Testing

- `cargo test --bin llamesh` — 432 passed (was 430; +2 new). The existing `parse_http_*` tests are unchanged and still pass (ASCII behavior identical).
- All integration tests pass (22 across 10 files), including the Noise peer-forward suites.
- `cargo fmt --check` clean; `cargo clippy` adds no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
