### PR TITLE
feat: add proxy_instances_crashed_total metric for abnormal instance exits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.21.0] - 2026-07-04
+
+### Added
+
+- New `proxy_instances_crashed_total` metric counting local `llama-server`
+  instances that exited abnormally. Instance crashes were previously visible
+  only as an `Instance exited unexpectedly` log line, so their rate could not be
+  scraped or alerted on; in practice they arrive in intermittent bursts (a bad
+  model/profile dying repeatedly), which is exactly the pattern a counter
+  surfaces better than logs. The counter increments in the liveness check
+  (`Instance::is_alive`), the single authoritative crash observer: it nulls the
+  child handle on the first poll that sees an exit, so each crash is counted
+  exactly once. Deliberate stops are excluded — the proxy's own `stop()` takes
+  the handle first, and an exit on a plain `SIGTERM` (how systemd's
+  whole-control-group `systemctl restart` and operators ask a process to stop)
+  is treated as a graceful shutdown rather than a crash, so a routine restart
+  does not inflate the counter even while a background sweep observes the exit.
+  Fault signals (SIGSEGV/SIGABRT/SIGKILL/…) and non-zero exit codes are counted.
+  Exposed on both `/metrics` and `/metrics/json`; process-global and resets on
+  restart, like the other static-sourced counters.
+
 ## [1.20.2] - 2026-06-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.20.2"
+version = "1.21.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.20.2"
+version = "1.21.0"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/SPEC.md
+++ b/SPEC.md
@@ -799,12 +799,12 @@ For full semantics (including drain/shutdown behavior), see **Health, Readiness,
 * `GET /metrics` -> Prometheus-style metrics (canonical source for real-time scraping).
 * `GET /metrics/json` -> JSON-encoded metrics for ad-hoc inspection or tooling.
 
-Key `proxy_*` series exposed. Gauges reflect the current moment; most counters are cumulative and persist across restarts via the metrics snapshot — the exception is the per-process stream counters in the **Streaming** group, which reset on restart.
+Key `proxy_*` series exposed. Gauges reflect the current moment; most counters are cumulative and persist across restarts via the metrics snapshot. Several are per-process and reset on restart instead: the **Streaming** group, `proxy_instances_crashed_total`, and the `proxy_queue_wait_*` counters.
 
 * **Request handling** — `proxy_requests_total` (requests received), `proxy_errors_total` (request errors), `proxy_current_requests` (in flight now).
 * **Queueing** — `proxy_queue_length` (waiting now), `proxy_queue_drops_total{reason}` (`full` / `timeout` / `global_limit`), `proxy_queue_wait_total_ms` and `proxy_queue_wait_count` (cumulative wait time and count), `proxy_queue_pending_tokens`.
 * **Node resources** — `proxy_node_active_instances`; `proxy_node_effective_vram_mb` / `proxy_node_max_vram_mb` (VRAM used for admission vs the configured guardrail) and the `_sysmem_` equivalents; `proxy_node_llamesh_vram_mb`, `proxy_node_external_vram_mb`, `proxy_node_device_vram_used_mb`, `proxy_node_device_vram_total_mb`; `proxy_node_gpu_telemetry_available` (1/0).
-* **Cluster health & recovery** — `proxy_circuit_breaker_state{peer}` (0=closed, 1=open, 2=half-open), `proxy_wedged_instances_killed_total` (local instances stopped by the wedged-instance watchdog).
+* **Cluster health & recovery** — `proxy_circuit_breaker_state{peer}` (0=closed, 1=open, 2=half-open), `proxy_wedged_instances_killed_total` (local instances stopped by the wedged-instance watchdog), `proxy_instances_crashed_total` (local instances that exited abnormally — a fault signal or non-zero exit, excluding a graceful `SIGTERM` — observed by the liveness check; per-process, resets on restart).
 * **Streaming** (per-process, reset on restart) — `proxy_peer_stream_body_aborts_total` (forwarded peer streams whose body aborted mid-stream), `proxy_skipped_stream_cleanups_total` (cleanups skipped during shutdown), `proxy_token_counting_disabled_total`.
 * **Per model:profile** — the `proxy_hash_*` family (`requests_total`, `errors_total`, `tokens_generated_total`, `total_latency_ms`, latency percentiles, `peak_vram_mb`, `peak_sysmem_mb`), labeled by the profile's args hash.
 * **Build** — `proxy_build_info{version=...,llama_cpp_version=...}` (info series, value `1`; aggregate with `count by (version) (proxy_build_info)`).

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -3,8 +3,9 @@ use parking_lot::Mutex;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use std::os::unix::process::ExitStatusExt;
 use std::process::Stdio;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::sync::LazyLock;
 use std::time::{Duration, Instant};
