### PR TITLE
fix: propagate client disconnects to peer-forwarded requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.21.1] - 2026-07-08
+
+### Fixed
+
+- Client disconnects now propagate across the cluster, so an abandoned request
+  stops consuming resources instead of running to completion. A request
+  forwarded to a peer over the encrypted cluster (Noise) transport previously
+  reached the router without a connection handle, which left the existing
+  client-disconnect detection inert for all cross-node traffic: when the
+  originating client went away, the serving node kept the request queued while
+  waiting for capacity and then generated a full upstream response that no one
+  would read — for however long the request would otherwise take (many minutes
+  of queue wait under memory contention). Peer-forwarded requests now carry a
+  handle to their per-request transport connection, and the router's upstream
+  waits — acquiring a local instance (including time spent queued for capacity),
+  forwarding to a peer, and the local generation request — are abandoned with
+  `499 Client Closed Request` when that connection closes, which in turn closes
+  the next hop's connection so the cancellation propagates down the chain.
+  Direct (non-forwarded) API requests were already covered by the HTTP server
+  cancelling the handler on disconnect; this brings cross-node forwarding to
+  parity.
+
 ## [1.21.0] - 2026-07-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,7 +1537,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "llamesh"
-version = "1.21.0"
+version = "1.21.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llamesh"
-version = "1.21.0"
+version = "1.21.1"
 edition = "2021"
 rust-version = "1.88"
 license = "Apache-2.0"

