### PR TITLE
fix: reject silently-broken configs at startup (auth lockout, ':' in names, version_mismatch_action)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.20.2] - 2026-06-23
+
+### Fixed
+
+- Startup config validation now rejects three more classes of configuration that
+  loaded cleanly but were silently broken at runtime (continuing the fail-fast
+  pattern already applied to ports, gossip, the circuit breaker, and the instance
+  cap):
+  - `auth.enabled: true` with an empty `allowed_keys` (or an empty
+    `required_header`) — every request would be rejected as `Unauthorized`, so the
+    proxy came up healthy but served nothing with no signal beyond 401s (easy to
+    hit when the keys live in a secrets file that was not merged). Validation is
+    skipped when auth is absent or disabled.
+  - A `:` in a cookbook model name or profile id — `:` is the reserved
+    `model:profile` request separator, so an embedded colon made the entry
+    permanently unaddressable (a silent 404 at request time).
+  - An unknown `cluster.version_mismatch_action` — only `warn`, `reject_major`,
+    and `reject_any` are honored; any other value silently degraded to accepting
+    all peers, inverting the operator's intended rejection policy during a rolling
+    upgrade. Checked only in cluster mode.
+
 ## [1.20.1] - 2026-06-21
 
 ### Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.20.1"
+version = "1.20.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.20.1"
+version = "1.20.2"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -295,6 +295,24 @@ impl NodeConfig {
                     ));
                 }
             }
+
+            // Validate the peer version-mismatch policy. The gossip handler in
+            // `cluster.rs` matches exactly "reject_any" and "reject_major" and
+            // treats every other string as the permissive default (accept all
+            // peers), so a typo like "reject-major" or "strict" silently disables
+            // the rejection an operator intended during a rolling upgrade. The
+            // field has a default ("warn"), so only a non-default typo trips this.
+            if !matches!(
+                self.cluster.version_mismatch_action.as_str(),
+                "warn" | "reject_major" | "reject_any"
+            ) {
+                return Err(anyhow::anyhow!(
+                    "cluster.version_mismatch_action '{}' is invalid; expected one of: \
+                     warn, reject_major, reject_any. An unknown value silently degrades to \
+                     'warn' (accept all peers).",
+                    self.cluster.version_mismatch_action
+                ));
+            }
         }
 
         // Validate the local instance cap. `max_instances_per_node` caps how many
@@ -375,6 +393,32 @@ impl NodeConfig {
             // A sample interval larger than the window is allowed: it does not
             // make confirmation impossible, it only raises detection latency
             // (the sustained-wedge check still accumulates across samples).
+        }
+
+        // Validate API key auth, but only when enabled. `check_api_key_auth`
+        // rejects a request unless its key matches one of `allowed_keys`, so an
+        // enabled auth block with an empty `allowed_keys` rejects *every* request
+        // as Unauthorized — the proxy comes up healthy but serves nothing, with
+        // no signal beyond 401s (easy to hit when the keys live in a secrets file
+        // that was not merged). An empty `required_header` likewise leaves clients
+        // no header to send the key in. Both deserialize cleanly, so catch them
+        // at startup. Skipped when auth is absent or disabled.
+        if let Some(auth) = &self.auth {
+            if auth.enabled {
+                if auth.allowed_keys.is_empty() {
+                    return Err(anyhow::anyhow!(
+                        "auth.enabled is true but auth.allowed_keys is empty; every request \
+                         would be rejected as Unauthorized. Add at least one key, or set \
+                         auth.enabled: false."
+                    ));
+                }
+                if auth.required_header.trim().is_empty() {
+                    return Err(anyhow::anyhow!(
+                        "auth.enabled is true but auth.required_header is empty; set the header \
+                         name clients send the API key in (e.g. \"x-api-key\")."
+                    ));
+                }
+            }
         }
 
         Ok(())
