### PR TITLE
feat: add proxy_peer_stream_body_aborts_total metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.20.0] - 2026-06-21
+
+### Added
+
+- New `proxy_peer_stream_body_aborts_total` metric counting streaming responses
+  forwarded from a cluster peer whose body aborted mid-stream (a connection
+  reset, or — with `upstream_read_timeout_ms` enabled — an inactivity timeout).
+  This failure mode was previously invisible: the peer's `2xx` response head is
+  surfaced to the client and recorded as a circuit-breaker success before the
+  body streams, so a later body abort is neither a local body-read failure
+  (`proxy_errors_total`) nor a circuit-breaker signal. The counter increments
+  once per aborted forwarded stream and a `peer_stream_body_aborted` event is
+  logged. Process-global and resets on restart, like the other stream counters.
+
 ## [1.19.4] - 2026-06-21
 
 ### Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.19.4"
+version = "1.20.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.19.4"
+version = "1.20.0"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -291,6 +291,11 @@ pub struct MetricsSnapshot {
     pub token_counting_disabled_total: u64,
     #[serde(default)]
     pub skipped_stream_cleanups_total: u64,
+    /// Streaming responses forwarded from a cluster peer whose body aborted
+    /// mid-stream. Process-global, resets on restart; `#[serde(default)]` keeps
+    /// older snapshots loadable.
+    #[serde(default)]
+    pub peer_stream_body_aborts_total: u64,
     pub hashes: HashMap<String, HashMetricsSnapshot>,
     pub updated_at: String,
     #[serde(default)]
@@ -664,6 +669,8 @@ impl Metrics {
                 .load(Ordering::Relaxed),
             skipped_stream_cleanups_total: crate::router::SKIPPED_STREAM_CLEANUPS
                 .load(Ordering::Relaxed),
+            peer_stream_body_aborts_total: crate::router::PEER_STREAM_BODY_ABORTS
+                .load(Ordering::Relaxed),
             hashes,
             updated_at: chrono::Utc::now().to_rfc3339(),
             is_building: build_status
@@ -899,6 +906,16 @@ pub async fn render_prometheus_with_circuit_breaker(
     out.push_str(&format!(
         "proxy_skipped_stream_cleanups_total {}\n",
         crate::router::SKIPPED_STREAM_CLEANUPS.load(Ordering::Relaxed)
+    ));
+
+    // Peer streaming responses whose forwarded body aborted mid-stream
+    out.push_str(
+        "# HELP proxy_peer_stream_body_aborts_total Forwarded peer streaming responses whose body aborted mid-stream.\n",
+    );
+    out.push_str("# TYPE proxy_peer_stream_body_aborts_total counter\n");
+    out.push_str(&format!(
+        "proxy_peer_stream_body_aborts_total {}\n",
+        crate::router::PEER_STREAM_BODY_ABORTS.load(Ordering::Relaxed)
     ));
 
     // Circuit breaker metrics (if available)

--- a/src/router.rs
+++ b/src/router.rs
@@ -1866,14 +1866,16 @@ fn build_streaming_response_from_parts<S, E>(
     stream: S,
     cleanup: BoxFuture<'static, ()>,
     tokens_generated: Arc<AtomicU64>,
+    peer_stream: bool,
 ) -> Response<Body>
 where
     S: Stream<Item = Result<Bytes, E>> + Send + 'static,
     E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
 {
-    // Peer (Noise) stream: no local error recorder, but a mid-stream abort is
-    // counted in `PEER_STREAM_BODY_ABORTS` (peer_stream = true).
-    let stream = CleanupStream::new(stream, cleanup, tokens_generated, None, true);
+    // Peer (Noise) stream: no local error recorder; a mid-stream abort is
+    // counted in `PEER_STREAM_BODY_ABORTS` when `peer_stream` (a successful
+    // streamed peer response — the otherwise-invisible 2xx-body-abort case).
+    let stream = CleanupStream::new(stream, cleanup, tokens_generated, None, peer_stream);
     let mut response = Response::new(Body::from_stream(stream));
     *response.status_mut() = status;
     *response.headers_mut() = headers;
@@ -1889,9 +1891,14 @@ async fn peer_response_to_client(
     match response {
         PeerResponse::Http(resp) => {
             if stream_requested {
-                // Peer path: no local error recorder, but a mid-stream abort is
-                // counted in `PEER_STREAM_BODY_ABORTS` (peer_stream = true).
-                build_streaming_response(resp, cleanup, tokens_generated, None, true)
+                // Peer path: no local error recorder. Count a mid-stream abort in
+                // `PEER_STREAM_BODY_ABORTS` only for a *successful* (2xx) streamed
+                // response — the otherwise-invisible case. A non-2xx response is
+                // already visible via its error status (this matters on the
+                // spawn-failure fallback path, which streams whatever status the
+                // peer returned; the primary path only surfaces 2xx).
+                let peer_stream = resp.status().is_success();
+                build_streaming_response(resp, cleanup, tokens_generated, None, peer_stream)
             } else {
                 handle_non_streaming_response(resp, cleanup, tokens_generated, None).await
             }
@@ -1909,6 +1916,7 @@ async fn peer_response_to_client(
                     body,
                     cleanup,
                     tokens_generated,
+                    status.is_success(),
                 )
             } else {
                 let _cleanup_guard = AutoCleanup::new(cleanup);

--- a/src/router.rs
+++ b/src/router.rs
@@ -2176,8 +2176,10 @@ where
                         );
                     }
                     if self.peer_stream {
+                        // Peer-attributed (not a node `proxy_errors_total` error);
+                        // logged at warn like the other peer-forward failures.
                         PEER_STREAM_BODY_ABORTS.fetch_add(1, Ordering::Relaxed);
-                        error!(
+                        warn!(
                             event = "peer_stream_body_aborted",
                             "Forwarded peer streaming body aborted mid-stream"
                         );

--- a/src/router.rs
+++ b/src/router.rs
@@ -1248,6 +1248,7 @@ pub async fn route_request(
                                     cleanup_fut,
                                     tokens_counter,
                                     error_recorder,
+                                    false,
                                 )
                             } else {
                                 handle_non_streaming_response(
@@ -1842,6 +1843,7 @@ fn build_streaming_response(
     cleanup: BoxFuture<'static, ()>,
     tokens_generated: Arc<AtomicU64>,
     error_recorder: BodyReadErrorRecorder,
+    peer_stream: bool,
 ) -> Response<Body> {
     let status = resp.status();
     let headers = resp.headers().clone();
@@ -1850,6 +1852,7 @@ fn build_streaming_response(
         cleanup,
         tokens_generated,
         error_recorder,
+        peer_stream,
     );
     let mut response = Response::new(Body::from_stream(stream));
     *response.status_mut() = status;
@@ -1868,9 +1871,9 @@ where
     S: Stream<Item = Result<Bytes, E>> + Send + 'static,
     E: Into<Box<dyn std::error::Error + Send + Sync>> + 'static,
 {
-    // Peer (Noise) stream: peer-path failures are accounted for separately, so
-    // no local error recorder.
-    let stream = CleanupStream::new(stream, cleanup, tokens_generated, None);
+    // Peer (Noise) stream: no local error recorder, but a mid-stream abort is
+    // counted in `PEER_STREAM_BODY_ABORTS` (peer_stream = true).
+    let stream = CleanupStream::new(stream, cleanup, tokens_generated, None, true);
     let mut response = Response::new(Body::from_stream(stream));
     *response.status_mut() = status;
     *response.headers_mut() = headers;
@@ -1886,9 +1889,9 @@ async fn peer_response_to_client(
     match response {
         PeerResponse::Http(resp) => {
             if stream_requested {
-                // Peer path: no local error recorder (failures accounted for
-                // separately via the peer-fallback status check / circuit breaker).
-                build_streaming_response(resp, cleanup, tokens_generated, None)
+                // Peer path: no local error recorder, but a mid-stream abort is
+                // counted in `PEER_STREAM_BODY_ABORTS` (peer_stream = true).
+                build_streaming_response(resp, cleanup, tokens_generated, None, true)
             } else {
                 handle_non_streaming_response(resp, cleanup, tokens_generated, None).await
             }
@@ -1946,6 +1949,15 @@ pub static SKIPPED_STREAM_CLEANUPS: AtomicU64 = AtomicU64::new(0);
 /// Exposed via metrics endpoint.
 pub static TOKEN_COUNTING_DISABLED: AtomicU64 = AtomicU64::new(0);
 
+/// Counter for streaming responses forwarded from a cluster peer whose body
+/// aborted mid-stream (a connection reset, or — with `upstream_read_timeout_ms`
+/// enabled — an inactivity timeout). The peer's 2xx response head is surfaced to
+/// the client and recorded as a success before the body streams, so an abort
+/// after that point is otherwise invisible: it is not a local body-read failure
+/// (`proxy_errors_total`) and does not move the peer's circuit breaker. Exposed
+/// as `proxy_peer_stream_body_aborts_total`; runtime-only (resets on restart).
+pub static PEER_STREAM_BODY_ABORTS: AtomicU64 = AtomicU64::new(0);
+
 struct CleanupStream<S, E>
 where
     S: Stream<Item = Result<Bytes, E>> + Send + 'static,
@@ -1961,6 +1973,9 @@ where
     error_recorder: BodyReadErrorRecorder,
     /// Guards the body-read error count to exactly one per failed stream.
     error_recorded: bool,
+    /// True when this stream forwards a cluster peer's response body. A
+    /// mid-stream abort then increments `PEER_STREAM_BODY_ABORTS` (once).
+    peer_stream: bool,
 }
 
 impl<S, E> CleanupStream<S, E>
@@ -1972,6 +1987,7 @@ where
         cleanup: BoxFuture<'static, ()>,
         tokens_generated: Arc<AtomicU64>,
         error_recorder: BodyReadErrorRecorder,
+        peer_stream: bool,
     ) -> Self {
         Self {
             inner: Box::pin(inner),
@@ -1982,6 +1998,7 @@ where
             cleanup_executed: false,
             error_recorder,
             error_recorded: false,
+            peer_stream,
         }
     }
 }
@@ -2144,9 +2161,11 @@ where
                 Poll::Ready(None)
             }
             Poll::Ready(Some(Err(e))) => {
-                // A mid-stream body-read failure aborts the client stream. On
-                // the local path, count it once (like a non-streaming body-read
-                // failure or a send error); peer streams carry no recorder.
+                // A mid-stream body-read failure aborts the client stream. Count
+                // it once: on the local path via the error recorder (like a
+                // non-streaming body-read failure or a send error); on a peer
+                // forward via `PEER_STREAM_BODY_ABORTS`, since the peer's 2xx
+                // head was already surfaced/recorded as a success.
                 if !self.error_recorded {
                     self.error_recorded = true;
                     record_local_body_read_error(&self.error_recorder);
@@ -2154,6 +2173,13 @@ where
                         error!(
                             event = "local_stream_body_read_failed",
                             "Local streaming body read failed"
+                        );
+                    }
+                    if self.peer_stream {
+                        PEER_STREAM_BODY_ABORTS.fetch_add(1, Ordering::Relaxed);
+                        error!(
+                            event = "peer_stream_body_aborted",
+                            "Forwarded peer streaming body aborted mid-stream"
                         );
                     }
                 }
@@ -2838,6 +2864,7 @@ mod tests {
             Box::pin(async {}),
             Arc::new(AtomicU64::new(0)),
             Some((metrics.clone(), hm.clone())),
+            false,
         );
         while s.next().await.is_some() {}
         assert_eq!(metrics.errors_total.load(Ordering::Relaxed), 1);
@@ -2859,6 +2886,7 @@ mod tests {
             Box::pin(async {}),
             Arc::new(AtomicU64::new(0)),
             Some((metrics.clone(), hm.clone())),
+            false,
         );
         while s.next().await.is_some() {}
         assert_eq!(metrics.errors_total.load(Ordering::Relaxed), 1);
@@ -2868,15 +2896,62 @@ mod tests {
     #[tokio::test]
     async fn cleanup_stream_does_not_count_without_recorder() {
         use futures::StreamExt;
-        // Peer streams pass no recorder: a body error must not be counted.
+        // A non-peer stream with no recorder: a body error must not be counted.
         let metrics = Arc::new(Metrics::default());
         let inner = body_stream(vec![
             Ok(Bytes::from("x")),
             Err(std::io::Error::other("boom")),
         ]);
-        let mut s =
-            CleanupStream::new(inner, Box::pin(async {}), Arc::new(AtomicU64::new(0)), None);
+        let mut s = CleanupStream::new(
+            inner,
+            Box::pin(async {}),
+            Arc::new(AtomicU64::new(0)),
+            None,
+            false,
+        );
         while s.next().await.is_some() {}
         assert_eq!(metrics.errors_total.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn cleanup_stream_counts_peer_body_abort_once() {
+        use futures::StreamExt;
+        // A peer stream (peer_stream = true, no local recorder) increments the
+        // peer-abort counter exactly once on a mid-stream error, and not on a
+        // clean stream.
+        let before = PEER_STREAM_BODY_ABORTS.load(Ordering::Relaxed);
+        let aborting = body_stream(vec![
+            Ok(Bytes::from("data: {}\n")),
+            Err(std::io::Error::other("peer reset")),
+            Err(std::io::Error::other("again")),
+        ]);
+        let mut s = CleanupStream::new(
+            aborting,
+            Box::pin(async {}),
+            Arc::new(AtomicU64::new(0)),
+            None,
+            true,
+        );
+        while s.next().await.is_some() {}
+        assert_eq!(
+            PEER_STREAM_BODY_ABORTS.load(Ordering::Relaxed),
+            before + 1,
+            "a peer body abort counts exactly once"
+        );
+
+        let clean = body_stream(vec![Ok(Bytes::from("a")), Ok(Bytes::from("b"))]);
+        let mut s = CleanupStream::new(
+            clean,
+            Box::pin(async {}),
+            Arc::new(AtomicU64::new(0)),
+            None,
+            true,
+        );
+        while s.next().await.is_some() {}
+        assert_eq!(
+            PEER_STREAM_BODY_ABORTS.load(Ordering::Relaxed),
+            before + 1,
+            "a clean peer stream does not count"
+        );
     }
 }


### PR DESCRIPTION
Resolves #147 via observability. Investigating #147 (PR #150) showed that feeding peer streaming body-aborts into the circuit breaker does not work — any closed-state success resets the failure counter, and both the per-request 2xx head success and the shared-key gossip success reset it, so the failure never accumulates. Rather than the deeper circuit-breaker rework that automatic backoff would require, this exposes the signal directly so operators (and any future automation) can see it.

## Problem

A streaming request forwarded to a cluster peer is surfaced to the client as soon as the peer's `2xx` response head arrives, and that head is recorded as a circuit-breaker success before the body streams. If the peer's body then aborts mid-stream (a reset, or — with `upstream_read_timeout_ms` enabled — an inactivity timeout), the failure is **invisible**: it is not a local body-read failure (`proxy_errors_total`) and does not move the peer's circuit breaker.

## Change

`CleanupStream` carries a `peer_stream` flag; on a mid-stream body error for a peer forward it increments the new process-global `PEER_STREAM_BODY_ABORTS` counter exactly once (sharing the existing one-shot guard) and logs a `peer_stream_body_aborted` event. Exposed as `proxy_peer_stream_body_aborts_total` in `/metrics` and `/metrics/json` (runtime-only, resets on restart, like the sibling `proxy_skipped_stream_cleanups_total` / `proxy_token_counting_disabled_total` counters).

No change to the happy path or to local-stream accounting; the local path passes `peer_stream = false`.

## Validation

- New unit test `cleanup_stream_counts_peer_body_abort_once`: a peer stream counts a mid-stream abort exactly once and a clean peer stream counts zero.
- 455 unit tests pass; `cargo clippy --all-targets` and `fmt` clean.

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)