### PR TITLE
chore: clear clippy --all-targets warnings for a clean full-target gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.19.3] - 2026-06-21
+
+### Changed
+
+- Cleared the remaining `cargo clippy --all-targets` warnings so the full-target
+  lint is a clean gate (previously only `--bin llamesh` was clean): a test
+  helper's complex boxed-future return type is now a named type alias, and the
+  non-empty `SCHEDULED_UPDATE_RETRY_DELAYS` invariant is enforced by a
+  compile-time assertion next to the constant (stronger than the former runtime
+  test, which clippy flagged as an always-true `const` check). No runtime
+  behavior change.
+
 ## [1.19.2] - 2026-06-20
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.19.2"
+version = "1.19.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.19.2"
+version = "1.19.3"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,11 @@ const SCHEDULED_UPDATE_RETRY_DELAYS: &[Duration] = &[
     Duration::from_secs(300),
 ];
 
+// An empty schedule would silently make a single `git fetch` blip skip a whole
+// `auto_update_interval_seconds` (commonly a day) and log it at ERROR as a build
+// failure. Enforce a non-empty schedule at compile time.
+const _: () = assert!(!SCHEDULED_UPDATE_RETRY_DELAYS.is_empty());
+
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
@@ -526,14 +531,8 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
-    // A scheduled-update cycle must retry transient failures. An empty delay
-    // schedule would silently make a single `git fetch` blip skip a whole
-    // auto_update_interval_seconds (commonly a day) and log it at ERROR as a
-    // build failure — the regression this schedule guards against.
-    #[test]
-    fn scheduled_update_retry_delays_allow_retries() {
-        assert!(!SCHEDULED_UPDATE_RETRY_DELAYS.is_empty());
-    }
+    // The non-empty-schedule invariant this test used to assert at runtime is
+    // now enforced at compile time next to `SCHEDULED_UPDATE_RETRY_DELAYS`.
 
     // A transient failure recovers within the scheduled retry budget without
     // reaching the exhausted (ERROR-logged) outcome — the behavior this

--- a/src/util.rs
+++ b/src/util.rs
@@ -95,14 +95,11 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
+    type BoxedRetryFuture = std::pin::Pin<Box<dyn Future<Output = anyhow::Result<usize>> + Send>>;
+
     /// Returns an op closure that fails `failures` times, then succeeds,
     /// along with the attempt counter it increments.
-    fn flaky_op(
-        failures: usize,
-    ) -> (
-        impl FnMut() -> std::pin::Pin<Box<dyn Future<Output = anyhow::Result<usize>> + Send>>,
-        Arc<AtomicUsize>,
-    ) {
+    fn flaky_op(failures: usize) -> (impl FnMut() -> BoxedRetryFuture, Arc<AtomicUsize>) {
         let calls = Arc::new(AtomicUsize::new(0));
         let calls_in_op = calls.clone();
         let op = move || {
@@ -114,7 +111,7 @@ mod tests {
                 } else {
                     Ok(n)
                 }
-            }) as std::pin::Pin<Box<dyn Future<Output = anyhow::Result<usize>> + Send>>
+            }) as BoxedRetryFuture
         };
         (op, calls)
     }


### PR DESCRIPTION
Makes `cargo clippy --all-targets` a clean gate (previously only `--bin llamesh` was clean), so any future clippy warning is attributable to the change that introduced it.

## Changes

- `src/util.rs`: the `flaky_op` test helpers complex boxed-future return type is now a named type alias `BoxedRetryFuture` (clippy::type_complexity).
- `src/main.rs`: the non-empty `SCHEDULED_UPDATE_RETRY_DELAYS` invariant is now a compile-time assertion (`const _: () = assert!(...)`) next to the constant, replacing a runtime test that clippy flagged as an always-true const check (clippy::const_is_empty). The compile-time form is strictly stronger — an empty schedule fails to compile.

## Validation

- `cargo clippy --all-targets` and `cargo clippy --bin llamesh`: zero warnings.
- 454 unit tests pass (one redundant runtime test removed, superseded by the compile-time assertion); release build and an integration smoke test pass; `fmt` clean.

No runtime behavior change.

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)