@@ -741,8 +785,31 @@ impl Cookbook {
         // Only enabled pairs are indexed, so only those can actually collide.
         let mut seen: std::collections::HashMap<String, String> = std::collections::HashMap::new();
         for model in &self.models {
+            // A ':' in a model or profile name collides with the reserved
+            // `model:profile` request separator. The index key is built as
+            // `model:profile` and resolution splits on the first ':', so an
+            // embedded colon makes the entry permanently unaddressable (a silent
+            // 404 at request time with no startup signal). Reject it here.
+            if model.name.contains(':') {
+                return Err(anyhow::anyhow!(
+                    "Model name '{}' contains ':', which is reserved as the model:profile \
+                     request separator; an embedded colon makes the model unaddressable \
+                     (resolution splits on the first ':'). Remove the colon from the name.",
+                    model.name
+                ));
+            }
             for profile in &model.profiles {
                 profile.validate(&model.name)?;
+
+                if profile.id.contains(':') {
+                    return Err(anyhow::anyhow!(
+                        "Profile id '{}' (model '{}') contains ':', which is reserved as the \
+                         model:profile request separator; an embedded colon makes the profile \
+                         unaddressable. Remove the colon from the id.",
+                        profile.id,
+                        model.name
+                    ));
+                }
 
                 if model.enabled && profile.enabled {
                     let key = format!(
@@ -1473,6 +1540,122 @@ mod tests {
         let mut config = config_with_cluster(false, 5, 16);
         config.max_instances_per_node = 0;
         assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_enabled_auth_with_empty_allowed_keys() {
+        // Enabled auth with no keys rejects every request as Unauthorized, so the
+        // proxy comes up healthy but serves nothing. Catch it at startup.
+        let mut config = config_with_ports(None);
+        config.auth = Some(AuthConfig {
+            enabled: true,
+            required_header: "x-api-key".into(),
+            allowed_keys: vec![],
+        });
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_enabled_auth_with_empty_required_header() {
+        let mut config = config_with_ports(None);
+        config.auth = Some(AuthConfig {
+            enabled: true,
+            required_header: "   ".into(),
+            allowed_keys: vec!["k".into()],
+        });
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_accepts_enabled_auth_with_keys() {
+        let mut config = config_with_ports(None);
+        config.auth = Some(AuthConfig {
+            enabled: true,
+            required_header: "x-api-key".into(),
+            allowed_keys: vec!["k".into()],
+        });
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_ignores_empty_auth_keys_when_disabled() {
+        // A disabled auth block never gates requests, so stray empties are fine.
+        let mut config = config_with_ports(None);
+        config.auth = Some(AuthConfig {
+            enabled: false,
+            required_header: String::new(),
+            allowed_keys: vec![],
+        });
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_unknown_version_mismatch_action_when_cluster_enabled() {
+        let mut config = config_with_cluster(true, 5, 16);
+        config.cluster.version_mismatch_action = "reject-major".into();
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_accepts_known_version_mismatch_actions() {
+        for action in ["warn", "reject_major", "reject_any"] {
+            let mut config = config_with_cluster(true, 5, 16);
+            config.cluster.version_mismatch_action = action.into();
+            assert!(config.validate().is_ok(), "{action} should be accepted");
+        }
+    }
+
+    #[test]
+    fn validate_ignores_version_mismatch_action_when_cluster_disabled() {
+        // The gossip handler never runs in standalone mode, so the field is moot.
+        let mut config = config_with_cluster(false, 5, 16);
+        config.cluster.version_mismatch_action = "bogus".into();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn cookbook_validate_rejects_colon_in_model_name() {
+        let yaml = r#"
+models:
+  - name: "gpt:oss"
+    profiles:
+      - id: default
+        model_path: /tmp/m.gguf
+        idle_timeout_seconds: 10
+        llama_server_args: ""
+"#;
+        let cookbook: Cookbook = serde_yaml::from_str(yaml).unwrap();
+        assert!(cookbook.validate().is_err());
+    }
+
+    #[test]
+    fn cookbook_validate_rejects_colon_in_profile_id() {
+        let yaml = r#"
+models:
+  - name: gptoss
+    profiles:
+      - id: "fast:v2"
+        model_path: /tmp/m.gguf
+        idle_timeout_seconds: 10
+        llama_server_args: ""
+"#;
+        let cookbook: Cookbook = serde_yaml::from_str(yaml).unwrap();
+        assert!(cookbook.validate().is_err());
+    }
+
+    #[test]
+    fn cookbook_validate_accepts_colon_free_names() {
+        let yaml = r#"
+models:
+  - name: gpt-oss
+    profiles:
+      - id: default
+        model_path: /tmp/m.gguf
+        idle_timeout_seconds: 10
+        llama_server_args: ""
+"#;
+        let cookbook: Cookbook = serde_yaml::from_str(yaml).unwrap();
+        assert!(cookbook.validate().is_ok());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -785,33 +785,36 @@ impl Cookbook {
         // Only enabled pairs are indexed, so only those can actually collide.
         let mut seen: std::collections::HashMap<String, String> = std::collections::HashMap::new();
         for model in &self.models {
-            // A ':' in a model or profile name collides with the reserved
-            // `model:profile` request separator. The index key is built as
-            // `model:profile` and resolution splits on the first ':', so an
-            // embedded colon makes the entry permanently unaddressable (a silent
-            // 404 at request time with no startup signal). Reject it here.
-            if model.name.contains(':') {
-                return Err(anyhow::anyhow!(
-                    "Model name '{}' contains ':', which is reserved as the model:profile \
-                     request separator; an embedded colon makes the model unaddressable \
-                     (resolution splits on the first ':'). Remove the colon from the name.",
-                    model.name
-                ));
-            }
             for profile in &model.profiles {
                 profile.validate(&model.name)?;
 
-                if profile.id.contains(':') {
-                    return Err(anyhow::anyhow!(
-                        "Profile id '{}' (model '{}') contains ':', which is reserved as the \
-                         model:profile request separator; an embedded colon makes the profile \
-                         unaddressable. Remove the colon from the id.",
-                        profile.id,
-                        model.name
-                    ));
-                }
-
                 if model.enabled && profile.enabled {
+                    // A ':' in a model or profile name collides with the reserved
+                    // `model:profile` request separator: the index key is built as
+                    // `model:profile` and resolution splits on the first ':', so an
+                    // embedded colon makes the pair permanently unaddressable (a
+                    // silent 404). Only enabled pairs are indexed (`build_model_index`
+                    // skips disabled ones), so — like the duplicate-key check below
+                    // — gate this on enabled so a disabled, inert colon-named entry
+                    // does not turn a working cookbook into a startup/reload error.
+                    if model.name.contains(':') {
+                        return Err(anyhow::anyhow!(
+                            "Model name '{}' contains ':', which is reserved as the model:profile \
+                             request separator; an embedded colon makes the model unaddressable \
+                             (resolution splits on the first ':'). Remove the colon from the name.",
+                            model.name
+                        ));
+                    }
+                    if profile.id.contains(':') {
+                        return Err(anyhow::anyhow!(
+                            "Profile id '{}' (model '{}') contains ':', which is reserved as the \
+                             model:profile request separator; an embedded colon makes the profile \
+                             unaddressable. Remove the colon from the id.",
+                            profile.id,
+                            model.name
+                        ));
+                    }
+
                     let key = format!(
                         "{}:{}",
                         model.name.to_lowercase(),
@@ -1650,6 +1653,25 @@ models:
   - name: gpt-oss
     profiles:
       - id: default
+        model_path: /tmp/m.gguf
+        idle_timeout_seconds: 10
+        llama_server_args: ""
+"#;
+        let cookbook: Cookbook = serde_yaml::from_str(yaml).unwrap();
+        assert!(cookbook.validate().is_ok());
+    }
+
+    #[test]
+    fn cookbook_validate_ignores_colon_in_disabled_entry() {
+        // A disabled model/profile is skipped by build_model_index and never
+        // indexed, so a colon in its (inert) name must not turn a working
+        // cookbook into a startup/reload error — mirrors the duplicate-key gate.
+        let yaml = r#"
+models:
+  - name: "retired:model"
+    enabled: false
+    profiles:
+      - id: "old:profile"
         model_path: /tmp/m.gguf
         idle_timeout_seconds: 10
         llama_server_args: ""


### PR DESCRIPTION
Three configurations load cleanly today but are silently broken at runtime with no startup or log signal. Each is now rejected in `validate()`, continuing the established fail-fast pattern already applied to ports, gossip, the circuit breaker, and the instance cap. Closes #156.

## What is rejected

1. **Auth lockout** (`NodeConfig::validate`) — `auth.enabled: true` with an empty `allowed_keys` (or empty `required_header`). `check_api_key_auth` rejects a request unless its key matches one of `allowed_keys`, so an empty list makes the proxy reject **every** request as `Unauthorized` — up and healthy, but serving nothing. Easy to hit when keys live in a secrets file that was not merged. Skipped when auth is absent or disabled, so auth-less deployments are unaffected.
2. **`:` in model/profile names** (`Cookbook::validate`) — the index key is built as `model:profile` and resolution splits on the first `:`, so an embedded colon makes the entry permanently unaddressable (a silent 404).
3. **Unknown `cluster.version_mismatch_action`** (`NodeConfig::validate`, cluster-gated) — `cluster.rs` honors only `reject_any` / `reject_major`; every other string falls through to the permissive default (accept all peers), so a typo silently disables the operator’s intended peer-rejection during a rolling upgrade.

## Safety

All three are additive, leaf-only validations gated so they cannot reject any currently-working config — they only reject configs that are already non-functional (or, for #3, already misbehaving). Off the hot path / concurrency / spawn / streaming surface.

## Validation

- 10 new `validate_*` / `cookbook_validate_*` unit tests (reject, accept, and disabled/standalone-ignored cases). 465 unit + 12 integration tests pass; `cargo clippy --all-targets` and `fmt` clean.
- Verified against the **live** pc1 + kls configs (both `auth.enabled: false`, zero colons in cookbook names, `version_mismatch_action` at the default) — neither node’s config is rejected by the new checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)