### PR TITLE
docs: add a metrics reference to SPEC.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.20.1] - 2026-06-21
+
+### Documentation
+
+- Added a metrics reference to `SPEC.md`: the `### Metrics` section previously
+  named only the `/metrics` and `/metrics/json` endpoints without listing what
+  they expose. It now groups the key `proxy_*` series (request handling,
+  queueing, node resources, cluster health/recovery, streaming, per-model:profile
+  `proxy_hash_*`, and build info) with one-line descriptions, so operators do not
+  have to read the source to know what is scraped. No code change.
+
 ## [1.20.0] - 2026-06-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.20.0"
+version = "1.20.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.20.0"
+version = "1.20.1"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/SPEC.md
+++ b/SPEC.md
@@ -799,6 +799,16 @@ For full semantics (including drain/shutdown behavior), see **Health, Readiness,
 * `GET /metrics` -> Prometheus-style metrics (canonical source for real-time scraping).
 * `GET /metrics/json` -> JSON-encoded metrics for ad-hoc inspection or tooling.
 
+Key `proxy_*` series exposed (process-global unless noted; counters reset on restart):
+
+* **Request handling** — `proxy_requests_total` (requests received), `proxy_errors_total` (request errors), `proxy_current_requests` (in flight now).
+* **Queueing** — `proxy_queue_length` (waiting now), `proxy_queue_drops_total{reason}` (`full` / `timeout` / `global_limit`), `proxy_queue_wait_total_ms` and `proxy_queue_wait_count` (cumulative wait time and count), `proxy_queue_pending_tokens`.
+* **Node resources** — `proxy_node_active_instances`; `proxy_node_effective_vram_mb` / `proxy_node_max_vram_mb` (VRAM used for admission vs the configured guardrail) and the `_sysmem_` equivalents; `proxy_node_llamesh_vram_mb`, `proxy_node_external_vram_mb`, `proxy_node_device_vram_used_mb`, `proxy_node_device_vram_total_mb`; `proxy_node_gpu_telemetry_available` (1/0).
+* **Cluster health & recovery** — `proxy_circuit_breaker_state{peer}` (0=closed, 1=open, 2=half-open), `proxy_wedged_instances_killed_total` (local instances stopped by the wedged-instance watchdog).
+* **Streaming** — `proxy_peer_stream_body_aborts_total` (forwarded peer streams whose body aborted mid-stream), `proxy_skipped_stream_cleanups_total` (cleanups skipped during shutdown), `proxy_token_counting_disabled_total`.
+* **Per model:profile** — the `proxy_hash_*` family (`requests_total`, `errors_total`, `tokens_generated_total`, `total_latency_ms`, latency percentiles, `peak_vram_mb`, `peak_sysmem_mb`), labeled by the profile's args hash.
+* **Build** — `proxy_build_info` / `proxy_version` (info series, value `1`).
+
 ### Cluster / Admin
 
 * `GET /cluster/nodes` -> current view of nodes and their capacities.

--- a/SPEC.md
+++ b/SPEC.md
@@ -799,13 +799,13 @@ For full semantics (including drain/shutdown behavior), see **Health, Readiness,
 * `GET /metrics` -> Prometheus-style metrics (canonical source for real-time scraping).
 * `GET /metrics/json` -> JSON-encoded metrics for ad-hoc inspection or tooling.
 
-Key `proxy_*` series exposed (process-global unless noted; counters reset on restart):
+Key `proxy_*` series exposed. Gauges reflect the current moment; most counters are cumulative and persist across restarts via the metrics snapshot — the exception is the per-process stream counters in the **Streaming** group, which reset on restart.
 
 * **Request handling** — `proxy_requests_total` (requests received), `proxy_errors_total` (request errors), `proxy_current_requests` (in flight now).
 * **Queueing** — `proxy_queue_length` (waiting now), `proxy_queue_drops_total{reason}` (`full` / `timeout` / `global_limit`), `proxy_queue_wait_total_ms` and `proxy_queue_wait_count` (cumulative wait time and count), `proxy_queue_pending_tokens`.
 * **Node resources** — `proxy_node_active_instances`; `proxy_node_effective_vram_mb` / `proxy_node_max_vram_mb` (VRAM used for admission vs the configured guardrail) and the `_sysmem_` equivalents; `proxy_node_llamesh_vram_mb`, `proxy_node_external_vram_mb`, `proxy_node_device_vram_used_mb`, `proxy_node_device_vram_total_mb`; `proxy_node_gpu_telemetry_available` (1/0).
 * **Cluster health & recovery** — `proxy_circuit_breaker_state{peer}` (0=closed, 1=open, 2=half-open), `proxy_wedged_instances_killed_total` (local instances stopped by the wedged-instance watchdog).
-* **Streaming** — `proxy_peer_stream_body_aborts_total` (forwarded peer streams whose body aborted mid-stream), `proxy_skipped_stream_cleanups_total` (cleanups skipped during shutdown), `proxy_token_counting_disabled_total`.
+* **Streaming** (per-process, reset on restart) — `proxy_peer_stream_body_aborts_total` (forwarded peer streams whose body aborted mid-stream), `proxy_skipped_stream_cleanups_total` (cleanups skipped during shutdown), `proxy_token_counting_disabled_total`.
 * **Per model:profile** — the `proxy_hash_*` family (`requests_total`, `errors_total`, `tokens_generated_total`, `total_latency_ms`, latency percentiles, `peak_vram_mb`, `peak_sysmem_mb`), labeled by the profile's args hash.
 * **Build** — `proxy_build_info` / `proxy_version` (info series, value `1`).
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -807,7 +807,7 @@ Key `proxy_*` series exposed. Gauges reflect the current moment; most counters a
 * **Cluster health & recovery** — `proxy_circuit_breaker_state{peer}` (0=closed, 1=open, 2=half-open), `proxy_wedged_instances_killed_total` (local instances stopped by the wedged-instance watchdog).
 * **Streaming** (per-process, reset on restart) — `proxy_peer_stream_body_aborts_total` (forwarded peer streams whose body aborted mid-stream), `proxy_skipped_stream_cleanups_total` (cleanups skipped during shutdown), `proxy_token_counting_disabled_total`.
 * **Per model:profile** — the `proxy_hash_*` family (`requests_total`, `errors_total`, `tokens_generated_total`, `total_latency_ms`, latency percentiles, `peak_vram_mb`, `peak_sysmem_mb`), labeled by the profile's args hash.
-* **Build** — `proxy_build_info` / `proxy_version` (info series, value `1`).
+* **Build** — `proxy_build_info{version=...,llama_cpp_version=...}` (info series, value `1`; aggregate with `count by (version) (proxy_build_info)`).
 
 ### Cluster / Admin
 


### PR DESCRIPTION
The SPEC `### Metrics` section named only the `/metrics` and `/metrics/json` endpoints without listing which `proxy_*` series they expose. This adds a concise, grouped reference (request handling, queueing, node resources, cluster health/recovery, streaming, per-model:profile `proxy_hash_*`, and build info) with one-line descriptions taken from the metric HELP strings — so operators do not have to read the source to know what is scrapeable.

Docs-only, no code change. Closes #154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)