### PR TITLE
docs: document circuit breaker runtime behavior in SPEC.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.19.4] - 2026-06-21
+
+### Documentation
+
+- Documented the circuit breaker's runtime behavior in `SPEC.md` (only its
+  configuration was described before): the per-peer circuit is keyed by the peer
+  node id and shared by both request forwarding and gossip; any success in the
+  closed state resets the failure counter to zero, so the breaker primarily
+  catches a peer failing outright rather than one that stays reachable but
+  returns occasional bad responses; and recovery is a single half-open probe
+  with exponential backoff, driven only by probe results. No code change.
+
 ## [1.19.3] - 2026-06-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   node id and shared by both request forwarding and gossip; any success in the
   closed state resets the failure counter to zero, so the breaker primarily
   catches a peer failing outright rather than one that stays reachable but
-  returns occasional bad responses; and recovery is a single half-open probe
-  with exponential backoff, driven only by probe results. No code change.
+  returns occasional bad responses; and recovery admits paced half-open probes
+  (one per `half_open_probe_interval_ms`) with exponential backoff, closing only
+  after `success_threshold` successful probes and driven only by probe results.
+  No code change.
 
 ## [1.19.3] - 2026-06-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.19.3"
+version = "1.19.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.19.3"
+version = "1.19.4"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/SPEC.md
+++ b/SPEC.md
@@ -1276,6 +1276,13 @@ cluster:
     open_duration_max_ms: 60000
 ```
 
+**Behavior:**
+
+* The circuit is **per peer**, keyed by the peer's node id. Both request forwarding *and* gossip to that peer feed the same circuit, so a peer that stays reachable for gossip is continually observed as healthy.
+* In the **closed** state each failure increments a counter and the circuit opens once the counter reaches `failure_threshold`; **any success resets that counter to zero**. Failures therefore have to reach the threshold without an intervening success — which is why the breaker primarily catches a peer that is failing outright (forwarding *and* gossip failing together) rather than one that stays reachable but returns the occasional bad response.
+* An **open** circuit blocks dispatches to the peer for an exponential backoff (`open_duration_base_ms`, doubling on each consecutive open, capped at `open_duration_max_ms`), then admits a single **half-open** recovery probe. `success_threshold` consecutive probe successes close the circuit; a probe failure reopens it with the next backoff step. On an otherwise idle cluster the periodic gossip exchange can serve as that recovery probe.
+* Recovery transitions are driven only by *probe* results: a slow failure from a request dispatched before the circuit opened does not re-block a peer that is already recovering.
+
 **Tuning tips:**
 
 * Lower `failure_threshold` for faster failure detection (trades off more false positives).

--- a/SPEC.md
+++ b/SPEC.md
@@ -1264,6 +1264,7 @@ Prevents cascading failures when peers become unhealthy. Only affects cross-node
 | `success_threshold` | 2 | Successes needed to close circuit |
 | `open_duration_base_ms` | 5000 | Initial backoff (doubles each time the circuit opens) |
 | `open_duration_max_ms` | 60000 | Maximum backoff cap |
+| `half_open_probe_interval_ms` | 1000 | Minimum spacing between half-open recovery probes (`0` = no pacing) |
 
 Configuration in `config.yaml`:
 
@@ -1274,13 +1275,14 @@ cluster:
     success_threshold: 2
     open_duration_base_ms: 5000
     open_duration_max_ms: 60000
+    half_open_probe_interval_ms: 1000
 ```
 
 **Behavior:**
 
 * The circuit is **per peer**, keyed by the peer's node id. Both request forwarding *and* gossip to that peer feed the same circuit, so a peer that stays reachable for gossip is continually observed as healthy.
 * In the **closed** state each failure increments a counter and the circuit opens once the counter reaches `failure_threshold`; **any success resets that counter to zero**. Failures therefore have to reach the threshold without an intervening success — which is why the breaker primarily catches a peer that is failing outright (forwarding *and* gossip failing together) rather than one that stays reachable but returns the occasional bad response.
-* An **open** circuit blocks dispatches to the peer for an exponential backoff (`open_duration_base_ms`, doubling on each consecutive open, capped at `open_duration_max_ms`), then admits a single **half-open** recovery probe. `success_threshold` consecutive probe successes close the circuit; a probe failure reopens it with the next backoff step. On an otherwise idle cluster the periodic gossip exchange can serve as that recovery probe.
+* An **open** circuit blocks dispatches to the peer for an exponential backoff (`open_duration_base_ms`, doubling on each consecutive open, capped at `open_duration_max_ms`). It then enters **half-open** and admits recovery probes paced at most one per `half_open_probe_interval_ms`; `success_threshold` successful probes close the circuit, while a probe failure reopens it with the next (longer) backoff. On an otherwise idle cluster the periodic gossip exchange can serve as a recovery probe.
 * Recovery transitions are driven only by *probe* results: a slow failure from a request dispatched before the circuit opened does not re-block a peer that is already recovering.
 
 **Tuning tips:**


### PR DESCRIPTION
SPEC.md described only the circuit breaker's configuration. This adds a short "Behavior" subsection documenting its runtime semantics (surfaced while investigating #147):

- The circuit is **per-peer**, keyed by the peer node id, and fed by **both** request forwarding and gossip to that peer.
- In the closed state, **any success resets the failure counter to zero**, so failures must reach `failure_threshold` without an intervening success — which is why the breaker catches a peer failing outright (forwarding and gossip both failing) rather than one that stays reachable but returns occasional bad responses.
- An open circuit blocks dispatches for an exponential backoff, then admits a single half-open recovery probe; `success_threshold` consecutive probe successes close it, and recovery transitions are driven only by probe results.

Docs-only — no code change. Closes #151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)