### PR TITLE
fix: add opt-in upstream_read_timeout_ms to release stalled local request slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,23 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.18.7] - 2026-06-20
 
-### Fixed
+### Added
 
-- A stalled local `llama-server` request no longer holds its in-flight slot
-  forever (which could hang a graceful drain indefinitely). The shared HTTP
-  client used to reach local instances had no timeout, so a request whose
-  upstream accepted it and then went silent — connection held open, no further
-  bytes — never completed: `current_requests` stayed above zero, `is_idle()`
-  never returned true, and a restart's graceful drain waited until the process
-  was killed by hand. The client now carries an inactivity `read_timeout`,
-  configurable via `upstream_read_timeout_ms` (default 600000 = 10 minutes;
-  `0` disables it). It is a per-chunk timer — reqwest resets it on every
-  response chunk — so a slow but actively-streaming generation is unaffected;
-  only a genuinely silent upstream is aborted, which releases the slot. The
-  default is generous enough to cover large-context prefill. A local body-read
-  failure (which this timeout now makes reachable) is also recorded in the
-  request error metrics, matching the existing send-failure and peer-forward
-  accounting. The cluster peer-forward paths share the same exposure and are
+- New `upstream_read_timeout_ms` option: an inactivity (read) timeout for
+  outbound requests to a local `llama-server`. A stalled upstream — one that
+  accepts a request and then goes silent (connection held open, no further
+  bytes) — otherwise holds its in-flight slot forever, so `current_requests`
+  never returns to zero and a graceful drain can hang until the process is
+  killed by hand. With this set, the request is aborted after the configured
+  silence and the slot is released. It is a per-chunk timer (reqwest resets it
+  on every response chunk), so an actively-streaming generation is unaffected.
+  Disabled by default (`0`): the timer also covers the wait for the first body
+  bytes, and a `stream: false` response only arrives once generation finishes,
+  so a non-zero value shorter than a request's full generation time would abort
+  a legitimate request — enable it only for deployments whose requests stream
+  tokens regularly. The cluster peer-forward paths share the exposure and are
   tracked separately.
 
 ## [1.18.6] - 2026-06-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.18.6] - 2026-06-19
+## [1.18.7] - 2026-06-20
+
+### Fixed
+
+- A stalled local `llama-server` request no longer holds its in-flight slot
+  forever (which could hang a graceful drain indefinitely). The shared HTTP
+  client used to reach local instances had no timeout, so a request whose
+  upstream accepted it and then went silent — connection held open, no further
+  bytes — never completed: `current_requests` stayed above zero, `is_idle()`
+  never returned true, and a restart's graceful drain waited until the process
+  was killed by hand. The client now carries an inactivity `read_timeout`,
+  configurable via `upstream_read_timeout_ms` (default 600000 = 10 minutes;
+  `0` disables it). It is a per-chunk timer — reqwest resets it on every
+  response chunk — so a slow but actively-streaming generation is unaffected;
+  only a genuinely silent upstream is aborted, which releases the slot. The
+  default is generous enough to cover large-context prefill. The cluster
+  peer-forward paths share the same exposure and are tracked separately.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `0` disables it). It is a per-chunk timer — reqwest resets it on every
   response chunk — so a slow but actively-streaming generation is unaffected;
   only a genuinely silent upstream is aborted, which releases the slot. The
-  default is generous enough to cover large-context prefill. The cluster
-  peer-forward paths share the same exposure and are tracked separately.
+  default is generous enough to cover large-context prefill. A local body-read
+  failure (which this timeout now makes reachable) is also recorded in the
+  request error metrics, matching the existing send-failure and peer-forward
+  accounting. The cluster peer-forward paths share the same exposure and are
+  tracked separately.
 
 ## [1.18.6] - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   default is generous enough to cover large-context prefill. The cluster
   peer-forward paths share the same exposure and are tracked separately.
 
+## [1.18.6] - 2026-06-19
+
 ### Fixed
 
 - Noise HTTP frame parsing now locates the header/body boundary on the raw

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.18.6"
+version = "1.18.7"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.18.6"
+version = "1.18.7"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -70,13 +70,16 @@ model_defaults:
 # pressure from queued requests. (default: 0)
 max_total_queue_entries: 0
 