--- a/src/api.rs
+++ b/src/api.rs
@@ -944,7 +944,17 @@ async fn handle_noise_connection(
             ("POST", "/cluster/gossip") => {
                 handle_noise_gossip(&state, request.body.as_ref(), &peer_node_id, remote_addr).await
             }
-            _ => handle_noise_http_request(state.clone(), request).await,
+            _ => {
+                // Give the forwarded request a handle to this per-request Noise
+                // TCP connection. The Noise transport opens one connection per
+                // request, so its liveness tracks the forwarding peer: when the
+                // peer closes it (because the original client disconnected and
+                // the peer aborted its forward), the router detects the close
+                // and abandons the request instead of queueing/generating for a
+                // client that is already gone.
+                let conn_handle = ConnectionHandle::new(tcp_stream.as_raw_fd());
+                handle_noise_http_request(state.clone(), conn_handle, request).await
+            }
         };
 
         if let Err(e) = send_noise_response(&mut session, &mut tcp_stream, response).await {
@@ -1008,6 +1018,7 @@ fn build_noise_request_headers(raw: &[(String, String)]) -> HeaderMap {
 
 async fn handle_noise_http_request(
     state: Arc<NodeState>,
+    conn_handle: ConnectionHandle,
     request: crate::noise::transport::NoiseRequest,
 ) -> axum::response::Response {
     let mut builder = Request::builder()
@@ -1029,7 +1040,7 @@ async fn handle_noise_http_request(
         }
     };
 
-    match router::route_request(State(state), None, req).await {
+    match router::route_request(State(state), Some(Extension(conn_handle)), req).await {
         Ok(resp) => resp.into_response(),
         Err(err) => err.into_response(),
     }

--- a/src/router.rs
+++ b/src/router.rs
@@ -52,6 +52,49 @@ async fn wait_for_capacity_or_disconnect(
     }
 }
 
+/// Await an upstream network operation, aborting early if the client's
+/// connection closes first.
+///
+/// Wraps a peer forward or a local generation so an abandoned request stops
+/// consuming cluster resources — a queued instance slot, a peer connection, an
+/// in-flight generation — instead of running to completion for a client that
+/// has already gone away. Returns the operation's output, or
+/// `AppError::client_disconnected()` if the client disconnects first. With no
+/// connection handle (`None`) the future is awaited without disconnect
+/// detection (e.g. an internally-originated request that has no client socket).
+///
+/// Dropping `fut` on disconnect is intentional: it cancels the wrapped
+/// operation, closing the per-request peer/backend connection so the abort
+/// propagates one hop downstream (a forwarding node closing its connection lets
+/// the serving node observe the disconnect in turn). The caller's
+/// `RequestGuard`/`PeerForwardGuard` release the request's in-flight and metric
+/// accounting on the early return exactly as they do on any other error path,
+/// and a circuit-breaker probe left unrecorded is benign (at worst the peer's
+/// next recovery probe waits one interval).
+async fn await_unless_client_gone<F, T>(
+    conn: &Option<ConnectionHandle>,
+    poll_interval: Duration,
+    stage: &'static str,
+    fut: F,
+) -> Result<T, AppError>
+where
+    F: std::future::Future<Output = T>,
+{
+    match conn {
+        Some(handle) => {
+            tokio::select! {
+                biased;
+                res = fut => Ok(res),
+                _ = crate::connection::poll_client_disconnect(handle, poll_interval) => {
+                    info!(event = "client_disconnected", stage = stage, "Client disconnected during upstream wait");
+                    Err(AppError::client_disconnected())
+                }
+            }
+        }
+        None => Ok(fut.await),
+    }
+}
+
 struct RequestGuard {
     state: Arc<NodeState>,
     // For local instances
@@ -865,20 +908,25 @@ pub async fn route_request(
                 // cleanup_fut on the attempt that commits.
                 let peer_forward_guard = state.track_peer_forward(&peer.node_id).await;
 
-                let outcome = attempt_peer_forward(
-                    &state,
-                    PeerRequest {
-                        peer_id: &peer.node_id,
-                        peer_address: &peer.address,
-                        method: parts.method.clone(),
-                        path_and_query: &path_and_query,
-                        headers: forward_headers.clone(),
-                        body: forward_body.clone(),
-                        timeout_ms,
-                    },
-                    response_streaming,
+                let outcome = await_unless_client_gone(
+                    &conn_handle,
+                    DISCONNECT_POLL_INTERVAL,
+                    "peer_forward",
+                    attempt_peer_forward(
+                        &state,
+                        PeerRequest {
+                            peer_id: &peer.node_id,
+                            peer_address: &peer.address,
+                            method: parts.method.clone(),
+                            path_and_query: &path_and_query,
+                            headers: forward_headers.clone(),
+                            body: forward_body.clone(),
+                            timeout_ms,
+                        },
+                        response_streaming,
+                    ),
                 )
-                .await;
+                .await?;
 
                 match outcome {
                     ForwardOutcome::StreamingSurface(resp) => {
@@ -1133,7 +1181,14 @@ pub async fn route_request(
                         client_req = client_req.timeout(Duration::from_millis(timeout_ms));
                     }
 
-                    match client_req.send().await {
+                    match await_unless_client_gone(
+                        &conn_handle,
+                        DISCONNECT_POLL_INTERVAL,
+                        "local_generation",
+                        client_req.send(),
+                    )
+                    .await?
+                    {
                         Ok(resp) => {
                             let tokens_counter = Arc::new(AtomicU64::new(0));
                             let tokens_for_cleanup = tokens_counter.clone();
@@ -1320,20 +1375,25 @@ pub async fn route_request(
                             let forward_headers =
                                 build_forward_headers(&parts.headers, current_hops, &request_id);
 
-                            match send_peer_request(
-                                &state,
-                                PeerRequest {
-                                    peer_id: &peer.node_id,
-                                    peer_address: &peer.address,
-                                    method: parts.method.clone(),
-                                    path_and_query: &path_and_query,
-                                    headers: forward_headers,
-                                    body: forward_body.clone(),
-                                    timeout_ms,
-                                },
-                                response_streaming,
+                            match await_unless_client_gone(
+                                &conn_handle,
+                                DISCONNECT_POLL_INTERVAL,
+                                "peer_forward",
+                                send_peer_request(
+                                    &state,
+                                    PeerRequest {
+                                        peer_id: &peer.node_id,
+                                        peer_address: &peer.address,
+                                        method: parts.method.clone(),
+                                        path_and_query: &path_and_query,
+                                        headers: forward_headers,
+                                        body: forward_body.clone(),
+                                        timeout_ms,
+                                    },
+                                    response_streaming,
+                                ),
                             )
-                            .await
+                            .await?
                             {
                                 Ok(resp) => {
                                     let status = match &resp {
@@ -1497,20 +1557,25 @@ pub async fn route_request(
                 let peer_forward_guard =
                     state.track_peer_forward(&current_node.node_id).await;
 
-                let outcome = attempt_peer_forward(
-                    &state,
-                    PeerRequest {
-                        peer_id: &current_node.node_id,
-                        peer_address: &current_node.address,
-                        method: parts.method.clone(),
-                        path_and_query: &path_and_query,
-                        headers: forward_headers.clone(),
-                        body: forward_body.clone(),
-                        timeout_ms,
-                    },
-                    response_streaming,
+                let outcome = await_unless_client_gone(
+                    &conn_handle,
+                    DISCONNECT_POLL_INTERVAL,
+                    "peer_forward",
+                    attempt_peer_forward(
+                        &state,
+                        PeerRequest {
+                            peer_id: &current_node.node_id,
+                            peer_address: &current_node.address,
+                            method: parts.method.clone(),
+                            path_and_query: &path_and_query,
+                            headers: forward_headers.clone(),
+                            body: forward_body.clone(),
+                            timeout_ms,
+                        },
+                        response_streaming,
+                    ),
                 )
-                .await;
+                .await?;
 
                 let mut probe_wait_deadline: Option<Duration> = None;
                 let mut skip_wait = false;
@@ -2338,6 +2403,56 @@ fn ensure_profile_supports_endpoint(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::io::AsRawFd;
+
+    // A live, connected server-side socket whose peer is still attached.
+    async fn connected_pair() -> (tokio::net::TcpStream, tokio::net::TcpStream) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (server, _) = listener.accept().await.unwrap();
+        (client, server)
+    }
+
+    #[tokio::test]
+    async fn await_unless_client_gone_without_handle_just_awaits() {
+        // No connection handle (e.g. an internally-originated request): the
+        // future is awaited with no disconnect detection.
+        let out: Result<u32, AppError> =
+            await_unless_client_gone(&None, Duration::from_millis(10), "test", async { 42 }).await;
+        assert_eq!(out.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn await_unless_client_gone_returns_output_when_still_connected() {
+        // Client still attached: a completing future returns its value and is
+        // never spuriously aborted as a disconnect.
+        let (client, server) = connected_pair().await;
+        let handle = Some(ConnectionHandle::new(server.as_raw_fd()));
+        let out: Result<u32, AppError> =
+            await_unless_client_gone(&handle, Duration::from_millis(20), "test", async { 7 }).await;
+        assert_eq!(out.unwrap(), 7);
+        drop(client);
+        drop(server);
+    }
+
+    #[tokio::test]
+    async fn await_unless_client_gone_aborts_when_client_disconnects() {
+        // Client goes away while the operation is still pending: the wrapped
+        // future is dropped and a 499 client_disconnected error is returned
+        // instead of the request running to completion.
+        let (client, server) = connected_pair().await;
+        let handle = Some(ConnectionHandle::new(server.as_raw_fd()));
+        drop(client); // client closes the connection
+        tokio::time::sleep(Duration::from_millis(50)).await; // let the kernel process the FIN
+        let never = std::future::pending::<u32>();
+        let out: Result<u32, AppError> =
+            await_unless_client_gone(&handle, Duration::from_millis(20), "test", never).await;
+        let err = out.expect_err("should abort on client disconnect");
+        assert_eq!(err.status.as_u16(), 499);
+        assert_eq!(err.error.type_, "client_disconnected");
+        drop(server);
+    }
 
     #[test]
     fn resolve_requested_model_absent_uses_default() {

--- a/src/router.rs
+++ b/src/router.rs
@@ -1445,13 +1445,27 @@ pub async fn route_request(
 
                                     guard.complete();
 
-                                    let client_response = peer_response_to_client(
-                                        resp,
-                                        response_streaming,
-                                        cleanup_fut,
-                                        tokens_counter,
+                                    // Watch for client disconnect across the peer
+                                    // body drain too. For a non-streaming response
+                                    // peer_response_to_client buffers the body, so
+                                    // without this an abandoned request would read
+                                    // the full peer generation; its AutoCleanup
+                                    // runs the cleanup if we bail mid-read. (A
+                                    // streaming response returns here at the
+                                    // headers and is torn down by its own
+                                    // write-failure path.)
+                                    let client_response = await_unless_client_gone(
+                                        &conn_handle,
+                                        DISCONNECT_POLL_INTERVAL,
+                                        "peer_forward",
+                                        peer_response_to_client(
+                                            resp,
+                                            response_streaming,
+                                            cleanup_fut,
+                                            tokens_counter,
+                                        ),
                                     )
-                                    .await;
+                                    .await?;
 
                                     // Count an error iff the client ultimately
                                     // receives an error response. `client_status` is

--- a/src/router.rs
+++ b/src/router.rs
@@ -1297,23 +1297,35 @@ pub async fn route_request(
                             // peer paths pass None and account for it elsewhere.
                             let error_recorder =
                                 Some((state.metrics.clone(), hash_metrics.clone()));
-                            Ok(if response_streaming {
-                                build_streaming_response(
+                            if response_streaming {
+                                Ok(build_streaming_response(
                                     resp,
                                     cleanup_fut,
                                     tokens_counter,
                                     error_recorder,
                                     false,
-                                )
+                                ))
                             } else {
-                                handle_non_streaming_response(
-                                    resp,
-                                    cleanup_fut,
-                                    tokens_counter,
-                                    error_recorder,
+                                // `send()` resolves at the response headers, so a
+                                // slow non-streaming body would otherwise be read
+                                // to completion for an already-gone client. Keep
+                                // watching for disconnect across the body drain
+                                // too; the `AutoCleanup` inside
+                                // `handle_non_streaming_response` runs the cleanup
+                                // if we bail mid-read.
+                                await_unless_client_gone(
+                                    &conn_handle,
+                                    DISCONNECT_POLL_INTERVAL,
+                                    "local_generation",
+                                    handle_non_streaming_response(
+                                        resp,
+                                        cleanup_fut,
+                                        tokens_counter,
+                                        error_recorder,
+                                    ),
                                 )
                                 .await
-                            })
+                            }
                         }
                         Err(e) => {
                             error!("Upstream error: {}", e);


### PR DESCRIPTION
## Summary

Client disconnects were not propagating across the cluster: a request forwarded to a peer over the Noise transport reached the router without a connection handle, so the existing client-disconnect detection was a no-op for all cross-node traffic. When the originating client went away, the serving node kept the request queued while waiting for capacity — repeatedly evicting the co-resident model to try to make room — and then generated a full upstream response that no one would read, for however long the request would otherwise take. Under memory contention this produced abandoned chat requests sitting queued for many minutes before generating into a closed connection. Fixes #160.

## What changed

Peer-forwarded requests now carry a `ConnectionHandle` built from their per-request Noise TCP connection (the Noise transport opens one connection per request, so its liveness tracks the forwarding peer). A small `await_unless_client_gone` helper races the router's upstream waits against `poll_client_disconnect` and returns `499 Client Closed Request` if the client goes away first. It is applied to the three peer-forward awaits and the local generation request; the local instance-acquisition wait was already guarded and simply becomes effective now that a handle is present. When a node abandons its request it drops the forward, which closes the next-hop connection, so the cancellation propagates one hop at a time down the chain.

Direct (non-forwarded) API requests were already handled correctly — the HTTP server cancels the handler future on disconnect — so this brings cross-node forwarding to parity.

## Why it's safe

The early return reuses the existing cleanup paths: `RequestGuard` / `PeerForwardGuard` / `SlotReleaseGuard` drops handle in-flight, current-request, and spawn-reservation accounting exactly as the pre-existing upstream-error returns already do (the same paths hardened in #9, #11, #20, #29, #33). Dropping an in-flight peer forward is cancel-safe because the circuit-breaker probe ticket is a plain bool, not an RAII slot. `poll_client_disconnect` only trips on terminal TCP states (CLOSE_WAIT and friends) and sleeps before its first check, so healthy in-flight requests and sub-interval operations are never falsely aborted.

## Validation

- New unit tests for `await_unless_client_gone` (returns the value on normal completion, aborts with 499 when the client disconnects, no-ops when no handle is present); full suite (470 tests) passes and `clippy --all-targets` is clean.
- Live-validated on a two-node cluster: a peer-forwarded request whose client disconnected mid-flight is now detected and aborted on the serving node, where it previously ran to completion. Confirmed no regression on normal requests and no resource accumulation under a sustained sequence of disconnect-aborts at production cadence.

## Note

A client that half-closes its write side (`shutdown(SHUT_WR)`) while still waiting to read the response would be treated as gone after the poll interval. This is unchanged, pre-existing behavior of the same detection heuristic (it already governed the capacity-wait path) and does not affect mainstream HTTP clients, which do not half-close before reading the response.

Version bumped to 1.21.1 with a matching CHANGELOG entry.