@@ -13,6 +14,19 @@ use tokio::sync::Notify;
 use tracing::{info, warn};
 
 use tokio::io::{AsyncBufReadExt, BufReader};
+
+/// Counter for local `llama-server` instances that exited abnormally, observed
+/// by the liveness check (`Instance::is_alive`). This is the sole runtime crash
+/// observer: `is_alive` sets the child handle to `None` on the first poll that
+/// sees an exit, so each crash is counted exactly once, and the proxy's own
+/// `stop()` takes the handle first so its intentional teardown never reaches the
+/// counting arm. Two further exits are deliberately not counted: a plain
+/// `SIGTERM` (how systemd's whole-control-group `systemctl restart` and
+/// operators ask a process to stop — an expected shutdown, not a crash), and a
+/// `try_wait` poll failure (which means "status unknown", not "exited"). Fault
+/// signals (SIGSEGV/SIGABRT/SIGKILL/…) and non-zero exit codes are counted.
+/// Exposed as `proxy_instances_crashed_total`; runtime-only (resets on restart).
+pub static INSTANCES_CRASHED_TOTAL: AtomicU64 = AtomicU64::new(0);
 
 /// Model parameters parsed from llama-server startup log.
 /// This is the ground truth for model capabilities.
@@ -590,6 +604,19 @@ impl Instance {
         match &mut *guard {
             Some(child) => match child.try_wait() {
                 Ok(Some(status)) => {
+                    // A plain SIGTERM is how systemd (whole control-group on a
+                    // `systemctl restart`) and operators ask a process to stop,
+                    // so an instance that exits on SIGTERM was terminated on
+                    // purpose, not crashed — do not count it. Genuine crashes
+                    // surface as a fault signal (SIGSEGV/SIGABRT/SIGKILL/…) or a
+                    // non-zero exit code, both still counted. The proxy's own
+                    // stop() takes the child handle first, so its intentional
+                    // teardown never reaches this arm; this guard covers the
+                    // out-of-band case where the child is signalled directly
+                    // (e.g. systemd during a graceful node shutdown).
+                    if status.signal() != Some(libc::SIGTERM) {
+                        INSTANCES_CRASHED_TOTAL.fetch_add(1, Ordering::Relaxed);
+                    }
                     warn!(
                         instance_id = %self.id,
                         model = %self.model_name,
@@ -1025,6 +1052,88 @@ mod tests {
         assert!(
             elapsed < Duration::from_secs(3),
             "probe must time out promptly rather than hang, took {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn crash_counter_classifies_exits() {
+        // The liveness check is the single authoritative crash observer. This is
+        // the only test that touches the process-global INSTANCES_CRASHED_TOTAL,
+        // and both cases run sequentially here, so its exact deltas stay
+        // deterministic under the parallel test harness.
+        fn make_instance(id: &str) -> Instance {
+            Instance::new(
+                id.to_string(),
+                "test-model".to_string(),
+                "default".to_string(),
+                "127.0.0.1".to_string(),
+                8080,
+                "hash123".to_string(),
+                false,
+            )
+        }
+        async fn observe_dead(instance: &Instance) -> bool {
+            for _ in 0..200 {
+                if !instance.is_alive() {
+                    return true;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            false
+        }
+
+        // 1. A non-zero exit stands in for a real crash: counted exactly once,
+        //    and a later liveness check on the already-observed exit (handle now
+        //    `None`) must not re-count.
+        let before = INSTANCES_CRASHED_TOTAL.load(Ordering::Relaxed);
+        let crashed = make_instance("crash-test");
+        *crashed.child.lock() = Some(
+            Command::new("sh")
+                .arg("-c")
+                .arg("exit 1")
+                .spawn()
+                .expect("spawn crashing child"),
+        );
+        assert!(
+            observe_dead(&crashed).await,
+            "is_alive should observe the exit"
+        );
+        assert_eq!(
+            INSTANCES_CRASHED_TOTAL.load(Ordering::Relaxed),
+            before + 1,
+            "a non-zero exit must be counted exactly once"
+        );
+        assert!(!crashed.is_alive());
+        assert_eq!(
+            INSTANCES_CRASHED_TOTAL.load(Ordering::Relaxed),
+            before + 1,
+            "an already-observed crash must not be re-counted"
+        );
+
+        // 2. A deliberate SIGTERM (systemd's whole-cgroup `systemctl restart`, an
+        //    operator stop) is an expected shutdown, not a crash: the liveness
+        //    check still observes the exit but must not count it.
+        let before_term = INSTANCES_CRASHED_TOTAL.load(Ordering::Relaxed);
+        let terminated = make_instance("sigterm-test");
+        let sleeper = Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn sleeping child");
+        let pid = sleeper.id().expect("child pid") as i32;
+        *terminated.child.lock() = Some(sleeper);
+        nix::sys::signal::kill(
+            nix::unistd::Pid::from_raw(pid),
+            nix::sys::signal::Signal::SIGTERM,
+        )
+        .expect("send SIGTERM to child");
+        assert!(
+            observe_dead(&terminated).await,
+            "is_alive should observe the SIGTERM exit"
+        );
+        assert_eq!(
+            INSTANCES_CRASHED_TOTAL.load(Ordering::Relaxed),
+            before_term,
+            "a SIGTERM (deliberate stop) must not count as a crash"
         );
     }
 }

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -20,7 +20,8 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 /// observer: `is_alive` sets the child handle to `None` on the first poll that
 /// sees an exit, so each crash is counted exactly once, and the proxy's own
 /// `stop()` takes the handle first so its intentional teardown never reaches the
-/// counting arm. Two further exits are deliberately not counted: a plain
+/// counting arm. Deliberately not counted: a clean exit (status 0, e.g. a
+/// server that handles a shutdown signal and exits on its own), a plain
 /// `SIGTERM` (how systemd's whole-control-group `systemctl restart` and
 /// operators ask a process to stop — an expected shutdown, not a crash), and a
 /// `try_wait` poll failure (which means "status unknown", not "exited"). Fault
@@ -604,17 +605,18 @@ impl Instance {
         match &mut *guard {
             Some(child) => match child.try_wait() {
                 Ok(Some(status)) => {
-                    // A plain SIGTERM is how systemd (whole control-group on a
-                    // `systemctl restart`) and operators ask a process to stop,
-                    // so an instance that exits on SIGTERM was terminated on
-                    // purpose, not crashed — do not count it. Genuine crashes
-                    // surface as a fault signal (SIGSEGV/SIGABRT/SIGKILL/…) or a
-                    // non-zero exit code, both still counted. The proxy's own
-                    // stop() takes the child handle first, so its intentional
-                    // teardown never reaches this arm; this guard covers the
-                    // out-of-band case where the child is signalled directly
-                    // (e.g. systemd during a graceful node shutdown).
-                    if status.signal() != Some(libc::SIGTERM) {
+                    // Count only abnormal exits. A clean exit (status 0) is not a
+                    // crash — llama-server may handle a shutdown signal and exit
+                    // 0 on its own before stop() takes the handle. A plain
+                    // SIGTERM is likewise a deliberate stop, not a crash: it is
+                    // how systemd (whole control-group on a `systemctl restart`)
+                    // and operators ask a process to terminate, and it reaches
+                    // this arm out-of-band during a graceful node shutdown while
+                    // the proxy's own stop() (which takes the handle first) has
+                    // not run yet. Genuine crashes — a fault signal
+                    // (SIGSEGV/SIGABRT/SIGKILL/…) or a non-zero exit code — are
+                    // counted.
+                    if !status.success() && status.signal() != Some(libc::SIGTERM) {
                         INSTANCES_CRASHED_TOTAL.fetch_add(1, Ordering::Relaxed);
                     }
                     warn!(
@@ -1134,6 +1136,28 @@ mod tests {
             INSTANCES_CRASHED_TOTAL.load(Ordering::Relaxed),
             before_term,
             "a SIGTERM (deliberate stop) must not count as a crash"
+        );
+
+        // 3. A clean exit (status 0) — e.g. a llama-server that handles a
+        //    shutdown signal and exits on its own before stop() takes the handle
+        //    — is not a crash: observed but not counted.
+        let before_clean = INSTANCES_CRASHED_TOTAL.load(Ordering::Relaxed);
+        let clean = make_instance("clean-exit-test");
+        *clean.child.lock() = Some(
+            Command::new("sh")
+                .arg("-c")
+                .arg("exit 0")
+                .spawn()
+                .expect("spawn clean-exit child"),
+        );
+        assert!(
+            observe_dead(&clean).await,
+            "is_alive should observe the clean exit"
+        );
+        assert_eq!(
+            INSTANCES_CRASHED_TOTAL.load(Ordering::Relaxed),
+            before_clean,
+            "a clean exit (status 0) must not count as a crash"
         );
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -296,6 +296,12 @@ pub struct MetricsSnapshot {
     /// older snapshots loadable.
     #[serde(default)]
     pub peer_stream_body_aborts_total: u64,
+    /// Local `llama-server` instances observed to have exited abnormally by the
+    /// liveness check (a fault signal or non-zero exit; a graceful `SIGTERM` is
+    /// not counted). Process-global, resets on restart; `#[serde(default)]` keeps
+    /// older snapshots loadable.
+    #[serde(default)]
+    pub instances_crashed_total: u64,
     pub hashes: HashMap<String, HashMetricsSnapshot>,
     pub updated_at: String,
     #[serde(default)]
@@ -671,6 +677,8 @@ impl Metrics {
                 .load(Ordering::Relaxed),
             peer_stream_body_aborts_total: crate::router::PEER_STREAM_BODY_ABORTS
                 .load(Ordering::Relaxed),
+            instances_crashed_total: crate::instance::INSTANCES_CRASHED_TOTAL
+                .load(Ordering::Relaxed),
             hashes,
             updated_at: chrono::Utc::now().to_rfc3339(),
             is_building: build_status
@@ -916,6 +924,16 @@ pub async fn render_prometheus_with_circuit_breaker(
     out.push_str(&format!(
         "proxy_peer_stream_body_aborts_total {}\n",
         crate::router::PEER_STREAM_BODY_ABORTS.load(Ordering::Relaxed)
+    ));
+
+    // Local instances observed to have exited abnormally by the liveness check
+    out.push_str(
+        "# HELP proxy_instances_crashed_total Local llama-server instances that exited abnormally (fault signal or non-zero exit; excludes graceful SIGTERM).\n",
+    );
+    out.push_str("# TYPE proxy_instances_crashed_total counter\n");
+    out.push_str(&format!(
+        "proxy_instances_crashed_total {}\n",
+        crate::instance::INSTANCES_CRASHED_TOTAL.load(Ordering::Relaxed)
     ));
 
     // Circuit breaker metrics (if available)


### PR DESCRIPTION
## Summary

Adds a `proxy_instances_crashed_total` Prometheus counter for local `llama-server` instances that exit abnormally. Until now an instance crash was only a log line (`Instance exited unexpectedly`), so its rate could not be scraped or alerted on — and in practice these arrive in intermittent bursts (a bad model or profile dying repeatedly), exactly the pattern a counter surfaces better than logs. The existing lifecycle metrics do not cover it: `proxy_node_active_instances` is a point-in-time gauge and `proxy_wedged_instances_killed_total` only counts watchdog kills.

Closes #158.

## Implementation

The counter increments in the liveness check (`Instance::is_alive`), which is the single authoritative crash observer: it nulls the child handle on the first poll that sees an exit, so each crash is counted exactly once.

Deliberate stops are excluded, so a routine restart does not inflate the counter:

- The proxy's own `stop()` takes the child handle first, so intentional teardown never reaches the counting arm at all.
- An exit on a plain `SIGTERM` is treated as a graceful shutdown rather than a crash. This matters because systemd's default `KillMode=control-group` SIGTERMs the whole cgroup on `systemctl restart`, so the llama-server children exit out-of-band while a detached background sweep is still polling `is_alive()` during the drain window — without this guard every graceful restart would spuriously count each running instance as a crash.

Fault signals (SIGSEGV/SIGABRT/SIGKILL/…) and non-zero exit codes are counted. It follows the existing `proxy_peer_stream_body_aborts_total` pattern: a process-global `AtomicU64` surfaced on both `/metrics` and `/metrics/json`, with a `#[serde(default)]` snapshot field so older snapshots still load. Like the other static-sourced counters it resets on restart; `SPEC.md` is updated to reflect that (and to correct the reset-on-restart counter list, which also omitted the `proxy_queue_wait_*` counters).

## Tests

New unit test `crash_counter_classifies_exits` drives real child processes and real signals: a non-zero exit is counted exactly once (and a second liveness check on the already-observed exit does not re-count), while a `SIGTERM`-terminated child is observed but not counted. Full unit suite: 467 pass (was 466). `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` are clean.