-# Inactivity timeout (ms) for outbound requests to a local llama-server. This is
-# a per-chunk read timeout, NOT a total deadline: it resets on every response
-# chunk, so a slow-but-active stream is unaffected while a stalled upstream (a
-# process that stops sending mid-response) is aborted instead of holding its
-# in-flight slot forever (which would block graceful drain). Set generously
-# enough to cover large-context prefill; 0 disables it. (default: 600000 = 10m)
-upstream_read_timeout_ms: 600000
+# Inactivity (read) timeout in ms for outbound requests to a local llama-server.
+# A stalled upstream (one that stops sending mid-response) otherwise holds its
+# in-flight slot forever, which can hang a graceful drain. It is a per-chunk
+# timer (reset on every chunk), so it bounds silence between streamed tokens
+# without aborting an actively-streaming generation. DISABLED by default (0): the
+# timer also covers the wait for the first body bytes, and a `stream: false`
+# response arrives only when generation finishes, so any non-zero value shorter
+# than a request's full generation time would abort a legitimate request. Set a
+# positive value (e.g. 600000) only if your requests stream tokens regularly.
+upstream_read_timeout_ms: 0
 
 # -----------------------------------------------------------------------------
 # llama-server Port Allocation

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -70,6 +70,14 @@ model_defaults:
 # pressure from queued requests. (default: 0)
 max_total_queue_entries: 0
 
+# Inactivity timeout (ms) for outbound requests to a local llama-server. This is
+# a per-chunk read timeout, NOT a total deadline: it resets on every response
+# chunk, so a slow-but-active stream is unaffected while a stalled upstream (a
+# process that stops sending mid-response) is aborted instead of holding its
+# in-flight slot forever (which would block graceful drain). Set generously
+# enough to cover large-context prefill; 0 disables it. (default: 600000 = 10m)
+upstream_read_timeout_ms: 600000
+
 # -----------------------------------------------------------------------------
 # llama-server Port Allocation
 # -----------------------------------------------------------------------------

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -665,6 +665,7 @@ mod tests {
             max_hops: 10,
             logging: None,
             max_total_queue_entries: 0,
+            upstream_read_timeout_ms: 600_000,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,13 +53,17 @@ pub struct NodeConfig {
     #[serde(default = "default_max_total_queue_entries")]
     pub max_total_queue_entries: usize,
     /// Inactivity (read) timeout in milliseconds for outbound requests to a
-    /// local `llama-server` instance. reqwest resets this on every received
-    /// response chunk, so it bounds *silence* from a stalled upstream (a process
-    /// that accepted the request but then stops sending, e.g. a hung instance at
-    /// 0% CPU) without affecting a slow-but-active stream. Without it, such a
-    /// request holds its in-flight slot forever, which (among other things)
-    /// blocks graceful drain on shutdown. Set generously (the default tolerates
-    /// large-context prefill); `0` disables it.
+    /// local `llama-server` instance. A stalled upstream (one that accepted the
+    /// request then stops sending, e.g. a hung instance at 0% CPU) otherwise
+    /// holds its in-flight slot forever, which can hang a graceful drain. reqwest
+    /// resets this on every received chunk, so for a streaming response it bounds
+    /// silence between tokens without affecting an actively-streaming generation.
+    /// Disabled by default (`0`): the timer also covers the wait for the first
+    /// body bytes — and for `stream: false` the body arrives only when generation
+    /// finishes — so any non-zero value shorter than a request's full generation
+    /// time would abort a legitimate long or non-streaming request. Enable it
+    /// (a positive ms) when requests stream tokens regularly and stalled
+    /// upstreams should be bounded.
     #[serde(default = "default_upstream_read_timeout_ms")]
     pub upstream_read_timeout_ms: u64,
 }
@@ -77,7 +81,8 @@ fn default_max_total_queue_entries() -> usize {
 }
 
 fn default_upstream_read_timeout_ms() -> u64 {
-    600_000 // 10 minutes: generous enough for large-context prefill, bounds a stalled upstream
+    0 // disabled by default; a non-zero default would abort legitimate long /
+      // non-streaming requests (see the field doc). Opt in per deployment.
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,6 +52,16 @@ pub struct NodeConfig {
     /// 0 = no global limit (only per-model limits apply).
     #[serde(default = "default_max_total_queue_entries")]
     pub max_total_queue_entries: usize,
+    /// Inactivity (read) timeout in milliseconds for outbound requests to a
+    /// local `llama-server` instance. reqwest resets this on every received
+    /// response chunk, so it bounds *silence* from a stalled upstream (a process
+    /// that accepted the request but then stops sending, e.g. a hung instance at
+    /// 0% CPU) without affecting a slow-but-active stream. Without it, such a
+    /// request holds its in-flight slot forever, which (among other things)
+    /// blocks graceful drain on shutdown. Set generously (the default tolerates
+    /// large-context prefill); `0` disables it.
+    #[serde(default = "default_upstream_read_timeout_ms")]
+    pub upstream_read_timeout_ms: u64,
 }
 
 fn default_shutdown_grace_period_seconds() -> u64 {
@@ -64,6 +74,10 @@ fn default_max_hops() -> usize {
 
 fn default_max_total_queue_entries() -> usize {
     0 // 0 = no global limit (only per-model limits apply)
+}
+
+fn default_upstream_read_timeout_ms() -> u64 {
+    600_000 // 10 minutes: generous enough for large-context prefill, bounds a stalled upstream
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -1075,6 +1089,7 @@ mod tests {
             max_hops: 10,
             logging: None,
             max_total_queue_entries: 0,
+            upstream_read_timeout_ms: 600_000,
         };
 
         assert!(config.validate().is_err());
@@ -1132,6 +1147,7 @@ mod tests {
             max_hops: 10,
             logging: None,
             max_total_queue_entries: 0,
+            upstream_read_timeout_ms: 600_000,
         }
     }
 
@@ -1590,6 +1606,10 @@ models:
         assert_eq!(config.llama_cpp.repo_path, default_repo_path());
         assert_eq!(config.llama_cpp.build_path, default_build_path());
         assert_eq!(config.llama_cpp.binary_path, default_binary_path());
+        assert_eq!(
+            config.upstream_read_timeout_ms,
+            default_upstream_read_timeout_ms()
+        );
 
         let cookbook =
             load_cookbook(Path::new("cookbook.example.yaml")).expect("cookbook.example.yaml loads");

--- a/src/health.rs
+++ b/src/health.rs
@@ -132,6 +132,7 @@ mod tests {
             max_hops: 10,
             logging: None,
             max_total_queue_entries: 0,
+            upstream_read_timeout_ms: 600_000,
         }
     }
 

--- a/src/node_state/mod.rs
+++ b/src/node_state/mod.rs
@@ -396,7 +396,19 @@ impl NodeState {
         build_manager: BuildManager,
     ) -> Result<Self> {
         let cluster_client = security::build_cluster_client(&config.cluster_tls)?;
-        let http_client = reqwest::Client::builder().build()?;
+        // `read_timeout` bounds inactivity (silence) from a local llama-server,
+        // not total duration: reqwest resets it on every received chunk, so a
+        // slow-but-active stream is unaffected while a stalled upstream (which
+        // would otherwise hold its in-flight slot forever and block graceful
+        // drain) is aborted. 0 disables it.
+        let http_client = {
+            let mut builder = reqwest::Client::builder();
+            if config.upstream_read_timeout_ms > 0 {
+                builder =
+                    builder.read_timeout(Duration::from_millis(config.upstream_read_timeout_ms));
+            }
+            builder.build()?
+        };
 
         let metrics = Metrics::load(std::path::Path::new(&config.metrics_path)).await;
         let model_index = Arc::new(ModelIndex::new(&cookbook));
@@ -3788,6 +3800,7 @@ mod tests {
             max_hops: 10,
             logging: None,
             max_total_queue_entries: 0,
+            upstream_read_timeout_ms: 600_000,
         }
     }
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -1228,8 +1228,21 @@ pub async fn route_request(
                             Ok(if response_streaming {
                                 build_streaming_response(resp, cleanup_fut, tokens_counter)
                             } else {
-                                handle_non_streaming_response(resp, cleanup_fut, tokens_counter)
-                                    .await
+                                let (resp, body_read_failed) = handle_non_streaming_response(
+                                    resp,
+                                    cleanup_fut,
+                                    tokens_counter,
+                                )
+                                .await;
+                                if body_read_failed {
+                                    // A read timeout / reset while reading the local
+                                    // body surfaces here as a 502; count it like the
+                                    // send-error case above (the guard handles the
+                                    // in-flight/current-request cleanup).
+                                    state.metrics.inc_errors();
+                                    hash_metrics.errors_total.fetch_add(1, Ordering::Relaxed);
+                                }
+                                resp
                             })
                         }
                         Err(e) => {
@@ -1689,11 +1702,16 @@ pub async fn route_request(
     .await
 }
 
+/// Reads a non-streaming upstream response and builds the client response. The
+/// returned `bool` is `true` when reading the upstream body failed (e.g. the
+/// upstream went silent and the client's read timeout fired, or the connection
+/// reset mid-body); the caller is responsible for recording that as an error,
+/// since this failure mode is otherwise invisible to the error metrics.
 async fn handle_non_streaming_response(
     resp: reqwest::Response,
     cleanup: BoxFuture<'static, ()>,
     tokens_generated: Arc<AtomicU64>,
-) -> Response<Body> {
+) -> (Response<Body>, bool) {
     // `AutoCleanup` guarantees `cleanup` runs exactly once — either when this
     // function returns normally, or if the enclosing task is cancelled while
     // awaiting the body (e.g. client disconnect mid-read). Without this
@@ -1710,12 +1728,17 @@ async fn handle_non_streaming_response(
         Ok(b) => b,
         Err(e) => {
             error!("Failed to read upstream response body: {}", e);
-            return AppError::upstream_error(format!("Failed to read upstream response body: {e}"))
-                .into_response();
+            let resp =
+                AppError::upstream_error(format!("Failed to read upstream response body: {e}"))
+                    .into_response();
+            return (resp, true);
         }
     };
 
-    build_non_streaming_body_response(status, headers, bytes, tokens_generated)
+    (
+        build_non_streaming_body_response(status, headers, bytes, tokens_generated),
+        false,
+    )
 }
 
 fn build_non_streaming_body_response(
@@ -1829,7 +1852,11 @@ async fn peer_response_to_client(
             if stream_requested {
                 build_streaming_response(resp, cleanup, tokens_generated)
             } else {
-                handle_non_streaming_response(resp, cleanup, tokens_generated).await
+                // Peer body-read failures are accounted for on the forward path
+                // (`attempt_peer_forward`), so the error flag is ignored here.
+                handle_non_streaming_response(resp, cleanup, tokens_generated)
+                    .await
+                    .0
             }
         }
         PeerResponse::Noise {

--- a/src/router.rs
+++ b/src/router.rs
@@ -1228,21 +1228,8 @@ pub async fn route_request(
                             Ok(if response_streaming {
                                 build_streaming_response(resp, cleanup_fut, tokens_counter)
                             } else {
-                                let (resp, body_read_failed) = handle_non_streaming_response(
-                                    resp,
-                                    cleanup_fut,
-                                    tokens_counter,
-                                )
-                                .await;
-                                if body_read_failed {
-                                    // A read timeout / reset while reading the local
-                                    // body surfaces here as a 502; count it like the
-                                    // send-error case above (the guard handles the
-                                    // in-flight/current-request cleanup).
-                                    state.metrics.inc_errors();
-                                    hash_metrics.errors_total.fetch_add(1, Ordering::Relaxed);
-                                }
-                                resp
+                                handle_non_streaming_response(resp, cleanup_fut, tokens_counter)
+                                    .await
                             })
                         }
                         Err(e) => {
@@ -1702,16 +1689,11 @@ pub async fn route_request(
     .await
 }
 
-/// Reads a non-streaming upstream response and builds the client response. The
-/// returned `bool` is `true` when reading the upstream body failed (e.g. the
-/// upstream went silent and the client's read timeout fired, or the connection
-/// reset mid-body); the caller is responsible for recording that as an error,
-/// since this failure mode is otherwise invisible to the error metrics.
 async fn handle_non_streaming_response(
     resp: reqwest::Response,
     cleanup: BoxFuture<'static, ()>,
     tokens_generated: Arc<AtomicU64>,
-) -> (Response<Body>, bool) {
+) -> Response<Body> {
     // `AutoCleanup` guarantees `cleanup` runs exactly once — either when this
     // function returns normally, or if the enclosing task is cancelled while
     // awaiting the body (e.g. client disconnect mid-read). Without this
@@ -1728,17 +1710,12 @@ async fn handle_non_streaming_response(
         Ok(b) => b,
         Err(e) => {
             error!("Failed to read upstream response body: {}", e);
-            let resp =
-                AppError::upstream_error(format!("Failed to read upstream response body: {e}"))
-                    .into_response();
-            return (resp, true);
+            return AppError::upstream_error(format!("Failed to read upstream response body: {e}"))
+                .into_response();
         }
     };
 
-    (
-        build_non_streaming_body_response(status, headers, bytes, tokens_generated),
-        false,
-    )
+    build_non_streaming_body_response(status, headers, bytes, tokens_generated)
 }
 
 fn build_non_streaming_body_response(
@@ -1852,11 +1829,7 @@ async fn peer_response_to_client(
             if stream_requested {
                 build_streaming_response(resp, cleanup, tokens_generated)
             } else {
-                // Peer body-read failures are accounted for on the forward path
-                // (`attempt_peer_forward`), so the error flag is ignored here.
-                handle_non_streaming_response(resp, cleanup, tokens_generated)
-                    .await
-                    .0
+                handle_non_streaming_response(resp, cleanup, tokens_generated).await
             }
         }
         PeerResponse::Noise {


### PR DESCRIPTION
## Summary

A request to a local `llama-server` could hold its in-flight slot forever, which can hang a graceful drain indefinitely. The shared HTTP client used to reach local instances (`src/node_state/mod.rs`) was built with no timeout, and the only per-request timeout (`max_request_duration_ms`) defaults to `0` (unlimited). So when a local instance returns `200`, opens its response body, and then goes silent — connection held open, no further bytes — the proxy waits forever: `current_requests` stays above zero, `is_idle()` never returns true, and a restart's drain waits until the process is killed by hand (the operator observed a ~30-minute drain ended only by killing an idle-but-stuck `llama-server`). The same hang keeps idle-eviction from reclaiming the stuck instance (eviction requires `in_flight_requests == 0`).

This adds an inactivity `read_timeout` on the local client, exposed as a new `upstream_read_timeout_ms` option. reqwest resets `read_timeout` on every received response chunk, so it is a **per-chunk inactivity timer, not a total deadline**: an actively-streaming generation is unaffected; only a genuinely silent upstream is aborted, which ends the stream, runs the existing cleanup, and releases the slot.

**Disabled by default (`0`).** The read timer also covers the wait for the *first* body bytes, and a `stream: false` response only arrives once generation finishes — so any non-zero value shorter than a request's full generation time would abort a legitimate long or non-streaming request. It is therefore opt-in: enable it (a positive ms) for deployments whose requests stream tokens regularly and where stalled upstreams should be bounded. This keeps the default "unlimited request duration" behavior unchanged.

Addresses #137 (provides the mechanism to bound the stall that causes the hang). The cluster peer-forward paths share the exposure and are tracked in #138. Consistent local body-read-failure error accounting (a pre-existing gap, both streaming and non-streaming) is tracked in #140.

## Changes

- New `upstream_read_timeout_ms` `NodeConfig` field (default `0` = disabled); the local `http_client` is built with `.read_timeout(...)` only when it is non-zero.
- `config.example.yaml`: documented the field (per-chunk semantics, the first-byte/non-streaming caveat, `0` disables).
- `example_config_and_cookbook_load_and_validate` asserts the example value equals the default (drift guard).

## Testing

- `cargo test --bin llamesh` — 432 passed; all integration tests pass (22). With the default `0` there is no behavior change.
- `cargo fmt --check` clean; `cargo clippy` adds no new warnings.
- **Manual reproduction** against the running proxy: with a local upstream that sends `200` + first chunk then stalls, `current_requests` holds at 1 indefinitely with the timeout disabled (the bug) and is released ~`read_timeout` after the stall begins with it enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
